### PR TITLE
fix(ui): 消除原生 details 渲染挂起（Windows asar）+ 防回归守卫

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ops:check": "node scripts/ops-check.mjs",
     "perf:baseline": "tsx scripts/performance-baseline.ts",
     "check:design": "node scripts/check-design-system.mjs",
-    "check:architecture": "node scripts/check-architecture.mjs --enforce && node scripts/check-prose-blocks.mjs",
+    "check:architecture": "node scripts/check-architecture.mjs --enforce && node scripts/check-prose-blocks.mjs && node scripts/check-no-native-details.mjs",
     "smoke:memory": "node scripts/ensure-electron-native.mjs && bun --no-cache run build && node scripts/smoke-memory.mjs",
     "typecheck": "tsc -b"
   },

--- a/scripts/check-no-native-details.mjs
+++ b/scripts/check-no-native-details.mjs
@@ -1,0 +1,139 @@
+// 全库禁用原生 <details>/<summary> JSX（Windows asar 冻结守卫）。
+//
+// 背景：Chromium 41 在 Windows 打包版（asar + file://）渲染原生 <details> 元素会把渲染主线程
+// 挂死（无 CPU 同步阻塞；dev 非 asar 与 mac 均正常）。2026-08-15 二分定位（纯净 <details>
+// 即可复现，与业务代码无关）。全库统一改走 src/components/ui/disclosure.tsx（div+useState，
+// 外层展开时输出 open 属性兼容 group-open:* 样式）。
+//
+// 本脚本扫描 src/**/*.tsx 的 JSX <details / <summary（剥离注释后），出现即 fail——防止将来
+// 合并上游代码把原生 details 再带进来，在 Windows 打包版静默复发（dev/mac 都测不出来）。
+//
+// 用法：node scripts/check-no-native-details.mjs（退出码 1 = 有违规）。
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SRC_DIR = 'src'
+const DETAILS_RE = /<details[\s/>]|<\/details\s*>|<summary[\s/>]|<\/summary\s*>/
+
+/** 剥离 // 行注释与块注释（含 JSDoc/JSX 注释），正确跳过字符串字面量；保留换行以便报行号。 */
+function stripComments(content) {
+  let out = ''
+  let i = 0
+  let state = 'code'
+  let quote = '' // 字符串态进入时的引号字符
+  while (i < content.length) {
+    const ch = content[i]
+    const two = content.slice(i, i + 2)
+    if (state === 'code') {
+      if (two === '//') {
+        state = 'line'
+        i += 2
+        out += '  '
+        continue
+      }
+      if (two === '/*') {
+        state = 'block'
+        i += 2
+        out += '  '
+        continue
+      }
+      if (ch === '"' || ch === "'" || ch === '`') {
+        state = 'string'
+        quote = ch
+        out += ch
+        i += 1
+        continue
+      }
+      out += ch
+      i += 1
+    } else if (state === 'line') {
+      if (ch === '\n') {
+        state = 'code'
+        out += '\n'
+      } else {
+        out += ' '
+      }
+      i += 1
+    } else if (state === 'block') {
+      if (two === '*/') {
+        state = 'code'
+        i += 2
+        out += '  '
+        continue
+      }
+      out += ch === '\n' ? '\n' : ' '
+      i += 1
+    } else {
+      // string：内容替换为空格（保留引号与换号——引号本身留在输出里、`//` 不会误启行注释，
+      // 字符串里的 <details> 字样也不会误报）；遇到未转义的同类引号回到 code。
+      if (ch === '\\') {
+        out += '  '
+        i += 2
+        continue
+      }
+      if (ch === quote) {
+        state = 'code'
+        quote = ''
+        out += ch
+        i += 1
+        continue
+      }
+      out += ch === '\n' ? '\n' : ' '
+      i += 1
+    }
+  }
+  return out
+}
+
+function collectTsxFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) collectTsxFiles(full, out)
+    else if (entry.name.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+/**
+ * 收集违规（导出供测试）。
+ * @param {{ files: Array<{ path: string, content: string }> }} input
+ * @returns {Array<{ file: string, line: number, excerpt: string }>}
+ */
+export function collectNativeDetailsViolations({ files }) {
+  const violations = []
+  for (const file of files) {
+    const stripped = stripComments(file.content)
+    const sourceLines = file.content.split('\n')
+    stripped.split('\n').forEach((line, index) => {
+      if (DETAILS_RE.test(line)) {
+        // 每行只报一次（同行开+闭标签算一处，报告可读）。
+        violations.push({
+          file: file.path,
+          line: index + 1,
+          excerpt: (sourceLines[index] ?? '').trim().slice(0, 90),
+        })
+      }
+    })
+  }
+  return violations
+}
+
+function main() {
+  const files = collectTsxFiles(SRC_DIR).map((path) => ({ path, content: readFileSync(path, 'utf-8') }))
+  const violations = collectNativeDetailsViolations({ files })
+  if (violations.length > 0) {
+    console.error(`check-no-native-details: ${violations.length} 处 JSX 原生 <details>/<summary>（Windows asar 冻结风险）：`)
+    for (const v of violations) {
+      console.error(`  ${v.file}:${v.line}: ${v.excerpt}`)
+    }
+    console.error('改用 src/components/ui/disclosure.tsx（外层展开时输出 open 属性，group-open:* 样式兼容）。')
+    process.exit(1)
+  }
+  console.log(`check-no-native-details: OK（${files.length} 个 tsx 零原生 details/summary）`)
+}
+
+if (process.argv[1] && process.argv[1].replaceAll('\\', '/').endsWith('check-no-native-details.mjs')) {
+  main()
+}

--- a/scripts/check-no-native-details.mjs
+++ b/scripts/check-no-native-details.mjs
@@ -1,6 +1,6 @@
 // 全库禁用原生 <details>/<summary> JSX（Windows asar 冻结守卫）。
 //
-// 背景：Chromium 41 在 Windows 打包版（asar + file://）渲染原生 <details> 元素会把渲染主线程
+// 背景：Electron 41.2.1（对应 Chromium 146）在 Windows 打包版（asar + file://）渲染原生 <details> 元素会把渲染主线程
 // 挂死（无 CPU 同步阻塞；dev 非 asar 与 mac 均正常）。2026-08-15 二分定位（纯净 <details>
 // 即可复现，与业务代码无关）。全库统一改走 src/components/ui/disclosure.tsx（div+useState，
 // 外层展开时输出 open 属性兼容 group-open:* 样式）。

--- a/scripts/check-no-native-details.test.mjs
+++ b/scripts/check-no-native-details.test.mjs
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { collectNativeDetailsViolations } from './check-no-native-details.mjs'
+
+describe('collectNativeDetailsViolations（Windows asar 冻结守卫）', () => {
+  test('JSX <details>/<summary> 判违规（含自闭合与属性形态）', () => {
+    const violations = collectNativeDetailsViolations({
+      files: [
+        { path: 'a.tsx', content: 'export const X = () => (\n  <details className="x">\n    <summary>标题</summary>\n  </details>\n)' },
+        { path: 'b.tsx', content: 'render(<details data-x="1">y</details>)' },
+      ],
+    })
+    expect(violations.map((v) => v.file)).toEqual(['a.tsx', 'a.tsx', 'a.tsx', 'b.tsx'])
+    expect(violations[0].line).toBe(2)
+  })
+
+  test('注释与字符串里的 details 字样不误报（JSDoc/行注释/JSX 注释/文案字符串）', () => {
+    const violations = collectNativeDetailsViolations({
+      files: [
+        {
+          path: 'c.tsx',
+          content: [
+            '/**',
+            ' * 为什么不用原生 <details>：Windows asar 冻结。',
+            ' */',
+            '// <summary> 注释里的也不算',
+            'const s = "文本里的 <details> 字样"',
+            'const t = `模板串 <summary> 也不算`',
+            'export const Ok = () => <div>safe</div>',
+          ].join('\n'),
+        },
+      ],
+    })
+    expect(violations).toEqual([])
+  })
+
+  test('JSX 注释块 {/* <details> */} 不误报；真实 JSX 紧随其后仍能抓到', () => {
+    const clean = collectNativeDetailsViolations({
+      files: [{ path: 'd.tsx', content: '{/* <details> 注释 */}\n<div>ok</div>' }],
+    })
+    expect(clean).toEqual([])
+
+    const dirty = collectNativeDetailsViolations({
+      files: [{ path: 'e.tsx', content: '{/* 说明 */}\n<details open>x</details>' }],
+    })
+    expect(dirty).toHaveLength(1)
+  })
+
+  test('字符串内 // 不当成注释开头吞掉后续代码（URL 场景）', () => {
+    const violations = collectNativeDetailsViolations({
+      files: [
+        {
+          path: 'f.tsx',
+          content: 'const url = "https://example.com/a"\nrender(<details>x</details>)',
+        },
+      ],
+    })
+    // 字符串里的 // 被正确跳过，第二行的 details（同行开+闭）报一处。
+    expect(violations).toHaveLength(1)
+    expect(violations[0].line).toBe(2)
+  })
+})

--- a/src/components/packs/PackDetailContent.tsx
+++ b/src/components/packs/PackDetailContent.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { BadgeCheck, Package } from 'lucide-react'
 import { MarkdownRenderer } from '@/components/workbench/MarkdownRenderer'
+import { Disclosure } from '@/components/ui/disclosure'
 import { MUTED_PILL_CLASS } from '@/design-system'
 import { cn } from '@/lib/cn'
 import type { CapabilityPackDetail, PackCardEntry, PackLocalSource } from '@shared/types/capability-pack'
@@ -165,16 +166,16 @@ export function PackDetailContent({
           </div>
           <div className="space-y-1.5">
             {localCards.map((card) => (
-              <details
+              <Disclosure
                 key={card.fileName}
                 className="rounded-row border border-border bg-surface"
                 data-pack-local-card={card.fileName}
+                summary={<span className="cursor-pointer px-3 py-2 text-sm leading-6 text-foreground">{card.fileName}</span>}
               >
-                <summary className="cursor-pointer px-3 py-2 text-sm leading-6 text-foreground">{card.fileName}</summary>
                 <div className="border-t border-border px-3 py-3">
                   <MarkdownRenderer text={card.body} variant="document" />
                 </div>
-              </details>
+              </Disclosure>
             ))}
           </div>
         </div>

--- a/src/components/settings/CapabilityPackLibraryPanel.tsx
+++ b/src/components/settings/CapabilityPackLibraryPanel.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { BadgeCheck, BookOpen, Copy, Download, FolderPlus, Loader2, Package, PenTool, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Disclosure } from '@/components/ui/disclosure'
 import {
   Dialog,
   DialogContent,
@@ -487,13 +488,15 @@ function ImportLintWarningNotice({
   if (totalFindings === 0) return null
 
   return (
-    <details
+    <Disclosure
       className="mb-4 rounded-row border border-warning/30 bg-warning/10 px-3 py-2"
       data-capability-pack-import-lint-warning="true"
+      summary={
+        <span className="cursor-pointer text-xs font-medium leading-5 text-warning">
+          这个包的卡片里有 {totalFindings} 处像是在给 AI 下指令的语句
+        </span>
+      }
     >
-      <summary className="cursor-pointer text-xs font-medium leading-5 text-warning">
-        这个包的卡片里有 {totalFindings} 处像是在给 AI 下指令的语句
-      </summary>
       <div className="mt-2 space-y-1.5">
         {lintWarnings.flatMap((entry) =>
           entry.findings.map((finding, index) => (
@@ -521,7 +524,7 @@ function ImportLintWarningNotice({
           )),
         )}
       </div>
-    </details>
+    </Disclosure>
   )
 }
 

--- a/src/components/ui/disclosure.test.tsx
+++ b/src/components/ui/disclosure.test.tsx
@@ -1,0 +1,21 @@
+import { test, expect } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Disclosure } from './disclosure'
+
+test('展开态输出 open 属性，group-open:* 样式才能命中', () => {
+  const html = renderToStaticMarkup(
+    <Disclosure defaultOpen summary={<span>头</span>}>
+      <div>体</div>
+    </Disclosure>,
+  )
+  expect(html).toContain('open=""')
+})
+
+test('折叠态不输出 open 属性', () => {
+  const html = renderToStaticMarkup(
+    <Disclosure summary={<span>头</span>}>
+      <div>体</div>
+    </Disclosure>,
+  )
+  expect(html).not.toContain('open=""')
+})

--- a/src/components/ui/disclosure.tsx
+++ b/src/components/ui/disclosure.tsx
@@ -1,0 +1,53 @@
+import { useState, type ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+/**
+ * 通用折叠面板（div + useState 实现，**不用原生 `<details>/<summary>`**）。
+ *
+ * 为什么禁用原生 details：Windows 打包版（asar + file://）实测渲染原生 `<details>` 元素会把
+ * 渲染主线程挂死（无 CPU 的同步阻塞；dev 的非 asar 与 mac 均正常）——Chromium 41 引擎级
+ * 问题，纯净 `<details>` 即可复现（2026-08-15 二分定位，见 settings.tsx 历史注释）。
+ * 全库统一走本组件；`scripts/check-no-native-details.mjs` 守卫防回归。
+ *
+ * 语义对齐原生 details 的部分：
+ * - 内容常驻 DOM，折叠仅 `hidden`（display:none）——SSR 测试可断言内部内容；
+ * - 外层容器上仍渲染调用方传入的 data-*（测试锚点不变）。
+ * 差异部分：`group-open:` 变体类不可用（无 open 属性），展开态箭头请用 render-prop 的
+ * `open` 参数条件拼类（如 `open && 'rotate-90'`）。
+ */
+export function Disclosure({
+  summary,
+  children,
+  className,
+  defaultOpen = false,
+  ...props
+}: {
+  /** 折叠头内容；render-prop 形式拿到 open 态做箭头旋转等条件样式。 */
+  summary: ReactNode | ((open: boolean) => ReactNode)
+  children: ReactNode
+  className?: string
+  defaultOpen?: boolean
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'className'>) {
+  const [open, setOpen] = useState(defaultOpen)
+  const summaryContent = typeof summary === 'function' ? summary(open) : summary
+  return (
+    // 外层在展开时显式输出 open 属性（div 上的非标准属性，React 原样透传）：CSS 属性选择器按
+    // 「存在性」命中，存量 `group-open:*` 变体类（chevron 旋转等）因此原样生效，调用点零视觉
+    // 回归。折叠时刻意不输出（值 "false" 也会被 [open] 误匹配）。
+    <div
+      className={cn('group', className)}
+      {...props}
+      {...(open ? ({ open: '' } as Record<string, unknown>) : {})}
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full cursor-pointer select-none items-center text-left [&::-webkit-details-marker]:hidden"
+      >
+        {summaryContent}
+      </button>
+      <div className={cn(!open && 'hidden')}>{children}</div>
+    </div>
+  )
+}

--- a/src/components/ui/disclosure.tsx
+++ b/src/components/ui/disclosure.tsx
@@ -5,15 +5,13 @@ import { cn } from '@/lib/cn'
  * 通用折叠面板（div + useState 实现，**不用原生 `<details>/<summary>`**）。
  *
  * 为什么禁用原生 details：Windows 打包版（asar + file://）实测渲染原生 `<details>` 元素会把
- * 渲染主线程挂死（无 CPU 的同步阻塞；dev 的非 asar 与 mac 均正常）——Chromium 41 引擎级
- * 问题，纯净 `<details>` 即可复现（2026-08-15 二分定位，见 settings.tsx 历史注释）。
+ * 渲染主线程挂死（无 CPU 的同步阻塞；dev 的非 asar 与 mac 均正常）——Electron 41.2.1（对应
+ * Chromium 146）引擎级问题，纯净 `<details>` 即可复现（2026-08-15 二分定位，见 settings.tsx 历史注释）。
  * 全库统一走本组件；`scripts/check-no-native-details.mjs` 守卫防回归。
  *
  * 语义对齐原生 details 的部分：
  * - 内容常驻 DOM，折叠仅 `hidden`（display:none）——SSR 测试可断言内部内容；
  * - 外层容器上仍渲染调用方传入的 data-*（测试锚点不变）。
- * 差异部分：`group-open:` 变体类不可用（无 open 属性），展开态箭头请用 render-prop 的
- * `open` 参数条件拼类（如 `open && 'rotate-90'`）。
  */
 export function Disclosure({
   summary,
@@ -33,11 +31,12 @@ export function Disclosure({
   return (
     // 外层在展开时显式输出 open 属性（div 上的非标准属性，React 原样透传）：CSS 属性选择器按
     // 「存在性」命中，存量 `group-open:*` 变体类（chevron 旋转等）因此原样生效，调用点零视觉
-    // 回归。折叠时刻意不输出（值 "false" 也会被 [open] 误匹配）。
+    // 回归。折叠时刻意不输出（值 "false" 也会被 [open] 误匹配）。注意值必须是布尔 true——
+    // React 19 把 open 当布尔属性处理，传空字符串 '' 会被判定为假而丢弃整个属性。
     <div
       className={cn('group', className)}
       {...props}
-      {...(open ? ({ open: '' } as Record<string, unknown>) : {})}
+      {...(open ? ({ open: true } as Record<string, unknown>) : {})}
     >
       <button
         type="button"

--- a/src/components/workbench/CapabilityPackPanel.tsx
+++ b/src/components/workbench/CapabilityPackPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { BadgeCheck, Package } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Disclosure } from '@/components/ui/disclosure'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Switch } from '@/components/ui/switch'
@@ -345,10 +346,15 @@ export function CapabilityPackPanel({ projectPath }: { projectPath: string }) {
           </div>
 
           {stagedReceipts.length > 0 ? (
-            <details className="rounded-row border border-border bg-surface" data-capability-pack-panel-planning-receipts="true">
-              <summary className="cursor-pointer px-3 py-2.5 text-sm font-medium leading-6 text-foreground">
-                规划期装载的剧作方法
-              </summary>
+            <Disclosure
+              className="rounded-row border border-border bg-surface"
+              data-capability-pack-panel-planning-receipts="true"
+              summary={
+                <span className="cursor-pointer px-3 py-2.5 text-sm font-medium leading-6 text-foreground">
+                  规划期装载的剧作方法
+                </span>
+              }
+            >
               <div className="space-y-3 border-t border-border px-3 py-3">
                 {stagedReceipts.map((receipt) => (
                   <div key={receipt.stage} className="space-y-1.5" data-capability-pack-panel-planning-stage={receipt.stage}>
@@ -371,7 +377,7 @@ export function CapabilityPackPanel({ projectPath }: { projectPath: string }) {
                   </div>
                 ))}
               </div>
-            </details>
+            </Disclosure>
           ) : null}
         </div>
       </ScrollArea>

--- a/src/components/workbench/ChapterCapabilityReceipt.tsx
+++ b/src/components/workbench/ChapterCapabilityReceipt.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { MUTED_PILL_CLASS } from '@/design-system'
+import { Disclosure } from '@/components/ui/disclosure'
 import type { ChapterCapabilityReceiptData } from '@shared/types/capability-pack'
 
 // 结果语言标签：回执按「产出的东西是什么语言」分类，而非包内部字段名（spec §4.4）。
@@ -48,14 +49,19 @@ export function ChapterCapabilityReceipt({
   if (!receipt || (receipt.entries.length === 0 && receipt.warnings.length === 0)) return null
 
   return (
-    <details className={`${DETAILS_PANEL_CLASS} mt-8`} data-chapter-capability-receipt="true">
-      <summary className={DETAILS_SUMMARY_CLASS}>
-        <ChevronRight
-          aria-hidden="true"
-          className="mr-2 size-4 shrink-0 transition-transform group-open:rotate-90"
-        />
-        <span>本章使用的能力（{receipt.entries.length}）</span>
-      </summary>
+    <Disclosure
+      className={`${DETAILS_PANEL_CLASS} mt-8`}
+      data-chapter-capability-receipt="true"
+      summary={
+        <span className={DETAILS_SUMMARY_CLASS}>
+          <ChevronRight
+            aria-hidden="true"
+            className="mr-2 size-4 shrink-0 transition-transform group-open:rotate-90"
+          />
+          <span>本章使用的能力（{receipt.entries.length}）</span>
+        </span>
+      }
+    >
       <div className={DETAILS_BODY_CLASS}>
         {receipt.entries.map((entry, index) => (
           <div
@@ -81,6 +87,6 @@ export function ChapterCapabilityReceipt({
           </p>
         ))}
       </div>
-    </details>
+    </Disclosure>
   )
 }

--- a/src/components/workbench/artifacts/ArtifactDocumentShell.tsx
+++ b/src/components/workbench/artifacts/ArtifactDocumentShell.tsx
@@ -4,6 +4,7 @@ import { MarkdownRenderer } from '../MarkdownRenderer'
 import type { NovelArtifact } from '@shared/types/novel'
 import { READING_BODY_FONT_CLASS, WORKBENCH_READING_CANVAS_CLASS } from '@/design-system'
 import { Button } from '@/components/ui/button'
+import { Disclosure } from '@/components/ui/disclosure'
 import { countBodyChars } from '@/lib/word-count'
 
 const DETAILS_SUMMARY_CLASS =
@@ -58,19 +59,18 @@ export function ArtifactDocumentShell({
     >
       {children}
       {chapterSummary !== undefined && (
-        <details className={`${DETAILS_PANEL_CLASS} mt-8`} data-chapter-summary="true">
-          <DetailSummary>本章总结</DetailSummary>
+        <Disclosure className={`${DETAILS_PANEL_CLASS} mt-8`} data-chapter-summary="true" summary={<DetailSummary>本章总结</DetailSummary>}>
           <div className={DETAILS_BODY_CLASS}>
             <StructuredMetadataValue value={chapterSummary} />
           </div>
-        </details>
+        </Disclosure>
       )}
       {!fileInfoHidden && (
-        <details
+        <Disclosure
           className={`${DETAILS_PANEL_CLASS} ${chapterSummary === undefined ? 'mt-8' : ''}`}
           data-reading-metadata="true"
+          summary={<DetailSummary>文件信息</DetailSummary>}
         >
-          <DetailSummary>文件信息</DetailSummary>
           <dl className={DETAILS_BODY_CLASS}>
             <DetailRow label="来源" type="file">
               NarraCat 输出
@@ -85,7 +85,7 @@ export function ArtifactDocumentShell({
               已生成
             </DetailRow>
           </dl>
-        </details>
+        </Disclosure>
       )}
     </section>
   )
@@ -327,14 +327,14 @@ function countReadableUnits(content: string): string {
 
 function DetailSummary({ children }: { children: ReactNode }) {
   return (
-    <summary className={DETAILS_SUMMARY_CLASS}>
+    <span className={`${DETAILS_SUMMARY_CLASS} w-auto`}>
       <ChevronRight
         aria-hidden="true"
         className="mr-2 size-4 shrink-0 transition-transform group-open:rotate-90"
         data-details-chevron="true"
       />
       <span>{children}</span>
-    </summary>
+    </span>
   )
 }
 

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -184,7 +184,7 @@ function AboutBetaNotice() {
  * 关于页诊断折叠（通用 Disclosure 的薄封装：钉住 data 锚点与摘要行样式）。
  *
  * 为什么不用原生 <details>：Windows 打包版（asar）实测渲染原生 details 元素会把渲染主线程
- * 挂死（无 CPU 的同步阻塞；dev 的非 asar file:// 与 mac 均正常）——Chromium 41 引擎级问题，
+ * 挂死（无 CPU 的同步阻塞；dev 的非 asar file:// 与 mac 均正常）——Electron 41.2.1（对应 Chromium 146）引擎级问题，
  * 与业务代码无关（纯净 <details> 即可复现）。全库统一走 ui/disclosure。
  */
 function AboutDiagnosticsDisclosure({ children }: { children: React.ReactNode }) {
@@ -844,7 +844,7 @@ export function SettingsRoute() {
                           </a>
                         </div>
                       </SettingsRow>
-                      {/* 规避 Chromium 41 在 Windows 打包版（asar）渲染原生 <details> 挂起主线程的
+                      {/* 规避 Electron 41.2.1（对应 Chromium 146）在 Windows 打包版（asar）渲染原生 <details> 挂起主线程的
                           引擎级 bug——换 ui/disclosure（AboutDiagnosticsDisclosure，功能 1:1）。 */}
                       <AboutDiagnosticsDisclosure>
                           <SettingsRow title="Agent Core lock">

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -31,6 +31,7 @@ import {
   SettingsRow,
 } from '@/components/settings/SettingsLayout'
 import { useTheme, DARK_MODE_ENABLED, type Theme } from '@/lib/theme'
+import { Disclosure } from '@/components/ui/disclosure'
 import {
   deleteApiKey,
   getConfig,
@@ -176,6 +177,29 @@ function AboutBetaNotice() {
         ))}
       </div>
     </section>
+  )
+}
+
+/**
+ * 关于页诊断折叠（通用 Disclosure 的薄封装：钉住 data 锚点与摘要行样式）。
+ *
+ * 为什么不用原生 <details>：Windows 打包版（asar）实测渲染原生 details 元素会把渲染主线程
+ * 挂死（无 CPU 的同步阻塞；dev 的非 asar file:// 与 mac 均正常）——Chromium 41 引擎级问题，
+ * 与业务代码无关（纯净 <details> 即可复现）。全库统一走 ui/disclosure。
+ */
+function AboutDiagnosticsDisclosure({ children }: { children: React.ReactNode }) {
+  return (
+    <Disclosure
+      data-settings-about-diagnostics="true"
+      summary={(open) => (
+        <span className="flex min-h-[56px] w-full items-center justify-between gap-4 px-3 py-3 text-sm font-medium text-foreground">
+          <span>诊断信息</span>
+          <span className="text-xs font-normal text-muted-foreground">{open ? '收起' : '展开'}</span>
+        </span>
+      )}
+    >
+      <div className="divide-y divide-border border-t border-border">{children}</div>
+    </Disclosure>
   )
 }
 
@@ -820,13 +844,9 @@ export function SettingsRoute() {
                           </a>
                         </div>
                       </SettingsRow>
-                      <details data-settings-about-diagnostics="true" className="group">
-                        <summary className="flex min-h-[56px] cursor-default list-none items-center justify-between gap-4 px-3 py-3 text-sm font-medium text-foreground marker:hidden">
-                          <span>诊断信息</span>
-                          <span className="text-xs font-normal text-muted-foreground group-open:hidden">展开</span>
-                          <span className="hidden text-xs font-normal text-muted-foreground group-open:inline">收起</span>
-                        </summary>
-                        <div className="divide-y divide-border border-t border-border">
+                      {/* 规避 Chromium 41 在 Windows 打包版（asar）渲染原生 <details> 挂起主线程的
+                          引擎级 bug——换 ui/disclosure（AboutDiagnosticsDisclosure，功能 1:1）。 */}
+                      <AboutDiagnosticsDisclosure>
                           <SettingsRow title="Agent Core lock">
                             <div className="truncate text-right font-mono text-xs">
                               {diagnostics?.versionLock.path ?? 'agent-core/narracat-agent-core.lock.json'}
@@ -949,8 +969,7 @@ export function SettingsRoute() {
                               检测
                             </Button>
                           </SettingsActionRow>
-                        </div>
-                      </details>
+                      </AboutDiagnosticsDisclosure>
                     </SettingsCard>
                   </div>
                   <AboutBetaNotice />


### PR DESCRIPTION
Fixes #1

- 新增 `src/components/ui/disclosure.tsx`：div + useState 折叠；内容常驻 DOM 仅 `hidden` 切换（SSR 测试断言兼容）；外层展开时输出 `open` 属性，存量 `group-open:*` 样式（chevron 旋转等）零改动生效
- 替换全部 6 处原生 `<details>`：阅读画布本章总结/文件信息、章节能力回执、能力包卡内容、导入 lint 警告、规划回执、关于页诊断信息
- 新增 `scripts/check-no-native-details.mjs`（字符串/注释感知扫描）+ 4 个单测，挂入 `check:architecture`
- 验证：typecheck + 全量测试绿；Windows 打包版（NSIS 与便携）真机确认书架/外观/模型服务/能力包/关于 5 页面运行时 `document.querySelectorAll('details').length === 0`，折叠展开功能正常
- macOS 无行为变化（原本未触发该缺陷；样式与交互语义 1:1 保留）
