### PR TITLE
fix(build): electronLanguages 按平台分设（mac lproj 下划线 / win pak 连字符）

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,16 @@
   },
   "build": {
     "appId": "app.narracat.desktop",
-    "artifactName": "NarraCat-${version}-mac-${arch}.${ext}",
-    "electronLanguages": [
-      "zh_CN",
-      "en"
-    ],
+    "artifactName": "NarraCat-${version}-${os}-${arch}.${ext}",
     "mac": {
       "icon": "build/icon.icns",
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "electronLanguages": [
+        "zh_CN",
+        "en"
+      ],
       "target": [
         {
           "target": "dmg",
@@ -53,6 +53,12 @@
             "arm64"
           ]
         }
+      ]
+    },
+    "win": {
+      "electronLanguages": [
+        "zh-CN",
+        "en-US"
       ]
     },
     "dmg": {

--- a/scripts/package-config.test.mjs
+++ b/scripts/package-config.test.mjs
@@ -14,7 +14,7 @@ describe('RC package configuration', () => {
   test('targets Developer ID signed + notarized macOS arm64 DMG/ZIP artifacts', () => {
     expect(packageJson.scripts.package).toBe('node scripts/package-rc.mjs')
     expect(packageJson.scripts['package:release']).toBe('node scripts/package-rc.mjs --notarize')
-    expect(packageJson.build.artifactName).toBe('NarraCat-${version}-mac-${arch}.${ext}')
+    expect(packageJson.build.artifactName).toBe('NarraCat-${version}-${os}-${arch}.${ext}')
     // 不再硬编码 identity：由 electron-builder 从 Keychain 解析 Developer ID Application。
     // 缺证书时 electron-builder 只警告不报错，故打包链另设 check-signing-identity 硬闸（Task 2）。
     expect(packageJson.build.mac.identity).toBeUndefined()
@@ -74,8 +74,12 @@ describe('RC package configuration', () => {
     expect(appIconSvg).toContain('<rect width="512" height="512" rx="96" fill="#FFFFFF"/>')
   })
 
-  test('keeps only the Electron locales used by the RC app', () => {
-    expect(packageJson.build.electronLanguages).toEqual(['zh_CN', 'en'])
+  test('keeps only the Electron locales used by the RC app (per-platform)', () => {
+    // mac lproj 用下划线命名（zh_CN.lproj），win pak 用连字符命名（zh-CN.pak）——
+    // electron-builder 按平台精确匹配，两套命名各对一半，必须分设（#3）。
+    expect(packageJson.build.electronLanguages).toBeUndefined()
+    expect(packageJson.build.mac.electronLanguages).toEqual(['zh_CN', 'en'])
+    expect(packageJson.build.win.electronLanguages).toEqual(['zh-CN', 'en-US'])
   })
 
   test('packages only built runtime output into app.asar', () => {


### PR DESCRIPTION
Fixes #3

按作者在 #3 中核实的结论实施：electron-builder 的 `removeUnusedLanguagesIfNeeded` 用 `path.basename(file, langFileExt)` 做精确匹配，`langFileExt` 按平台分叉——mac 是 `.lproj`（下划线命名 `zh_CN.lproj`），Windows 是 `.pak`（连字符命名 `zh-CN.pak`）。同一份根级配置不可能两边都命中，按平台分设是唯一两边都对的写法。

## 改动

```diff
- "electronLanguages": ["zh_CN", "en"],
  "mac": {
+   "electronLanguages": ["zh_CN", "en"],
    ...
  },
+ "win": {
+   "electronLanguages": ["zh-CN", "en-US"]
+ },
```

- `mac.electronLanguages` 保持原值不动（作者已实物核实：已安装的 mac 打包版 `Electron Framework.framework/Resources/` 下正好剩 `en.lproj` + `zh_CN.lproj`，精确命中）
- `win.electronLanguages` 用 Windows 真机三轮验收过的值（建项目 → 生成核心前提 → 立项对话流式输出，无白屏）
- 顺带 `artifactName` 的 `-mac-` 硬编码改 `${os}`——加了 win 段后 Windows 产物名不应再叫 `-mac-`
- 同步更新 `package-config.test.mjs` 断言（分平台结构 + `${os}` 产物名）

## 命名差异说明（因 package.json 严格 JSON 写不了注释，放这里）

| 平台 | 语言资源后缀 | 命名规则 | 示例 |
|---|---|---|---|
| macOS | `.lproj` | **下划线** | `zh_CN.lproj` / `en.lproj` |
| Windows | `.pak` | **连字符**（BCP-47） | `zh-CN.pak` / `en-US.pak` |

electron-builder 匹配逻辑（`app-builder-lib/out/electron/ElectronFramework.js`）：
- `path.basename(file, langFileExt)` 精确字符串比对，无归一化
- `langFileExt` 按平台取值：mac → `.lproj`，win → `.pak`
- 平台级 `electronLanguages` 优先于根级（`platformSpecificBuildOptions.electronLanguages || config.electronLanguages`）

## 验证

- `bun --no-cache run typecheck` ✅
- `bun test scripts/package-config.test.mjs`（9/9 全绿，含新增分平台断言）✅
- `bun run check:architecture` ✅
- Windows 打包版三轮真机验收（详见 #3）：修复前 `locales/` 为空、渲染文本即崩（渲染进程 exitCode -36861，dump 符号化崩在 `blink::LCIDFromLocaleInternal`）；修复后 `zh-CN.pak` + `en-US.pak` 正确落盘，完整流程无白屏
- mac 侧由作者实物核实保持原样（本 PR mac 段与原值完全一致）
