### PR TITLE
chore(ui): Disclosure 守卫补自检、样式去死码、补交互测试（#2 review 跟进）

### DIFF
--- a/scripts/check-no-native-details.mjs
+++ b/scripts/check-no-native-details.mjs
@@ -9,12 +9,34 @@
 // 合并上游代码把原生 details 再带进来，在 Windows 打包版静默复发（dev/mac 都测不出来）。
 //
 // 用法：node scripts/check-no-native-details.mjs（退出码 1 = 有违规）。
+//
+// 解除条件：本守卫是为绕开引擎 bug 而设的临时纪律，不是永久设计约束。定位时的组合是
+// electron 41.2.1 / Chromium 146；将来升级 Electron 后，用一个纯净 <details> 在 Windows
+// 打包版（必须是 asar + file://，dev 与 mac 都测不出来）复测，若不再挂起，本脚本连同
+// package.json 里的 check:architecture 挂载可一并撤下，UI 回归原生 details。
 
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 const SRC_DIR = 'src'
 const DETAILS_RE = /<details[\s/>]|<\/details\s*>|<summary[\s/>]|<\/summary\s*>/
+
+/**
+ * 扫描范围下限。守卫必须真的扫到东西才算数：cwd 不在仓库根、src 改名或目录搬迁都会让扫描
+ * 范围塌成 0，而「零违规」恰好长得和「全部通过」一模一样——本仓在别处已经吃过这种静默通过
+ * 的亏（打包链断了两周靠陈旧产物假绿）。src 现有 181 个 tsx，取 50 作下限。
+ */
+export const MIN_SCANNED_TSX = 50
+
+/**
+ * 扫描范围自检（导出供测试）。
+ * @param {number} fileCount 实际扫到的 tsx 数量
+ * @returns {string | null} 错误文案；null = 覆盖面正常
+ */
+export function scanCoverageFailure(fileCount) {
+  if (fileCount >= MIN_SCANNED_TSX) return null
+  return `check-no-native-details: 只扫到 ${fileCount} 个 tsx（预期 ≥ ${MIN_SCANNED_TSX}）——扫描范围异常（cwd 不是仓库根？src 改名或搬迁？），守卫已形同虚设，先修扫描范围。`
+}
 
 /** 剥离 // 行注释与块注释（含 JSDoc/JSX 注释），正确跳过字符串字面量；保留换行以便报行号。 */
 function stripComments(content) {
@@ -122,6 +144,11 @@ export function collectNativeDetailsViolations({ files }) {
 
 function main() {
   const files = collectTsxFiles(SRC_DIR).map((path) => ({ path, content: readFileSync(path, 'utf-8') }))
+  const coverageFailure = scanCoverageFailure(files.length)
+  if (coverageFailure) {
+    console.error(coverageFailure)
+    process.exit(1)
+  }
   const violations = collectNativeDetailsViolations({ files })
   if (violations.length > 0) {
     console.error(`check-no-native-details: ${violations.length} 处 JSX 原生 <details>/<summary>（Windows asar 冻结风险）：`)

--- a/scripts/check-no-native-details.test.mjs
+++ b/scripts/check-no-native-details.test.mjs
@@ -1,5 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { collectNativeDetailsViolations } from './check-no-native-details.mjs'
+import { MIN_SCANNED_TSX, collectNativeDetailsViolations, scanCoverageFailure } from './check-no-native-details.mjs'
+
+describe('scanCoverageFailure（扫描范围自检）', () => {
+  test('扫到 0 个文件判失败——零文件不许静默打印 OK', () => {
+    expect(scanCoverageFailure(0)).toContain('只扫到 0 个 tsx')
+  })
+
+  test('低于下限判失败，达到下限放行', () => {
+    expect(scanCoverageFailure(MIN_SCANNED_TSX - 1)).not.toBeNull()
+    expect(scanCoverageFailure(MIN_SCANNED_TSX)).toBeNull()
+  })
+})
 
 describe('collectNativeDetailsViolations（Windows asar 冻结守卫）', () => {
   test('JSX <details>/<summary> 判违规（含自闭合与属性形态）', () => {

--- a/src/components/ui/disclosure.interactions.test.tsx
+++ b/src/components/ui/disclosure.interactions.test.tsx
@@ -1,0 +1,96 @@
+// Disclosure 真实 DOM 交互测试（点击展开/折叠）。
+//
+// 为什么单独一个文件、且不与 disclosure.test.tsx 合并：那份走 renderToStaticMarkup，不需要
+// DOM；而全局挂载必须发生在 @testing-library/react 被 import 之前，ES import 又会提升到模块
+// 顶部——只能靠「先同步挂全局，再顶层 await 动态 import」，这条纪律会污染同文件里的普通用例。
+//
+// 为什么不用 GlobalRegistrator：本仓同进程安全共存上限 = 4（已被 ChapterManuscriptView.interactions /
+// StateChangesLedger / AgentThreadView.interactions / BookVoiceAnchors 占满），追加会让它们集体
+// 失败。改走 UpdateRow.test.tsx / WizardView.mount.test.tsx 的先例：手动把 happy-dom 的
+// Window/Document 挂到 globalThis，afterAll 恢复。
+//
+// 为什么查询一律走 container.querySelector：@testing-library/dom 的 screen 是进程级单例，模块
+// 首次求值时把查询函数焊死在当时的 document.body 上，同进程多个 DOM 测试文件会互相打空。
+import { Window } from 'happy-dom'
+
+const happyWindow = new Window()
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document')
+Object.defineProperty(globalThis, 'window', { configurable: true, value: happyWindow })
+Object.defineProperty(globalThis, 'document', { configurable: true, value: happyWindow.document })
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const { afterAll, afterEach, describe, expect, test } = await import('bun:test')
+const { cleanup, fireEvent, render } = await import('@testing-library/react')
+const { Disclosure } = await import('./disclosure.tsx')
+
+afterEach(() => {
+  cleanup()
+})
+
+afterAll(async () => {
+  if (originalWindowDescriptor) Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+  else Reflect.deleteProperty(globalThis, 'window')
+  if (originalDocumentDescriptor) Object.defineProperty(globalThis, 'document', originalDocumentDescriptor)
+  else Reflect.deleteProperty(globalThis, 'document')
+  await happyWindow.happyDOM.close()
+})
+
+describe('Disclosure 交互', () => {
+  test('点击切换：open 属性、内容 hidden、aria-expanded 三者同步', () => {
+    const { container } = render(
+      <Disclosure summary={<span>头</span>} data-test-anchor="true">
+        <div data-test-body="true">体</div>
+      </Disclosure>,
+    )
+    const root = container.querySelector('[data-test-anchor]') as HTMLElement
+    const body = container.querySelector('[data-test-body]')?.parentElement as HTMLElement
+    const button = container.querySelector('button') as HTMLElement
+
+    // 折叠态：group-open:* 靠 open 属性存在性命中，所以折叠时必须没有该属性。
+    expect(root.hasAttribute('open')).toBe(false)
+    expect(body.className).toContain('hidden')
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(button)
+    expect(root.getAttribute('open')).toBe('')
+    expect(body.className).not.toContain('hidden')
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(button)
+    expect(root.hasAttribute('open')).toBe(false)
+    expect(body.className).toContain('hidden')
+  })
+
+  test('defaultOpen 直接进展开态', () => {
+    const { container } = render(
+      <Disclosure defaultOpen summary={<span>头</span>} data-test-anchor="true">
+        <div>体</div>
+      </Disclosure>,
+    )
+    expect((container.querySelector('[data-test-anchor]') as HTMLElement).getAttribute('open')).toBe('')
+  })
+
+  test('summary 传函数时拿得到 open 态（关于页「展开/收起」文案靠它）', () => {
+    const { container } = render(
+      <Disclosure summary={(open) => <span>{open ? '收起' : '展开'}</span>}>
+        <div>体</div>
+      </Disclosure>,
+    )
+    const button = container.querySelector('button') as HTMLElement
+    expect(button.textContent).toBe('展开')
+    fireEvent.click(button)
+    expect(button.textContent).toBe('收起')
+  })
+
+  test('调用方的 className 与 data-* 锚点保留在外层，group 类不丢', () => {
+    const { container } = render(
+      <Disclosure className="my-panel" summary={<span>头</span>} data-test-anchor="true">
+        <div>体</div>
+      </Disclosure>,
+    )
+    const root = container.querySelector('[data-test-anchor]') as HTMLElement
+    expect(root.className).toContain('group')
+    expect(root.className).toContain('my-panel')
+  })
+})

--- a/src/components/ui/disclosure.tsx
+++ b/src/components/ui/disclosure.tsx
@@ -42,7 +42,7 @@ export function Disclosure({
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
-        className="flex w-full cursor-pointer select-none items-center text-left [&::-webkit-details-marker]:hidden"
+        className="flex w-full cursor-pointer select-none items-center text-left"
       >
         {summaryContent}
       </button>

--- a/src/components/workbench/ChapterCapabilityReceipt.tsx
+++ b/src/components/workbench/ChapterCapabilityReceipt.tsx
@@ -15,7 +15,7 @@ const TYPE_LABELS: Record<string, string> = {
 // 折叠区排版对齐 ArtifactDocumentShell 既有「文件信息」/「本章总结」折叠区（同一套 details/summary 词汇）。
 const DETAILS_PANEL_CLASS = 'group border-t border-border text-xs text-muted-foreground'
 const DETAILS_SUMMARY_CLASS =
-  'flex min-h-10 w-full cursor-pointer list-none select-none items-center py-2 text-sm font-medium text-hint-foreground [&::-webkit-details-marker]:hidden'
+  'flex min-h-10 w-full cursor-pointer select-none items-center py-2 text-sm font-medium text-hint-foreground'
 const DETAILS_BODY_CLASS = 'space-y-1.5 pb-3'
 const ENTRY_ROW_CLASS =
   'flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border/60 py-1.5 last:border-b-0'

--- a/src/components/workbench/artifacts/ArtifactDocumentShell.tsx
+++ b/src/components/workbench/artifacts/ArtifactDocumentShell.tsx
@@ -8,7 +8,7 @@ import { Disclosure } from '@/components/ui/disclosure'
 import { countBodyChars } from '@/lib/word-count'
 
 const DETAILS_SUMMARY_CLASS =
-  'flex min-h-10 w-full cursor-pointer list-none select-none items-center py-2 text-sm font-medium text-hint-foreground [&::-webkit-details-marker]:hidden'
+  'flex min-h-10 w-full cursor-pointer select-none items-center py-2 text-sm font-medium text-hint-foreground'
 const DETAILS_BODY_CLASS = 'pb-3'
 const DETAILS_PANEL_CLASS = 'group border-t border-border text-xs text-muted-foreground'
 const DETAIL_ROW_CLASS =
@@ -327,7 +327,7 @@ function countReadableUnits(content: string): string {
 
 function DetailSummary({ children }: { children: ReactNode }) {
   return (
-    <span className={`${DETAILS_SUMMARY_CLASS} w-auto`}>
+    <span className={DETAILS_SUMMARY_CLASS}>
       <ChevronRight
         aria-hidden="true"
         className="mr-2 size-4 shrink-0 transition-transform group-open:rotate-90"


### PR DESCRIPTION
#2 合并时留下的几条 review 意见的跟进（当时都标了不阻塞合并）。纯收尾，不改任何用户可见行为。

## 改动

**1. 守卫加扫描范围自检（这条最实质）**

`check-no-native-details.mjs` 原来在扫到 0 个文件时仍会打印 OK 并退出 0 —— 将来 `src` 改名或目录搬迁，守卫会静默塌成一句空话，而「零违规」和「全部通过」长得一模一样。本仓已经在打包链上吃过同类的亏（产物断链两周靠陈旧构建假绿）。

新增 `scanCoverageFailure()`：扫到的 tsx 少于 50 个直接 fail（当前 182 个）。TDD 走的——先写测试确认它红（`Export named 'scanCoverageFailure' not found`），再实现。

**2. 补守卫的解除条件**

这条守卫等于永久禁用原生 `<details>`，但它是绕引擎 bug 的临时纪律，不是设计约束。脚本头部补上：钉死当时的 electron 41.2.1 / Chromium 146，写明复测方法（必须 Windows 打包版 + asar + `file://`，dev 与 mac 都测不出来），以及确认修复后可以把脚本连同 `check:architecture` 挂载一并撤下。免得两年后没人知道这条限制为什么存在。

**3. 删掉 `w-auto`**

`ArtifactDocumentShell` 的 `DetailSummary` 用 `w-auto` 覆盖常量里的 `w-full`，但 `ChapterCapabilityReceipt` 的同款 summary 没加；而且这里是模板字符串拼接、不走 `cn`/twMerge，两个 width 类会并存，谁生效取决于 CSS 生成顺序。视觉上两种结果一样（真正撑满整行的是外层 `button`），属无害但误导后人的写法，删掉后两处一致。

**4. 清死类名**

`list-none`、`[&::-webkit-details-marker]:hidden` 只对原生 `<details>` 有意义，迁到 div+button 后是纯死码，三处清掉，grep 复查已干净。

**5. 补真实 DOM 交互测试**

`disclosure.test.tsx` 走的是 `renderToStaticMarkup`，只锁住了 SSR 的 open 属性输出，而 React 19 的 SSR 与浏览器端是两套独立的属性写入路径，最核心的「点击展开/折叠」没被锁住。

新增 `disclosure.interactions.test.tsx`，4 个用例：点击切换（open 属性 / 内容 hidden / aria-expanded 三者同步）、`defaultOpen`、summary 传函数形态（关于页「展开/收起」文案靠它）、调用方 className 与 `data-*` 锚点保留。

写法照 `UpdateRow.test.tsx` 的先例：手动挂 happy-dom 的 Window/Document、`afterAll` 恢复，**不用 `GlobalRegistrator`**（本仓同进程安全共存上限 4，已被占满，加第 5 个会让前面几个文件集体失败）；查询一律走 `container.querySelector`，不碰进程级单例 `screen`。文件顶部把这两条纪律的原因都写下来了。

## 没做的一条

review 里还提过关于页光标从 `cursor-default` 变成 `cursor-pointer`（`Disclosure` 把它写死在 button 上，调用方覆盖不了）。没改：那行本来就可点，显手型更诚实；要让调用方能覆盖就得给组件加 `buttonClassName` 之类的口子，为一个光标造抽象不划算，等真出现第二个需要定制的调用点再说。

## 验证

- `bun --no-cache run test` → **2982 pass / 0 fail**（比 main 多 6 个，正好是新增的 2 + 4）
- 5 个手动挂载 DOM 的测试文件凑一起单跑 → 64 pass / 0 fail，确认新文件不引发跑序冲突（这是典型的本机绿、CI 红组合，专门验了）
- `bun --no-cache run typecheck` ✅
- `bun --no-cache run check:architecture` ✅（守卫报 182 个 tsx 零原生 details）
- `bun --no-cache run check:design` ✅
- 反证：把扫描范围人为打空后守卫确实 fail，不再静默 OK

无用户可见行为变更，故未做真机走查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
