### PR TITLE
fix(pi): 救回被抹空的 eager 工具参数（Closes #16）

### DIFF
--- a/electron/main/agent/runtime/adapters/pi/index.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/index.test.ts
@@ -162,8 +162,8 @@ describe('切片③ 权限门禁接线', () => {
   test('guard 扩展始终注入且允许根含 novelRootDir/projectPath/cwd', async () => {
     const adapter = createPiAdapter()
     const options = (await adapter.createRunOptions(makeRunConfig())) as PiRunOptions
-    expect(options.extensions).toHaveLength(1)
-    expect(options.extensions[0].handlers.has('tool_call')).toBe(true)
+    expect(options.extensions).toHaveLength(2)
+    expect(options.extensions.some((extension) => extension.handlers.has('tool_call'))).toBe(true)
   })
 
   test('computeBaselineAllowedRoots：四根去重去空——projectPath 与 cwd 不同时各留一条', () => {
@@ -208,7 +208,7 @@ describe('切片③ 权限门禁接线', () => {
     expect(options.tools).toEqual(['read', 'write', 'find'])
     expect(options.cwd).toBe('/tmp/sandbox-ws')
     expect(options.customTools).toHaveLength(0)
-    expect(options.extensions).toHaveLength(1)
+    expect(options.extensions).toHaveLength(2)
   })
 
   test('createSandboxedRunOptions 沙盒路径同规持久化：resume 翻成 sessionStore.resumeSessionId（对齐 SDK persistSession 默认，向导轮次续接同构）', async () => {
@@ -228,17 +228,50 @@ describe('切片④ 引擎钩子接线', () => {
   test('loadNarraCatRuntime=true → extensions 含 guard + engine-hooks 两个扩展', async () => {
     const adapter = createPiAdapter()
     const options = (await adapter.createRunOptions(makeRunConfig({ loadNarraCatRuntime: true }))) as PiRunOptions
-    expect(options.extensions).toHaveLength(2)
-    expect(options.extensions[0].handlers.has('tool_call')).toBe(true)
-    expect(options.extensions[1].handlers.has('tool_result')).toBe(true)
+    expect(options.extensions).toHaveLength(3)
+    expect(options.extensions.some((extension) => extension.handlers.has('tool_call'))).toBe(true)
+    expect(options.extensions.some((extension) => extension.handlers.has('tool_result'))).toBe(true)
   })
 
   test('loadNarraCatRuntime 缺省/false → 只有 guard，不挂引擎钩子', async () => {
     const adapter = createPiAdapter()
     const withoutFlag = (await adapter.createRunOptions(makeRunConfig())) as PiRunOptions
-    expect(withoutFlag.extensions).toHaveLength(1)
+    expect(withoutFlag.extensions.some((extension) => extension.handlers.has('tool_result'))).toBe(false)
+    expect(withoutFlag.extensions).toHaveLength(2)
     const withFalse = (await adapter.createRunOptions(makeRunConfig({ loadNarraCatRuntime: false }))) as PiRunOptions
-    expect(withFalse.extensions).toHaveLength(1)
+    expect(withFalse.extensions.some((extension) => extension.handlers.has('tool_result'))).toBe(false)
+    expect(withFalse.extensions).toHaveLength(2)
+  })
+})
+
+/**
+ * issue #16 接线锁：eager 工具参数救回修的是 pi 传输层，与引擎契约无关，必须在**所有**会话形态上
+ * 挂载。这条测试的意义是防止将来有人顺手把它并进 loadNarraCatRuntime 门控里——真那样，学习/
+ * 向导沙盒与 direct-chat 会在 eager 端点上重新开始丢参数，而且是静默丢。
+ */
+describe('eager 工具参数救回接线（issue #16）', () => {
+  const hasEagerRestorer = (extensions: PiRunOptions['extensions']) =>
+    extensions.some((extension) => extension.handlers.has('message_update') && extension.handlers.has('message_end'))
+
+  test('主会话三种门控形态下都挂载', async () => {
+    const adapter = createPiAdapter()
+    for (const config of [
+      makeRunConfig(),
+      makeRunConfig({ loadNarraCatRuntime: false }),
+      makeRunConfig({ loadNarraCatRuntime: true }),
+    ]) {
+      const options = (await adapter.createRunOptions(config)) as PiRunOptions
+      expect(hasEagerRestorer(options.extensions)).toBe(true)
+    }
+  })
+
+  test('沙盒会话（学习/向导）同样挂载', async () => {
+    const adapter = createPiAdapter()
+    const options = (await adapter.createSandboxedRunOptions({
+      ...makeRunConfig(),
+      sandbox: { tools: ['Read'], workspaceDir: '/tmp/sandbox-ws' },
+    } as never)) as PiRunOptions
+    expect(hasEagerRestorer(options.extensions)).toBe(true)
   })
 })
 

--- a/electron/main/agent/runtime/adapters/pi/index.ts
+++ b/electron/main/agent/runtime/adapters/pi/index.ts
@@ -38,6 +38,7 @@ import type { MemoryToolChannel, PiMemoryBridge } from './pi-memory-tools.ts'
 import { runPiSession } from './pi-session.ts'
 import type { PiRunOptions, RunPiSessionArgs } from './pi-session.ts'
 import { mapPiMessageToAgentEvents, PI_SESSION_MESSAGE_TYPE } from './pi-event-mapper.ts'
+import { createPiEagerToolArgsRestorer } from './pi-eager-toolcall-args.ts'
 import { createPiEngineHooksExtension } from './pi-engine-hooks.ts'
 import { createSubagentEventChannel, createTaskCardTools, createTaskTool } from './pi-subagent.ts'
 import { createAskUserQuestionTool, createPiToolGuard, mapSdkToolFaceToPi } from './pi-tool-guard.ts'
@@ -100,7 +101,12 @@ async function buildPiRunOptions(
   // 引擎钩子（字数提示/任务书系统词硬门）只在 loadNarraCatRuntime 时挂：学习/向导等沙盒会话
   // 本就不跑引擎契约，与 SDK 侧同条件不装载 plugin 对齐（brief 见 Task 5 任务书）。
   const agentDir = join(args.userDataPath ?? args.appRoot, 'pi-agent')
-  const extensions = args.loadNarraCatRuntime ? [guard, createPiEngineHooksExtension({ cwd })] : [guard]
+  // eager 工具参数救回（issue #16）修的是 pi 传输层的参数丢失，与引擎契约无关：任何会话都可能
+  // 中招（学习/向导沙盒、direct-chat 一样打 Anthropic wire），故不受 loadNarraCatRuntime 门控。
+  // 排在最前：它把被抹空的参数补回后，后续扩展看到的才是模型真正发出的那份。
+  const extensions = args.loadNarraCatRuntime
+    ? [createPiEagerToolArgsRestorer(), guard, createPiEngineHooksExtension({ cwd })]
+    : [createPiEagerToolArgsRestorer(), guard]
 
   // NovelMemory 工具（切片⑥）：与 SDK createNovelMemoryMcpServers 同门条件（跑引擎契约 + 有项目），
   // face 无记忆名（如 direct-chat 默认面）时零装载。
@@ -149,7 +155,9 @@ async function buildPiRunOptions(
       maxTurns: SUBAGENT_MAX_TURNS,
       systemPrompt: definition.prompt,
       abortController: childAbort,
-      extensions: [childGuard, createPiEngineHooksExtension({ cwd })],
+      // 各子会话新起一个实例：救回逻辑的 eager 快照是扩展闭包内的 run 级状态，共用实例会让
+      // 并发子会话互相串参数。
+      extensions: [createPiEagerToolArgsRestorer(), childGuard, createPiEngineHooksExtension({ cwd })],
       customTools: childMemoryTools,
     }
   }

--- a/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.test.ts
@@ -1,0 +1,219 @@
+/**
+ * eager 工具参数救回扩展单测（issue #16）。
+ *
+ * 纪律：事件序列**不手写**，而是驱动真实的 `streamAnthropic`（注入假 client 喂构造 SSE）拿到
+ * 上游真正推送的 AssistantMessageEvent，再照 `agent-session.js` `_emitExtensionEvent` 的桥接
+ * 形状包成 message_update / message_end 交给扩展。手写事件只能验证「代码符合我对事件形状的
+ * 假设」，一旦假设错了测试照样绿——本仓吃过这种假绿的亏，这里用真实流事件把这条路堵死。
+ *
+ * 三条序列各锁一件事：
+ * - eager 无 delta   → 参数被上游抹空，扩展必须救回（本 issue 的现场）
+ * - 标准增量 delta   → 上游本来就对，扩展必须一个字节都不改（防回归）
+ * - delta 中途截断   → 上游交出半个对象，扩展不介入（明确的范围外，见实现文件拆除说明书）
+ */
+import { describe, expect, test } from 'bun:test'
+import { streamAnthropic } from '@mariozechner/pi-ai/anthropic'
+import type { Model } from '@mariozechner/pi-ai'
+import { createPiEagerToolArgsRestorer } from './pi-eager-toolcall-args.ts'
+
+const TOOL_NAME = 'novel_submit_outline'
+const FULL_ARGS = {
+  phase: 1,
+  scope: 'full',
+  payload: { central_dramatic_question: '他能否夺回宗门？', volumes: [{ volume_no: 1 }] },
+}
+const FULL_ARGS_JSON = JSON.stringify(FULL_ARGS)
+
+type SseEvent = { type: string } & Record<string, unknown>
+
+function toSse(events: SseEvent[]): string {
+  return events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join('')
+}
+
+function messageEnvelope(events: SseEvent[]): SseEvent[] {
+  return [
+    { type: 'message_start', message: { id: 'msg_1', usage: { input_tokens: 10, output_tokens: 0 } } },
+    ...events,
+    { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 20 } },
+    { type: 'message_stop' },
+  ]
+}
+
+/** 服务端把完整参数塞进 content_block_start.input，之后不发任何 input_json_delta。 */
+const EAGER_NO_DELTA = messageEnvelope([
+  {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'tool_use', id: 'toolu_1', name: TOOL_NAME, input: FULL_ARGS },
+  },
+  { type: 'content_block_stop', index: 0 },
+])
+
+/** 官方 Anthropic 的标准增量形态。 */
+const STANDARD_DELTA = messageEnvelope([
+  {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'tool_use', id: 'toolu_1', name: TOOL_NAME, input: {} },
+  },
+  {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'input_json_delta', partial_json: FULL_ARGS_JSON.slice(0, 30) },
+  },
+  {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'input_json_delta', partial_json: FULL_ARGS_JSON.slice(30) },
+  },
+  { type: 'content_block_stop', index: 0 },
+])
+
+/** 增量在 payload 的值开始之前断掉（max_tokens / 断流）。 */
+const TRUNCATED_DELTA = messageEnvelope([
+  {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'tool_use', id: 'toolu_1', name: TOOL_NAME, input: {} },
+  },
+  {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'input_json_delta', partial_json: '{"phase":1,"scope":"full","payload":' },
+  },
+  { type: 'content_block_stop', index: 0 },
+])
+
+const MODEL: Model<'anthropic-messages'> = {
+  id: 'fake-anthropic-compatible',
+  name: 'fake-anthropic-compatible',
+  api: 'anthropic-messages',
+  provider: 'anthropic',
+  baseUrl: 'https://example.invalid',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+}
+
+function fakeClient(events: SseEvent[]) {
+  return {
+    messages: {
+      create: () => ({
+        asResponse: async () =>
+          new Response(toSse(events), { status: 200, headers: { 'content-type': 'text/event-stream' } }),
+      }),
+    },
+  }
+}
+
+/**
+ * 跑真实上游解析，把流事件按 agent-session 的桥接形状交给扩展，返回扩展收工后的 assistant 消息
+ * （扩展返回替换消息则用替换后的那份，与 `_replaceMessageInPlace` 的效果等价）。
+ */
+async function runThroughExtension(events: SseEvent[]): Promise<{
+  beforeExtension: unknown
+  afterExtension: unknown
+}> {
+  const extension = createPiEagerToolArgsRestorer()
+  const onUpdate = extension.handlers.get('message_update')?.[0]
+  const onEnd = extension.handlers.get('message_end')?.[0]
+  if (!onUpdate || !onEnd) throw new Error('扩展未注册 message_update / message_end 处理器')
+
+  const stream = streamAnthropic(MODEL, {
+    messages: [{ role: 'user', content: '提交大纲' }],
+    tools: [{ name: TOOL_NAME, description: '提交全书大纲', parameters: { type: 'object', properties: {} } }],
+    // biome-ignore lint/suspicious/noExplicitAny: 测试替身，只需满足 streamAnthropic 的运行时形状
+  } as any, { client: fakeClient(events) as any, apiKey: 'test' })
+
+  let finalMessage: unknown
+  for await (const streamEvent of stream) {
+    if (streamEvent.type === 'done' || streamEvent.type === 'error') {
+      finalMessage = streamEvent.partial ?? streamEvent.message
+      continue
+    }
+    // agent-loop 对每个流事件都发一次 message_update，message 是当轮 partial 的浅拷贝。
+    const partial = (streamEvent as { partial?: unknown }).partial
+    if (partial) {
+      await onUpdate({ message: { ...(partial as object) }, assistantMessageEvent: streamEvent })
+    }
+  }
+
+  const beforeExtension = structuredClone(finalMessage)
+  const result = (await onEnd({ message: finalMessage })) as { message?: unknown } | undefined
+  return { beforeExtension, afterExtension: result?.message ?? finalMessage }
+}
+
+function toolCallArgs(message: unknown): unknown {
+  const content = (message as { content?: unknown[] })?.content ?? []
+  const block = content.find((entry) => (entry as { type?: string })?.type === 'toolCall')
+  return (block as { arguments?: unknown })?.arguments
+}
+
+describe('createPiEagerToolArgsRestorer', () => {
+  test('eager input 且无 delta：上游抹成空对象，扩展救回完整参数', async () => {
+    const { beforeExtension, afterExtension } = await runThroughExtension(EAGER_NO_DELTA)
+    // 先钉住上游确实有这个 bug——这条断言失败就说明上游修了，本扩展该按拆除说明书摘除。
+    expect(toolCallArgs(beforeExtension)).toEqual({})
+    expect(toolCallArgs(afterExtension)).toEqual(FULL_ARGS)
+  })
+
+  test('标准增量 delta：上游本就正确，扩展不改动', async () => {
+    const { beforeExtension, afterExtension } = await runThroughExtension(STANDARD_DELTA)
+    expect(toolCallArgs(beforeExtension)).toEqual(FULL_ARGS)
+    expect(toolCallArgs(afterExtension)).toEqual(FULL_ARGS)
+  })
+
+  test('delta 中途截断：非本扩展职责，不介入、不误救', async () => {
+    const { beforeExtension, afterExtension } = await runThroughExtension(TRUNCATED_DELTA)
+    // 上游对截断的 JSON 做部分解析，交出缺 payload 的半个对象；它非空，扩展不该碰。
+    expect(toolCallArgs(beforeExtension)).toEqual({ phase: 1, scope: 'full' })
+    expect(toolCallArgs(afterExtension)).toEqual({ phase: 1, scope: 'full' })
+  })
+
+  test('快照不跨消息残留：上一条消息的 eager 参数不会污染下一条', async () => {
+    const extension = createPiEagerToolArgsRestorer()
+    const onUpdate = extension.handlers.get('message_update')?.[0]
+    const onEnd = extension.handlers.get('message_end')?.[0]
+    if (!onUpdate || !onEnd) throw new Error('扩展未注册处理器')
+
+    await onUpdate({
+      message: {},
+      assistantMessageEvent: {
+        type: 'toolcall_start',
+        contentIndex: 0,
+        partial: { content: [{ type: 'toolCall', id: 'toolu_1', name: TOOL_NAME, arguments: FULL_ARGS }] },
+      },
+    })
+    await onEnd({
+      message: { role: 'assistant', content: [{ type: 'toolCall', id: 'toolu_1', name: TOOL_NAME, arguments: {} }] },
+    })
+
+    // 第二条消息没有任何 toolcall_start，空参数就该保持空——不能拿上一条的快照顶上。
+    const second = (await onEnd({
+      message: { role: 'assistant', content: [{ type: 'toolCall', id: 'toolu_2', name: TOOL_NAME, arguments: {} }] },
+    })) as { message?: unknown } | undefined
+    expect(second).toBeUndefined()
+  })
+
+  test('toolCallId 对不上时不张冠李戴', async () => {
+    const extension = createPiEagerToolArgsRestorer()
+    const onUpdate = extension.handlers.get('message_update')?.[0]
+    const onEnd = extension.handlers.get('message_end')?.[0]
+    if (!onUpdate || !onEnd) throw new Error('扩展未注册处理器')
+
+    await onUpdate({
+      message: {},
+      assistantMessageEvent: {
+        type: 'toolcall_start',
+        contentIndex: 0,
+        partial: { content: [{ type: 'toolCall', id: 'toolu_1', name: TOOL_NAME, arguments: FULL_ARGS }] },
+      },
+    })
+    const result = (await onEnd({
+      message: { role: 'assistant', content: [{ type: 'toolCall', id: 'toolu_OTHER', name: TOOL_NAME, arguments: {} }] },
+    })) as { message?: unknown } | undefined
+    expect(result).toBeUndefined()
+  })
+})

--- a/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.test.ts
@@ -69,6 +69,20 @@ const STANDARD_DELTA = messageEnvelope([
   { type: 'content_block_stop', index: 0 },
 ])
 
+/**
+ * eager input 之后跟一条把参数撤空的增量。最终的 `{}` 是模型自己算出来的真实意图，
+ * 不是传输丢失——恢复旧值等于执行一个模型已经放弃的调用。
+ */
+const EAGER_THEN_EMPTY_DELTA = messageEnvelope([
+  {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'tool_use', id: 'toolu_1', name: TOOL_NAME, input: FULL_ARGS },
+  },
+  { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{}' } },
+  { type: 'content_block_stop', index: 0 },
+])
+
 /** 增量在 payload 的值开始之前断掉（max_tokens / 断流）。 */
 const TRUNCATED_DELTA = messageEnvelope([
   {
@@ -163,6 +177,14 @@ describe('createPiEagerToolArgsRestorer', () => {
     const { beforeExtension, afterExtension } = await runThroughExtension(STANDARD_DELTA)
     expect(toolCallArgs(beforeExtension)).toEqual(FULL_ARGS)
     expect(toolCallArgs(afterExtension)).toEqual(FULL_ARGS)
+  })
+
+  test('eager 之后来了把参数撤空的增量：那是模型的真实意图，不许恢复', async () => {
+    const { beforeExtension, afterExtension } = await runThroughExtension(EAGER_THEN_EMPTY_DELTA)
+    // 最终参数同样是 {}，但这次是模型自己撤销的，与「无 delta 被抹空」必须区别对待——
+    // 判据是「有没有来过 toolcall_delta」，不是「最终是不是空」。
+    expect(toolCallArgs(beforeExtension)).toEqual({})
+    expect(toolCallArgs(afterExtension)).toEqual({})
   })
 
   test('delta 中途截断：非本扩展职责，不介入、不误救', async () => {

--- a/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.ts
@@ -1,0 +1,159 @@
+/**
+ * eager 工具参数救回扩展（issue #16）：Anthropic 兼容端点把完整工具参数直接放在
+ * `content_block_start.input`、之后不发任何 `input_json_delta` 时，pi 会在流收尾处把已经收到的
+ * 参数覆盖成 `{}`，工具因此收到空参数并撞 schema 校验。本扩展在 pi 官方扩展点上把它救回来。
+ *
+ * ## 上游根因（@mariozechner/pi-ai@0.73.1）
+ *
+ * - `dist/providers/anthropic.js` L383：`arguments: event.content_block.input ?? {}`
+ *   —— eager input 是正确收下的。
+ * - `dist/providers/anthropic.js` L463：`content_block_stop` 分支**无条件**执行
+ *   `block.arguments = parseStreamingJson(block.partialJson)`。
+ * - `dist/utils/json-parse.js` L91：`parseStreamingJson("")` 直接 `return {}`。
+ *
+ * 没有 delta 时 `partialJson` 恒为空串，于是收尾这一步把完整参数抹成空对象。官方 Anthropic
+ * 端点走增量 delta，不受影响；受影响的是自建/第三方兼容端点。这不是边角场景——
+ * `pi-model.ts` 把 `api` 恒定写成 `'anthropic-messages'`，本 App 的所有 provider 都走这段解析。
+ *
+ * ## 为什么落在这里
+ *
+ * 试过且不可行的更早落点：
+ * - **注入自定义 streamFn**：`pi-coding-agent` 的 `sdk.js` 内部硬编码构造 streamFn，
+ *   `createAgentSession` 的 options 不透传，注入不进去。
+ * - **`ToolDefinition.prepareArguments`**（上游自称 "compatibility shim"）：它在校验前跑，
+ *   但签名只收 `args`、拿不到 toolCallId，也拿不到被覆盖前的 eager 值，救不了本场景。
+ * - **`tool_call` 扩展事件**：`pi-agent-core/dist/agent-loop.js` L340-341 是
+ *   `prepareToolCallArguments` → `validateToolArguments` → 之后才 `beforeToolCall`。
+ *   参数为空时校验已经先抛错，钩子根本不会被调用。
+ *
+ * 可行的是这一对官方扩展事件，时序由上游保证：
+ * - `message_update` 携带 pi-ai 原始流事件（`assistantMessageEvent`），`toolcall_start` 那一拍
+ *   读得到尚未被覆盖的 eager 参数。
+ * - `message_end` 在 `agent-loop.js` L96 emit、L111 才提取 toolCalls、L115 才执行工具，
+ *   且 `agent-session.js` 的 `_emitExtensionEvent` 是在通知普通监听者**之前** await 扩展的。
+ *   返回 `{ message }` 由上游 `_replaceMessageInPlace` 原地写回（官方替换通道，会同步到
+ *   agent 状态、后续事件与会话持久化），比自行 mutate 事件对象规范。
+ *
+ * ## 拆除说明书
+ *
+ * 这是给上游 bug 打的桥，不是本仓要长期持有的能力。
+ * - 钉死版本：`@mariozechner/pi-ai@0.73.1`（`package.json` 精确版本，非 range）。
+ * - 上游修复后如何确认：读 `dist/providers/anthropic.js` 的 `content_block_stop` 分支，
+ *   若覆盖前已判空（形如 `if (block.partialJson) block.arguments = ...`），本扩展即可摘除。
+ * - 怎么复测：`pi-eager-toolcall-args.test.ts` 覆盖三种事件序列（eager 无 delta / 标准增量 /
+ *   截断）。摘除时整份删掉即可，不与其他模块耦合；装配处见 `index.ts` 的 extensions 数组。
+ * - 注意本扩展**不**处理截断场景（见测试第三例）：截断时 pi 会静默交出半个对象，那是另一条
+ *   路径（缺字段而非全空），救它需要的是「参数不完整」信号，上游目前没有，不在本扩展范围内。
+ */
+import { createSyntheticSourceInfo } from '@mariozechner/pi-coding-agent'
+import type { Extension } from '@mariozechner/pi-coding-agent'
+
+type UnknownRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** 空参数判定：非对象（含 null/undefined）或零键对象都算——两者模型都无法用于真实调用。 */
+function isEmptyArguments(value: unknown): boolean {
+  if (!isRecord(value)) return true
+  return Object.keys(value).length === 0
+}
+
+/**
+ * pi 包根 barrel 没导出 `MessageUpdateEvent` / `MessageEndEvent` / `MessageEndEventResult`
+ * （只在内部 `core/extensions/types.d.ts`），照 `agent-session.js` `_emitExtensionEvent` 实际
+ * 推送的形状在此本地声明等价结构（同 pi-engine-hooks.ts 的先例）。
+ */
+type PiMessageUpdateEvent = {
+  message: unknown
+  assistantMessageEvent: unknown
+}
+type PiMessageEndEvent = {
+  message: unknown
+}
+type PiMessageEndEventResult = {
+  message: unknown
+}
+
+/**
+ * 单条 assistant 消息内的 eager 参数快照。键用 `contentIndex` 而非 toolCallId：部分 provider
+ * 压根不回 tool call id（`pi-session.ts` 的 toolCallId 空串兜底就是为此而存在），用 id 做键
+ * 会在那些 provider 上直接失效。索引在 `message_update.partial.content` 与
+ * `message_end.message.content` 之间是同一个数组，天然对齐。
+ */
+type EagerSnapshot = { args: UnknownRecord; toolCallId: string | undefined }
+
+export function createPiEagerToolArgsRestorer(): Extension {
+  /** run 级、按 assistant 消息滚动清空：每条 message_end 收尾即清，不跨消息累积。 */
+  let snapshots = new Map<number, EagerSnapshot>()
+
+  function onMessageUpdate(event: PiMessageUpdateEvent): void {
+    const streamEvent = event.assistantMessageEvent
+    if (!isRecord(streamEvent) || streamEvent.type !== 'toolcall_start') return
+    const contentIndex = streamEvent.contentIndex
+    if (typeof contentIndex !== 'number') return
+
+    // eager 参数只在 toolcall_start 这一拍可见；partial 与 message 指向同一 content 数组，
+    // 优先读 partial（pi-ai 直接推送的那份），缺失时回落 message。
+    const partial = isRecord(streamEvent.partial) ? streamEvent.partial : event.message
+    if (!isRecord(partial) || !Array.isArray(partial.content)) return
+    const block = partial.content[contentIndex]
+    if (!isRecord(block) || block.type !== 'toolCall') return
+    if (isEmptyArguments(block.arguments)) return
+
+    snapshots.set(contentIndex, {
+      // 存引用即可：上游收尾是把 block.arguments 整体**换成**新对象，不是就地改写这一份。
+      args: block.arguments as UnknownRecord,
+      toolCallId: typeof block.id === 'string' && block.id ? block.id : undefined,
+    })
+  }
+
+  function onMessageEnd(event: PiMessageEndEvent): PiMessageEndEventResult | undefined {
+    const captured = snapshots
+    // 无论本条消息救没救到，收尾都要清空——快照只对产生它的那条 assistant 消息有效。
+    snapshots = new Map()
+
+    if (captured.size === 0) return undefined
+    const message = event.message
+    if (!isRecord(message) || message.role !== 'assistant' || !Array.isArray(message.content)) return undefined
+
+    let restored = false
+    const content = message.content.map((block, index) => {
+      if (!isRecord(block) || block.type !== 'toolCall') return block
+      if (!isEmptyArguments(block.arguments)) return block
+      const snapshot = captured.get(index)
+      if (!snapshot) return block
+      // id 两端都在却对不上 = 索引语义与预期不符（上游改了 content 组装顺序之类），
+      // 宁可让原本的空参数报错，也不能张冠李戴把参数塞给另一个工具调用。
+      const blockId = typeof block.id === 'string' && block.id ? block.id : undefined
+      if (snapshot.toolCallId && blockId && snapshot.toolCallId !== blockId) return block
+      restored = true
+      return { ...block, arguments: snapshot.args }
+    })
+
+    if (!restored) return undefined
+    return { message: { ...message, content } }
+  }
+
+  const extensionPath = '<narracat:pi-eager-toolcall-args>'
+  const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>()
+  handlers.set('message_update', [
+    async (event) => {
+      onMessageUpdate(event as PiMessageUpdateEvent)
+      return undefined
+    },
+  ])
+  handlers.set('message_end', [async (event) => onMessageEnd(event as PiMessageEndEvent)])
+  return {
+    path: extensionPath,
+    resolvedPath: extensionPath,
+    sourceInfo: createSyntheticSourceInfo(extensionPath, { source: 'narracat' }),
+    handlers,
+    tools: new Map(),
+    messageRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  }
+}

--- a/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-eager-toolcall-args.ts
@@ -42,8 +42,16 @@
  *   若覆盖前已判空（形如 `if (block.partialJson) block.arguments = ...`），本扩展即可摘除。
  * - 怎么复测：`pi-eager-toolcall-args.test.ts` 覆盖三种事件序列（eager 无 delta / 标准增量 /
  *   截断）。摘除时整份删掉即可，不与其他模块耦合；装配处见 `index.ts` 的 extensions 数组。
- * - 注意本扩展**不**处理截断场景（见测试第三例）：截断时 pi 会静默交出半个对象，那是另一条
- *   路径（缺字段而非全空），救它需要的是「参数不完整」信号，上游目前没有，不在本扩展范围内。
+ * ## 恢复边界（两个条件同时成立才动手）
+ *
+ * 1. 该工具调用**从未收到过** `input_json_delta`（即没有 `toolcall_delta` 事件）；
+ * 2. 最终参数为空。
+ *
+ * 只看条件 2 是不够的：服务端先给 eager input、再发一条把参数撤空的增量时，最终的空对象是模型
+ * 自己算出来的真实意图，恢复旧值等于执行一个模型已经放弃的调用。条件 1 把这种情况挡在外面。
+ *
+ * 同理，本扩展**不**处理截断场景（见测试第三例）：截断必然来过增量，条件 1 直接不成立。截断时
+ * pi 会静默交出半个对象（缺字段而非全空），救它需要的是「参数不完整」信号，上游目前没有。
  */
 import { createSyntheticSourceInfo } from '@mariozechner/pi-coding-agent'
 import type { Extension } from '@mariozechner/pi-coding-agent'
@@ -87,10 +95,24 @@ type EagerSnapshot = { args: UnknownRecord; toolCallId: string | undefined }
 export function createPiEagerToolArgsRestorer(): Extension {
   /** run 级、按 assistant 消息滚动清空：每条 message_end 收尾即清，不跨消息累积。 */
   let snapshots = new Map<number, EagerSnapshot>()
+  /**
+   * 出现过增量的 contentIndex。恢复的前提是「服务端**没有**发过 input_json_delta」——只要来过
+   * 一条增量，最终参数就是模型自己算出来的结果，哪怕它是空对象也得原样交出去（模型可能在增量里
+   * 把参数撤空，那是真实意图，不是传输丢失）。只看「最终为空」不看「有没有来过增量」，会把这种
+   * 撤销当成丢失、把模型已经放弃的参数硬塞回去执行。
+   */
+  let sawDelta = new Set<number>()
 
   function onMessageUpdate(event: PiMessageUpdateEvent): void {
     const streamEvent = event.assistantMessageEvent
-    if (!isRecord(streamEvent) || streamEvent.type !== 'toolcall_start') return
+    if (!isRecord(streamEvent)) return
+
+    if (streamEvent.type === 'toolcall_delta') {
+      if (typeof streamEvent.contentIndex === 'number') sawDelta.add(streamEvent.contentIndex)
+      return
+    }
+
+    if (streamEvent.type !== 'toolcall_start') return
     const contentIndex = streamEvent.contentIndex
     if (typeof contentIndex !== 'number') return
 
@@ -111,8 +133,10 @@ export function createPiEagerToolArgsRestorer(): Extension {
 
   function onMessageEnd(event: PiMessageEndEvent): PiMessageEndEventResult | undefined {
     const captured = snapshots
+    const deltaSeen = sawDelta
     // 无论本条消息救没救到，收尾都要清空——快照只对产生它的那条 assistant 消息有效。
     snapshots = new Map()
+    sawDelta = new Set()
 
     if (captured.size === 0) return undefined
     const message = event.message
@@ -122,6 +146,8 @@ export function createPiEagerToolArgsRestorer(): Extension {
     const content = message.content.map((block, index) => {
       if (!isRecord(block) || block.type !== 'toolCall') return block
       if (!isEmptyArguments(block.arguments)) return block
+      // 来过增量 = 最终参数是模型自己算出来的，空也是它的意思，不许覆盖。
+      if (deltaSeen.has(index)) return block
       const snapshot = captured.get(index)
       if (!snapshot) return block
       // id 两端都在却对不上 = 索引语义与预期不符（上游改了 content 组装顺序之类），


### PR DESCRIPTION
Closes #16

## 第一关：该不该做

**解决什么问题，不改会怎样，影响哪些用户**

Anthropic 兼容端点把完整工具参数直接放在 `content_block_start.input`、之后不发 `input_json_delta` 时，工具会收到 `{}`。表现是模型看似成功发起了工具调用，工具却报「缺少必填字段」，错误回灌给模型重试——而模型改不掉传输层的问题，于是无限重试。

影响面比 issue 报告的更大：`pi-model.ts:43` 把 `api` 恒定写成 `'anthropic-messages'`，baseUrl 走用户配置，所以**本 App 的所有 provider 都走这段解析**，不只显式选了 Anthropic 的用户。我们自己没撞上，只是因为常用的那个端点规规矩矩发 delta。这是主力传输路径上的静默数据丢失。

**给主干留下什么长期成本**

给上游 bug 挂的本地补丁，是永久维护义务：pi 将来修了，这段会变成没人敢删的僵尸代码。按 CONTRIBUTING「引入长期约束时主动写解除条件」，实现文件顶部写了完整的拆除说明书——钉死 `pi-ai@0.73.1`、上游修复后如何确认（读 `content_block_stop` 分支是否已判空）、怎么整份摘除（不与其他模块耦合，删文件 + 摘装配即可）。

第一条测试断言（`expect(toolCallArgs(beforeExtension)).toEqual({})`）本身就是解除信号：它哪天失败，就说明上游修了。

**有没有更小的解法，为什么没选**

试过三个更早、更小的落点，逐个验证不可行（理由记在实现文件顶部注释）：

| 落点 | 为什么不行 |
|---|---|
| 注入自定义 `streamFn` | `pi-coding-agent/dist/core/sdk.js:198` 内部硬编码构造，`createAgentSession` 的 options 不透传 |
| `ToolDefinition.prepareArguments`（上游自称 "compatibility shim"） | 在校验前跑，但签名只收 `args`、拿不到 toolCallId，更拿不到被覆盖前的 eager 值 |
| `tool_call` 扩展事件 | `pi-agent-core/dist/agent-loop.js` L340-341 是 `prepareToolCallArguments` → `validateToolArguments` → 之后才 `beforeToolCall`；参数为空时校验已经先抛错，钩子根本不会被调用 |

也考虑过直接 patch `node_modules`，否决：本仓纪律是 pi 双包 import 唯一收口在 `adapters/pi/`（ADR-0036/0037），patch 依赖会绕过这条线且更难追踪。

## 第二关：实现对不对

**根因证据（上游源码位置）**

- `@mariozechner/pi-ai@0.73.1` `dist/providers/anthropic.js` L383：`arguments: event.content_block.input ?? {}` —— eager input 是正确收下的
- 同文件 L463：`content_block_stop` 分支**无条件**执行 `block.arguments = parseStreamingJson(block.partialJson)`
- `dist/utils/json-parse.js` L91：`parseStreamingJson("")` 直接 `return {}`

没有 delta 时 `partialJson` 恒为空串，收尾这一步把完整参数抹成空对象。

**复现**（不是「在我机器上好了」）

给 `streamAnthropic` 注入假 client 喂构造 SSE，三种序列对照：

| 序列 | `toolcall_start` | `toolcall_end` |
|---|---|---|
| eager input，无 delta | 完整参数 | `{}` ❌ |
| 标准增量 delta | `{}` | 完整参数 ✅ |
| delta 中途截断 | `{}` | 部分对象 ⚠️ |

**修法**

落在一对官方扩展事件上，时序由上游保证：

- `message_update` 携带 pi-ai 原始流事件（`assistantMessageEvent`），`toolcall_start` 那一拍读得到尚未被覆盖的 eager 参数
- `message_end` 在 `agent-loop.js` L96 emit、L111 才提取 toolCalls、L115 才执行工具；且 `agent-session.js` 的 `_emitExtensionEvent` 在通知普通监听者**之前** await 扩展。返回 `{ message }` 由上游 `_replaceMessageInPlace` 原地写回（官方替换通道，会同步到 agent 状态、后续事件与会话持久化）

快照键用 `contentIndex` 而非 toolCallId：部分 provider 压根不回 tool call id（`pi-session.ts:162` 的空串兜底就是为此存在），用 id 做键会在那些 provider 上直接失效。两端 id 都在却对不上时**不恢复**——宁可让原本的空参数报错，也不能张冠李戴塞给另一个工具调用。

**测试**

事件序列**不手写**，而是驱动真实 `streamAnthropic` 拿到上游真正推送的事件，再照 `agent-session.js` 的桥接形状包给扩展。手写事件只能验证「代码符合我对事件形状的假设」，假设错了照样绿——本仓吃过这种假绿的亏。

五条测试：eager 无 delta 必须救回、标准增量必须零改动（防回归）、截断场景明确不介入、快照不跨消息残留、toolCallId 对不上不误救。

另在 `index.test.ts` 加了接线锁：这个扩展**不受 `loadNarraCatRuntime` 门控**（传输层问题与引擎契约无关，沙盒会话与 direct-chat 一样会中招），测试防止将来有人顺手把它并进门控里。

**不破坏契约分层**：改动全在 `electron/main/agent/runtime/adapters/pi/`，pi import 的既有收口区内，无跨层泄漏。

## Review 跟进（commit 306fd4d）

**P1 出现合法增量时仍可能恢复旧参数 —— 已确认属实并修复。**

复现（实跑确认）：

```
content_block_start.input = {path:"a.md", content:"x"}
input_json_delta = "{}"
→ 上游最终参数 {}，扩展却恢复成了 eager 值
```

这种情况下的空对象是模型自己在增量里算出来的真实意图（把参数撤空），恢复旧值等于执行一个模型已经放弃的调用。原实现只看「最终参数为空」，漏了「有没有来过增量」这一半判据，确实违背 #16「无 delta 才恢复」的边界。

修法：按 `contentIndex` 记录是否出现过 `toolcall_delta`（pi-ai `anthropic.js` L423 在 `input_json_delta` 分支推送），恢复要求**两个条件同时成立**——从未收到过增量 **且** 最终参数为空。

副产品：「截断不介入」这条从「靠最终值非空兜住」变成「靠条件 1 直接排除」，语义更硬——截断必然来过增量。

已补第六条测试锁住 eager + 空增量序列，同样用真实 `streamAnthropic` 驱动。复验：6 pass / 0 fail，App 侧全量 2990 pass / 0 fail。

**P2 未补 `progress.md` 阶段记录 —— 接受要求，但请求放在三条 PR 合并之后统一补一条。**

理由是技术性的：三条 PR 若各自追加 `progress.md`，会在同一文件的同一区域制造第三个冲突点，把现在只有版本号一行的冲突扩大成两处。合并后补一条覆盖三者的记录，既满足流程也不制造新冲突。如果你更希望在本 PR 内就补，我照做，只是届时另外两条也要各补一段并接受额外的 rebase。

## 第三关：担不担得起

不碰打包/签名/更新、不碰用户小说数据读写、不碰 API key 与写权限隔离、不碰 Agent Core 契约。

回滚成本：删一个文件 + 摘两处装配行。

## 验证

| 命令 | 结果 |
|---|---|
| `bun --no-cache run typecheck` | 通过 |
| `bun --no-cache run test` | 2989 pass / 0 fail / 297 files |

未跑 `check:design`（没动 UI）、未跑 `build`（没加依赖、没改构建配置，typecheck 已覆盖类型面）。

## 未验证的部分（诚实交代）

**没有真机验证。** 手上没有会发 eager input 的端点，常用的 deepseek 规规矩矩发 delta。构造 SSE 能证明逻辑正确，不能证明真实端点的事件序列就长那样。已在 #16 请报告人 @Akimixu-19897 用他的现场验证。

## 归属

根因定位、复现条件、修复方向由 @Akimixu-19897 在 #16 提供，并已在其 fork 中实现过一版（commit a60ee9b）。本 PR 因该问题命中主力传输路径、需要连带补回归测试与拆除说明书而由维护者接手实现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
