### PR TITLE
fix(world): /world 派发前枚举既有设定集（Closes #14）

### DIFF
--- a/agent-core/narracat-agent-core.lock.json
+++ b/agent-core/narracat-agent-core.lock.json
@@ -1,7 +1,7 @@
 {
   "path": "agent-core/narracat-agent-core.lock.json",
   "name": "narracat",
-  "version": "4.0.170",
+  "version": "4.0.171",
   "manifestPath": "narracat.manifest.json",
   "upstream": {
     "repo": "the-lumos-labs/NarraCat",

--- a/agent-core/narracat/CLAUDE.md
+++ b/agent-core/narracat/CLAUDE.md
@@ -157,7 +157,7 @@ CI workflow 住在**仓库根** `.github/workflows/`（不在本目录的 `.gith
 
 三位版本号 `x.y.z`：x = 架构方向 / 重大转型；y = 功能阶段迭代；z = 每次非 trivial 提交递增。x / y 仅在用户明确要求时增加。
 
-当前基准：**4.0.170**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
+当前基准：**4.0.171**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
 
 **bump 流程**（每次非 trivial 提交）：(1) CHANGELOG.md 顶部加新版本段；(2) 更新本节「当前基准」；(3) 同步 narracat.manifest.json 与 mcp-server/package.json 的 version 字段；(4) 同步 App 层版本闸门 `agent-core/narracat-agent-core.lock.json` 的 `version`——漏改会导致 App 启动报「Agent Core version 应为 X，实际为 Y」、且 `bun --no-cache run verify:narracat-agent-core` 失败。版本历史归 CHANGELOG.md，不在本文件累积。
 

--- a/agent-core/narracat/agents/world-curator.md
+++ b/agent-core/narracat/agents/world-curator.md
@@ -12,7 +12,7 @@ tools: Read, Grep, Glob, mcp__plugin_narracat_novelmemory__novel_query, mcp__plu
 
 ## 工作方式（操作 = create / update）
 
-1. Read 任务列出的既有设定文件和参考指导文件。参考指导只作方向建议，专名不照搬；其中「不应继承」节列出的内容不得迁移进本项目。
+1. Read 任务列出的文件（立项卡 / 既有设定 / 参考指导）。立项卡是本书的地基，新设定与它冲突按冲突处理，不自行改写地基。参考指导只作方向建议，专名不照搬；其中「不应继承」节列出的内容不得迁移进本项目。
 2. 已开始写作的项目：用 novel_query / novel_character_state（角色类按 character_uid，取自角色档案 character_identity）查与本次对象相关的既有事实，作为冲突比对基准。
 3. 为每个对象合成完整 bible 内容，按下方结构组织，并标注目标文件路径：角色 → `bible/characters/<name>.md`；世界设定 → `bible/world/<topic>.md`；关系 → `bible/relationships.md` 追加段。
 4. 合成后对照 `${CLAUDE_PLUGIN_ROOT}/docs/contracts/world-guided.md` §一 的维度清单查缺：任务意图没有覆盖的维度，在对应位置写「（留白）」。

--- a/agent-core/narracat/commands/world.md
+++ b/agent-core/narracat/commands/world.md
@@ -37,6 +37,8 @@ allowed-tools: [Agent, Read, Write, Edit, Glob, Grep, AskUserQuestion, mcp__plug
 
 ## 步骤 3: 派发 world-curator（合成）
 
+先 Glob `bible/world/*.md` 与 `bible/characters/*.md` 取实际路径，`bible/relationships.md` 存在则一并计入，全部逐条列进下面的「既有设定文件」——策展人只读这份清单，漏列的设定就不在冲突检测的比对范围内。create 与 update 都要枚举：新对象同样会撞上既有关系与世界规则。
+
 一次 Task 调用覆盖本次全部对象，world-curator 只做内容合成与冲突检测，不落盘、不调用提交工具：
 
 ```
@@ -45,7 +47,7 @@ Task(world-curator): "操作: {create | update}
 - {对象 1: 意图}
 - {…}
 用户对话中确认的要点: {步骤 2 采集结果，无则省略}
-既有设定文件: {相关 bible/ 文件路径列表}
+既有设定文件: {上一步枚举得到的全部路径，逐条列出}
 状态词表: {bible/state-vocabulary.json 存在则传路径，否则省略}
 参考指导文件: {bible/reference-guidance/ 下存在的 premise.md / world.md / characters.md 路径，无则省略}
 返回: 每个对象的完整 bible 内容（标注目标文件路径）+ conflicts[] + 状态词表草案（对象中含角色时）+ 每个核心角色的结构化字段草案（name/aliases/gender/age/initial_states，对象中含角色时）"

--- a/agent-core/narracat/commands/world.md
+++ b/agent-core/narracat/commands/world.md
@@ -37,7 +37,7 @@ allowed-tools: [Agent, Read, Write, Edit, Glob, Grep, AskUserQuestion, mcp__plug
 
 ## 步骤 3: 派发 world-curator（合成）
 
-先 Glob `bible/world/*.md` 与 `bible/characters/*.md` 取实际路径，`bible/relationships.md` 存在则一并计入，全部逐条列进下面的「既有设定文件」——策展人只读这份清单，漏列的设定就不在冲突检测的比对范围内。create 与 update 都要枚举：新对象同样会撞上既有关系与世界规则。
+先 Glob `bible/world/*.md` 与 `bible/characters/*.md` 取实际路径，`bible/relationships.md` 存在则一并计入，全部逐条列进下面的「既有设定文件」——策展人只读派发指令列出的路径（子会话不共享本会话上下文），漏列的设定就不在冲突检测的比对范围内。create 与 update 都要枚举：新对象同样会撞上既有关系与世界规则。立项卡另有专门一行，不并入这份清单。
 
 一次 Task 调用覆盖本次全部对象，world-curator 只做内容合成与冲突检测，不落盘、不调用提交工具：
 
@@ -47,6 +47,7 @@ Task(world-curator): "操作: {create | update}
 - {对象 1: 意图}
 - {…}
 用户对话中确认的要点: {步骤 2 采集结果，无则省略}
+立项卡: bible/premise.md
 既有设定文件: {上一步枚举得到的全部路径，逐条列出}
 状态词表: {bible/state-vocabulary.json 存在则传路径，否则省略}
 参考指导文件: {bible/reference-guidance/ 下存在的 premise.md / world.md / characters.md 路径，无则省略}

--- a/agent-core/narracat/mcp-server/package.json
+++ b/agent-core/narracat/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narracat/mcp-server",
-  "version": "4.0.170",
+  "version": "4.0.171",
   "description": "NovelMemory MCP Server - adapter between NarraCat Agent runtime and OpenMemory",
   "type": "module",
   "main": "dist/index.js",

--- a/agent-core/narracat/narracat.manifest.json
+++ b/agent-core/narracat/narracat.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "narracat",
-  "version": "4.0.170",
+  "version": "4.0.171",
   "description": "NarraCat Agent Core — AI 辅助超长篇小说创作引擎（自有契约清单，App 层发现与校验的 SSOT）",
   "commands": ["init", "learn-craft", "plan", "reference", "review", "revise-premise", "rewrite", "setup", "status", "sync-chapter-memory", "world", "write", "writer-wizard"],
   "agents": ["outline-architect", "chapter-writer", "continuity-editor", "world-curator", "memory-keeper"],


### PR DESCRIPTION
Closes #14

## 第一关：该不该做

**解决什么问题，不改会怎样，影响哪些用户**

用「世界观与角色」修改已有角色或设定时，world-curator 返回与既有关系、世界规则矛盾的全新内容，冲突检测形同虚设。作者写到中后期、bible 攒了一批设定之后才最容易踩到——那时冲突的代价也最大。

**根因不在 agent 侧，和 issue 描述的不一样。** `agents/world-curator.md` 工作方式**第 1 条**本就是「Read 任务列出的既有设定文件」，`commands/world.md` 步骤 3 的 Envelope 也本就有「既有设定文件」槽位。缺口在「**任务列出的**」这个限定上：

- 槽位原文写「相关 bible/ 文件路径列表」——什么算「相关」全由主会话自由裁量
- 而命令全文**没有任何一步要求枚举 `bible/`**（步骤 1 的 update 分支只说「定位对应文件」，create 分支连提都没提）
- frontmatter 早已声明 `Glob` 权限，正文**零处使用**

槽位填空或只填目标文件时，策展人照契约只读到零星几个，比对基准随之塌掉。

**给主干留下什么长期成本**

几乎为零：补的是一步 Glob 枚举，范式直接照抄 `commands/plan.md`（同仓已有五处同款写法），没有新增机制、新组件或新守卫。

**有没有更小的解法，为什么没选**

有一个更小的：只在 update 分支补枚举。没选——create 同样会撞上既有关系与世界规则（新角色与既有角色的关系、新设定与既有世界规则），少枚举一半等于留一半的洞。

也**刻意没做**报告人 fork 里的另一半（在 world-curator prompt 里再强调一遍「必须读既有上下文」）：那条指令在工作方式第 1 条已经存在，再加一遍属重复加固，只会让后来者分不清哪句在起作用。按本仓「删一条规则永远优于加一条豁免」的 prompt 纪律，洞在派发侧就只补派发侧。

## 第二关：实现对不对

**根因证据**

```
world.md   frontmatter 声明 Glob 权限 → 正文 0 处使用
plan.md    5 处明确的 Glob 枚举步骤（L31 / L54 / L77 / L107 / L130）
```

同仓已有正确范式，`/world` 是漏了。`plan.md:54` 的标准写法是「先 Glob 取实际路径备用」+ 派发模板里「{上一步 Glob 得到的全部路径，**逐条列出**}」，本 PR 逐字对齐。

**改动**

- `commands/world.md` 步骤 3 开头补一句枚举指令：`bible/world/*.md` + `bible/characters/*.md` + `bible/relationships.md` 全部列进 Envelope，create 与 update 同等对待
- 同步把槽位从「{相关 bible/ 文件路径列表}」改成「{上一步枚举得到的全部路径，逐条列出}」，消掉「相关」这个裁量口子

**符合引擎侧纪律**

- Envelope 模式：只传路径 + 参数，不复述 agent 内部规则 ✅
- 运行时 prompt 出处中立：正文不带 issue 号 / ADR 引用 ✅（`lint:provenance` 通过）
- 不改 `agents/world-curator.md`，创作质量层零改动，不触发「改 prompt 需 A/B 证据」那条红线

**没有测试**：改动是 command 的自然语言编排指令，本仓对这一层没有自动化测试面（机械校验由 lint 承担）。验收靠真机 dogfood，见下。

## 第三关：担不担得起

碰到「Agent Core 契约」区域，按规矩升级审查：

- bump `4.0.170` → `4.0.171`，四处同步（`narracat.manifest.json` / `mcp-server/package.json` / `agent-core/narracat-agent-core.lock.json` / `CLAUDE.md` 当前基准）
- schema、manifest 清单、工具签名**零改动**；不涉及用户小说数据的写入路径

回滚成本：单文件两行改动 + 版本号回退。

## 验证

| 命令 | 结果 |
|---|---|
| `bun --no-cache run test` | 2982 pass / 0 fail / 296 files |
| `bun --no-cache run verify:narracat-agent-core` | 版本一致 4.0.171 |
| `lint:provenance` / `lint:manifest-sync` / `lint:plugin-paths` | 全过 |

## Review 跟进（commit dd29e69）

**P1 漏 `bible/premise.md` —— 已确认属实并修复。**

核实过程：`commands/plan.md:76` 明确传 `立项卡: bible/premise.md` 给 outline-architect，而 `world.md` 的 Envelope 从头到尾没有这一行；Task 工具 schema 写明「子会话不共享主会话上下文，须自足」（`pi-subagent.ts:118-121`），所以步骤 0 主会话读 premise 确实补救不了。

修法：照 plan.md 的写法加一行 `立项卡: bible/premise.md`，作为**独立槽位**而非并入「既有设定文件」——立项卡是引擎数据契约，与自由设定 md 不同层。

连带发现审核没提但同样致命的一点：只加槽位还不够。world-curator 工作方式第 1 条原文是「Read 任务列出的**既有设定文件和参考指导文件**」，不提立项卡，新槽位等于白加。已改成「Read 任务列出的文件（立项卡 / 既有设定 / 参考指导）」，对齐 outline-architect 的同款写法。

这处 agent prompt 改动与本 PR 先前拒收的那半性质不同：那半是把「读既有设定」再强调一遍（重复加固），这半是让 agent 知道有一个它此前拿不到的**新输入**（契约对齐），不涉及创作措辞，不触发「改 prompt 需 A/B 证据」。

**P1 关于「无自动化行为测试」—— 接受，但无法在本 PR 内消除。** 本仓对 command 编排层没有测试面（模型是否真把完整清单传进子会话，只有真机能证明）。已在下方「未验证的部分」如实标注，并已在 #14 请报告人用原始场景验收。

## 未验证的部分（诚实交代）

**没做真机 dogfood。** 需要一个已有 `relationships.md` + 若干 `characters/*.md` 的小说项目，走「修改已有角色」全链看冲突是否真被检出。已在 #14 请报告人 @Akimixu-19897 用他的原始复现场景验证。

**一个已知但本 PR 不处理的问题**：枚举后会把 `bible/characters/*.md` 全部列进 Envelope，策展人会全读。建书初期没问题，一本书攒到几十个角色档案时会偏贵。`plan.md` 是同样做法，所以这是既有惯例、非本 PR 引入；按「一个 PR 一件事」不在此处理，值得单开 issue 跟进。

## 版本号协调（更正）

**本节此前写的「两者无版本冲突、合并顺序不限」是错的**，感谢 review 指出。版本**号**确实错开了（本 PR `4.0.171`，#20 `4.0.172`），但两条 PR 改的是同四个**文件的同一行**，`git merge-tree` 实测四处全部 CONFLICT：

```
agent-core/narracat-agent-core.lock.json
agent-core/narracat/CLAUDE.md
agent-core/narracat/mcp-server/package.json
agent-core/narracat/narracat.manifest.json
```

事实是：**先落一条后，另一条必须 rebase**。冲突全部集中在版本号那一行，解决成本很低，但不能当作不存在。

建议 landing 顺序：本 PR（`4.0.171`）先，#20 后 rebase 保持 `4.0.172`。若顺序反过来，本 PR rebase 时改成 `4.0.173`（版本号只需单调递增，跳号无害）。

## 归属

根因现场由 @Akimixu-19897 在 #14 提供（其 fork commit 1aa7be3 实现过一版）。本 PR 采纳其派发侧的修复方向，未采纳 agent prompt 侧的重复加固，理由见上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
