### PR TITLE
fix(outline): novel_submit_outline 的 phase 改可选，缺省即 1（Closes #17）

### DIFF
--- a/agent-core/narracat-agent-core.lock.json
+++ b/agent-core/narracat-agent-core.lock.json
@@ -1,7 +1,7 @@
 {
   "path": "agent-core/narracat-agent-core.lock.json",
   "name": "narracat",
-  "version": "4.0.171",
+  "version": "4.0.172",
   "manifestPath": "narracat.manifest.json",
   "upstream": {
     "repo": "the-lumos-labs/NarraCat",

--- a/agent-core/narracat/CLAUDE.md
+++ b/agent-core/narracat/CLAUDE.md
@@ -157,7 +157,7 @@ CI workflow 住在**仓库根** `.github/workflows/`（不在本目录的 `.gith
 
 三位版本号 `x.y.z`：x = 架构方向 / 重大转型；y = 功能阶段迭代；z = 每次非 trivial 提交递增。x / y 仅在用户明确要求时增加。
 
-当前基准：**4.0.171**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
+当前基准：**4.0.172**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
 
 **bump 流程**（每次非 trivial 提交）：(1) CHANGELOG.md 顶部加新版本段；(2) 更新本节「当前基准」；(3) 同步 narracat.manifest.json 与 mcp-server/package.json 的 version 字段；(4) 同步 App 层版本闸门 `agent-core/narracat-agent-core.lock.json` 的 `version`——漏改会导致 App 启动报「Agent Core version 应为 X，实际为 Y」、且 `bun --no-cache run verify:narracat-agent-core` 失败。版本历史归 CHANGELOG.md，不在本文件累积。
 

--- a/agent-core/narracat/mcp-server/dist/handlers/writers.js
+++ b/agent-core/narracat/mcp-server/dist/handlers/writers.js
@@ -1452,7 +1452,11 @@ export async function novelSubmitOutline(args, ctx) {
     // phase 恒为 1、没有第二个取值，不值得让模型每次记着传（漏传只会白撞一轮入参校验）：
     // 缺省即 1。显式传了别的值仍 fail-loud——那是「误把章级细纲提交到书级入口」的真实误用，
     // 这条 hint 有价值，不能连它一起砍掉。
-    const phase = args["phase"] ?? 1;
+    //
+    // 判「省略」只认 undefined，不能用 `?? 1`：`null ?? 1` 也是 1，会把显式传入的 null 当成
+    // 省略静默放行，而 null 属于「显式传了但不等于 1」，必须走 fail-loud。runTool
+    // （core.ts）拿到 args 直接调 handler、不跑 tool inputSchema 校验，这里是唯一防线。
+    const phase = "phase" in args && args["phase"] !== undefined ? args["phase"] : 1;
     if (phase !== 1) {
         return singleError("phase", "integer 1（可省略，缺省即 1）", `${typeof phase}: ${JSON.stringify(phase)}`, "书级+卷级大纲提交 phase 固定为 1；章级细纲改用 novel_submit_chapter_outline");
     }

--- a/agent-core/narracat/mcp-server/dist/handlers/writers.js
+++ b/agent-core/narracat/mcp-server/dist/handlers/writers.js
@@ -1449,9 +1449,12 @@ function checkWrittenStructureIdentity(payload, scope, ctx) {
     return errors;
 }
 export async function novelSubmitOutline(args, ctx) {
-    const phase = args["phase"];
+    // phase 恒为 1、没有第二个取值，不值得让模型每次记着传（漏传只会白撞一轮入参校验）：
+    // 缺省即 1。显式传了别的值仍 fail-loud——那是「误把章级细纲提交到书级入口」的真实误用，
+    // 这条 hint 有价值，不能连它一起砍掉。
+    const phase = args["phase"] ?? 1;
     if (phase !== 1) {
-        return singleError("phase", "integer 1", `${typeof phase}: ${JSON.stringify(phase)}`, "书级+卷级大纲提交 phase 固定为 1；章级细纲改用 novel_submit_chapter_outline");
+        return singleError("phase", "integer 1（可省略，缺省即 1）", `${typeof phase}: ${JSON.stringify(phase)}`, "书级+卷级大纲提交 phase 固定为 1；章级细纲改用 novel_submit_chapter_outline");
     }
     const rawScope = args["scope"] ?? "full";
     if (!OUTLINE_SCOPES.includes(rawScope)) {

--- a/agent-core/narracat/mcp-server/dist/tools.js
+++ b/agent-core/narracat/mcp-server/dist/tools.js
@@ -562,7 +562,7 @@ export const TOOL_DEFINITIONS = [
         inputSchema: {
             type: "object",
             properties: {
-                phase: { type: "integer", enum: [1], description: "固定为 1" },
+                phase: { type: "integer", enum: [1], description: "可省略；本工具只受理书级+卷级，章级细纲改用 novel_submit_chapter_outline" },
                 scope: {
                     type: "string",
                     enum: ["full", "book", "volumes"],
@@ -573,7 +573,7 @@ export const TOOL_DEFINITIONS = [
                     description: "OutlineStructure 顶层对象（字段定义见 schemas/outline-structure.json）：central_dramatic_question / protagonist_core_desire / protagonist_core_lack / antagonistic_force / stakes_progression / storylines / foreshadowing_registry / volumes（scope=book 时省略；scope=volumes 时只需 volumes）",
                 },
             },
-            required: ["phase", "payload"],
+            required: ["payload"],
         },
     },
     {

--- a/agent-core/narracat/mcp-server/package.json
+++ b/agent-core/narracat/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narracat/mcp-server",
-  "version": "4.0.171",
+  "version": "4.0.172",
   "description": "NovelMemory MCP Server - adapter between NarraCat Agent runtime and OpenMemory",
   "type": "module",
   "main": "dist/index.js",

--- a/agent-core/narracat/mcp-server/src/core.test.ts
+++ b/agent-core/narracat/mcp-server/src/core.test.ts
@@ -28,6 +28,16 @@ describe("core 入口", () => {
     expect(handlerNames).toEqual(defNames);
   });
 
+  // 公开 schema 的锁：handler 侧「省略即 1」只有在 phase 不是 required 时才对模型可见。
+  // 只测 handler 会漏掉「有人把 phase 加回 required」——那时 handler 依旧全绿，模型却又被
+  // 要求每次传它，改动等于白做。
+  it("novel_submit_outline 的 phase 不在 required 中（payload 仍必填）", () => {
+    const def = TOOL_DEFINITIONS.find((d) => d.name === "novel_submit_outline");
+    expect(def).toBeDefined();
+    const required = (def!.inputSchema as { required?: string[] }).required ?? [];
+    expect(required).toEqual(["payload"]);
+  });
+
   it("runTool 未知工具返回 ERR_TOOL_001 信封且不触发 getContext", async () => {
     const getContext = vi.fn();
     const result = await runTool("novel_nonexistent", {}, getContext, () => {});

--- a/agent-core/narracat/mcp-server/src/handlers/writers.test.ts
+++ b/agent-core/narracat/mcp-server/src/handlers/writers.test.ts
@@ -239,6 +239,36 @@ describe("novel_submit_outline", () => {
     expect(result.ok).toBe(false);
   });
 
+  // phase 恒为 1、无第二个取值，故不强制模型传：漏传不该白撞一轮入参校验。
+  // 显式传错值的拒绝路径由上一条锁住，两条一起才是完整语义。
+  it("省略 phase 与显式传 1 等价（缺省即 1）", async () => {
+    const { ctx, root } = createProject();
+    const result = (await novelSubmitOutline(
+      { payload: loadFixture("outline-v5-valid-book.json") },
+      ctx,
+    )) as Record<string, unknown>;
+
+    expect(result.ok).toBe(true);
+    expect(result.volumes).toBe(1);
+    expect(result.arcs).toBe(2);
+    expect(existsSync(join(root, "outline", "master-outline.md"))).toBe(true);
+  });
+
+  it("省略 phase 时 scope 分支照常生效（不因缺省而回落 full）", async () => {
+    const { ctx } = createProject();
+    const base = loadFixture<Record<string, unknown>>("outline-v5-valid-book.json");
+    const { volumes: _volumes, ...book } = base;
+    const result = (await novelSubmitOutline({ scope: "book", payload: book }, ctx)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.ok).toBe(true);
+    // scope=book 只落书级骨架、卷结构待展开，故卷数为 0——若 phase 缺省把整条分支带偏回落
+    // full，这里会拿到 fixture 的 1 卷。
+    expect(result.volumes).toBe(0);
+  });
+
   it("伏笔延迟兑现告警随回执返回、不阻断入库（ok 仍 true）", async () => {
     const { ctx } = createProject();
     const payload = loadFixture<Record<string, any>>("outline-v5-valid-book.json");

--- a/agent-core/narracat/mcp-server/src/handlers/writers.test.ts
+++ b/agent-core/narracat/mcp-server/src/handlers/writers.test.ts
@@ -239,6 +239,19 @@ describe("novel_submit_outline", () => {
     expect(result.ok).toBe(false);
   });
 
+  // 显式 null 属于「传了但不等于 1」，不是省略——`?? 1` 会把它静默当成 1 放行。
+  // runTool 直接调 handler、不跑 tool inputSchema 校验，这里是唯一防线。
+  it("phase 显式为 null 时拒绝（不当成省略）", async () => {
+    const { ctx } = createProject();
+    const result = (await novelSubmitOutline({ phase: null, payload: {} }, ctx)) as Record<
+      string,
+      unknown
+    >;
+    expect(result.ok).toBe(false);
+    const fields = (result.errors as Array<{ field: string }>).map((e) => e.field);
+    expect(fields).toContain("phase");
+  });
+
   // phase 恒为 1、无第二个取值，故不强制模型传：漏传不该白撞一轮入参校验。
   // 显式传错值的拒绝路径由上一条锁住，两条一起才是完整语义。
   it("省略 phase 与显式传 1 等价（缺省即 1）", async () => {

--- a/agent-core/narracat/mcp-server/src/handlers/writers.ts
+++ b/agent-core/narracat/mcp-server/src/handlers/writers.ts
@@ -1895,11 +1895,14 @@ export async function novelSubmitOutline(
   args: Record<string, unknown>,
   ctx: ToolContext,
 ): Promise<unknown> {
-  const phase = args["phase"];
+  // phase 恒为 1、没有第二个取值，不值得让模型每次记着传（漏传只会白撞一轮入参校验）：
+  // 缺省即 1。显式传了别的值仍 fail-loud——那是「误把章级细纲提交到书级入口」的真实误用，
+  // 这条 hint 有价值，不能连它一起砍掉。
+  const phase = args["phase"] ?? 1;
   if (phase !== 1) {
     return singleError(
       "phase",
-      "integer 1",
+      "integer 1（可省略，缺省即 1）",
       `${typeof phase}: ${JSON.stringify(phase)}`,
       "书级+卷级大纲提交 phase 固定为 1；章级细纲改用 novel_submit_chapter_outline",
     );

--- a/agent-core/narracat/mcp-server/src/handlers/writers.ts
+++ b/agent-core/narracat/mcp-server/src/handlers/writers.ts
@@ -1898,7 +1898,11 @@ export async function novelSubmitOutline(
   // phase 恒为 1、没有第二个取值，不值得让模型每次记着传（漏传只会白撞一轮入参校验）：
   // 缺省即 1。显式传了别的值仍 fail-loud——那是「误把章级细纲提交到书级入口」的真实误用，
   // 这条 hint 有价值，不能连它一起砍掉。
-  const phase = args["phase"] ?? 1;
+  //
+  // 判「省略」只认 undefined，不能用 `?? 1`：`null ?? 1` 也是 1，会把显式传入的 null 当成
+  // 省略静默放行，而 null 属于「显式传了但不等于 1」，必须走 fail-loud。runTool
+  // （core.ts）拿到 args 直接调 handler、不跑 tool inputSchema 校验，这里是唯一防线。
+  const phase = "phase" in args && args["phase"] !== undefined ? args["phase"] : 1;
   if (phase !== 1) {
     return singleError(
       "phase",

--- a/agent-core/narracat/mcp-server/src/tools.ts
+++ b/agent-core/narracat/mcp-server/src/tools.ts
@@ -605,7 +605,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     inputSchema: {
       type: "object",
       properties: {
-        phase: { type: "integer", enum: [1], description: "固定为 1" },
+        phase: { type: "integer", enum: [1], description: "可省略；本工具只受理书级+卷级，章级细纲改用 novel_submit_chapter_outline" },
         scope: {
           type: "string",
           enum: ["full", "book", "volumes"],
@@ -618,7 +618,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
             "OutlineStructure 顶层对象（字段定义见 schemas/outline-structure.json）：central_dramatic_question / protagonist_core_desire / protagonist_core_lack / antagonistic_force / stakes_progression / storylines / foreshadowing_registry / volumes（scope=book 时省略；scope=volumes 时只需 volumes）",
         },
       },
-      required: ["phase", "payload"],
+      required: ["payload"],
     },
   },
   {

--- a/agent-core/narracat/narracat.manifest.json
+++ b/agent-core/narracat/narracat.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "narracat",
-  "version": "4.0.171",
+  "version": "4.0.172",
   "description": "NarraCat Agent Core — AI 辅助超长篇小说创作引擎（自有契约清单，App 层发现与校验的 SSOT）",
   "commands": ["init", "learn-craft", "plan", "reference", "review", "revise-premise", "rewrite", "setup", "status", "sync-chapter-memory", "world", "write", "writer-wizard"],
   "agents": ["outline-architect", "chapter-writer", "continuity-editor", "world-curator", "memory-keeper"],


### PR DESCRIPTION
Closes #17

## 第一关：该不该做

**解决什么问题，不改会怎样，影响哪些用户**

`novel_submit_outline` 的 `phase` 是一个零信息量的仪式性必填参数：

- `handlers/writers.ts` 拿到它只做一次 `phase !== 1` 的检查就报错，**没有任何分支**——它恒等于 1
- 可它在 `required` 里
- 而 `commands/plan.md` 与 `agents/outline-architect.md` 全文**从未提过这个参数**

模型只能从 schema description 里那句「固定为 1」自行推断。漏传就撞 typebox 入参校验，错误回灌重试，白烧一轮。影响所有走 `/plan` 提交全书大纲的作者——这是建书期的必经步骤。

**给主干留下什么长期成本**

负的：这个 PR 是**减法**，砍掉一个必填约束，不新增任何东西。

**有没有更小的解法，为什么没选**

有，而且我刻意否掉了：在 `plan.md` / `outline-architect.md` 加一句「记得传 phase」。

不选的理由——让模型记住一个恒定值，不如让它不必记。加提示是在给一个不该存在的必填参数续命，而且踩本仓「删一条规则永远优于加一条豁免」的 prompt 纪律。

## 第二关：实现对不对

**根因证据**

- `mcp-server/src/tools.ts`：`phase: { type: "integer", enum: [1], description: "固定为 1" }`，且在 `required: ["phase", "payload"]` 中
- `mcp-server/src/handlers/writers.ts:1898`：`const phase = args["phase"]; if (phase !== 1) { return singleError(...) }` —— 检查完就再没用过这个变量
- 现场（来自 #15）：模型发出 `{}`，报 `phase: must have required properties phase, payload`

**改动**

| 文件 | 改动 |
|---|---|
| `tools.ts` | `phase` 移出 `required`（只剩 `payload`）；description 从「固定为 1」改为说明可省略 + 章级细纲的正确入口 |
| `writers.ts` | `args["phase"] ?? 1`，缺省即 1 |

**显式传非 1 的拒绝路径原样保留。** 那条 hint（「章级细纲改用 `novel_submit_chapter_outline`」）拦的是真实的用户误用——把章级细纲提交到书级入口——不能连它一起砍掉。原有的「phase 不为 1 时拒绝」测试未改动，继续锁这条路径。

**测试**

补两条：

1. 省略 `phase` 与显式传 1 等价（入库 + 渲染 + 卷/arc 计数全部照常）
2. 省略 `phase` 时 `scope` 分支照常生效——防的是「缺省处理把整条分支带偏回落 full」

第二条不是凑数：写第一版时我把返回的卷数断言写成了 `undefined`，实际是 `0`，靠这条测试跑出来才发现假设错了。

**兼容性**：老调用方显式传 `phase: 1` 行为逐字节不变，零迁移。`required` 收窄只放宽不收紧，不影响任何既有合法调用（既有 20 余处调用点全部显式传 1，测试已覆盖）。

**`dist` 随 `src` 重新编译提交**——`dist` 是 tracked 编译产物，打包跑的是 dist 不是 src，漏提交会导致打包静默不生效而单测仍绿。

## 第三关：担不担得起

碰到「Agent Core 契约（schema / manifest / 版本闸门）」区域，按规矩升级审查：

- 改的是工具 `inputSchema`（`tools.ts`），**不是** `schemas/*.json`，不触发 `agent-core-schema-pr-check.yml` 的下游影响评估要求
- bump `4.0.170` → `4.0.172`，四处同步
- 不涉及用户小说数据的写入语义：入库逻辑一行未改，只改了入口参数的必填性

**「破了会静默毁坏用户数据」的风险评估**：`required` 放宽不会让任何非法 payload 通过——payload 本身的 ajv 校验与结构预算核验全部在 `phase` 检查之后，一步没少。

回滚成本：两处单行改动 + 版本号回退 + 重新 build dist。

## 验证

| 命令 | 结果 |
|---|---|
| `cd mcp-server && npm run build` | 零错误 |
| `cd mcp-server && npm run test`（vitest） | 923 pass / 0 fail / 38 files |
| `bun --no-cache run test`（App 侧） | 2982 pass / 0 fail / 296 files |
| `bun --no-cache run verify:narracat-agent-core` | 版本一致 4.0.172 |
| `lint:manifest-sync` / `lint:provenance` / `lint:schema-drift` | 全过 |

## 版本号协调（更正）

**本节此前写的「两者无冲突、合并顺序不限」是错的**，感谢 review 指出。版本**号**确实错开了（#19 `4.0.171`，本 PR `4.0.172`），但两条 PR 改的是同四个**文件的同一行**，`git merge-tree` 实测四处全部 CONFLICT：

```
agent-core/narracat-agent-core.lock.json
agent-core/narracat/CLAUDE.md
agent-core/narracat/mcp-server/package.json
agent-core/narracat/narracat.manifest.json
```

事实是：**先落一条后，另一条必须 rebase**。冲突全部集中在版本号那一行，解决成本很低，但不能当作不存在。

建议 landing 顺序：#19（`4.0.171`）先，本 PR 后 rebase 保持 `4.0.172`。若本 PR 先落，则 #19 rebase 时改成 `4.0.173`。

## Review 跟进（commit f3d5713）

**P1 显式 `phase: null` 被当成省略 —— 已确认属实并修复。**

实测（改前 → 改后）：

| 输入 | 改前的错误字段 | 改后 |
|---|---|---|
| `{ phase: null }` | `central_dramatic_question, ...`（跳过了 phase 检查） | `phase` ✅ |
| `{ phase: 2 }` | `phase` | `phase` |
| 省略 `phase` | `central_dramatic_question, ...` | 不变 |

审核指出的关键前提也已核实：`core.ts` 的 `runTool` 拿到 args 直接 `handler(args, ctx)`，**不跑 tool inputSchema 校验**——handler 是唯一防线，不能指望公开 schema 兜底。

修法：判「省略」只认 `undefined`（`"phase" in args && args["phase"] !== undefined`），不用 `??`——`null ?? 1` 也是 1。

**P2 测试没锁公开 schema —— 接受，已补。** `core.test.ts` 新增一条断言 `required` 恰为 `["payload"]`。此前只直调 handler，以后有人把 `phase` 加回 `required` 仍会全绿，而那时 handler 的「省略即 1」对模型根本不可见，改动等于白做。

复验：mcp-server 925 pass / 0 fail（+2），App 侧 2982 pass / 0 fail。

## 归属

线索来自 @Akimixu-19897 在 #15 贴出的现场错误。这条问题本身不在他的报告里（#15 提的是补 prompt 与内联 payload schema，那两条经评估未采纳，理由见 #15 的讨论），但没有他贴的原始错误，不会有人去翻这个 handler。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
