### PR TITLE
docs(agent-core): bump 流程改为反映现实——CHANGELOG 不入仓

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,6 @@ Review 第一关（判据见 CONTRIBUTING.md「PR 会被怎样审」）。三问
 - **兼容性策略**：
   - [ ] 完全向后兼容（仅新增可选字段）
   - [ ] 老数据需迁移（已提供 migration 脚本 / 启动钩子自动迁移）
-  - [ ] Breaking change（已在 CHANGELOG 标注 / 升级注意事项）
+  - [ ] Breaking change（已在本 PR 描述写明升级注意事项）
 - **客户端验证**：
   - <!-- 是否在 dogfood 项目上验证过 / 测试覆盖哪些场景 -->

--- a/agent-core/narracat/CLAUDE.md
+++ b/agent-core/narracat/CLAUDE.md
@@ -108,7 +108,7 @@ App 层「Agent 档案」页让作者在设置页覆盖官方 Agent 的部分正
 `id` 一旦发布（进了 `prose-blocks.lock.json` 并随版本发出），**不得改名**——作者的 override 是按 id 存的，改名等于让存量 override 静默孤儿化。删除一个块必须同步：
 
 1. 从 `prose-blocks.lock.json` 移除该条目；
-2. bump 引擎版本（四步 bump，见下节）。
+2. bump 引擎版本（三步 bump，见下节）。
 
 `scripts/check-prose-blocks.mjs`（本地串进 `check:architecture`；CI 侧 `.github/workflows/agent-core-ci.yml` 的 `agent-core-prose-blocks-guard` job 直接跑同一条命令）机械校验：标记成对闭合、id 为 kebab-case、id 全局唯一、id 集合与 lock 文件双向一致。**新增或修改块后必须跑 `node scripts/check-prose-blocks.mjs`**，本地失败等价 CI 会红。
 
@@ -159,7 +159,11 @@ CI workflow 住在**仓库根** `.github/workflows/`（不在本目录的 `.gith
 
 当前基准：**4.0.172**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
 
-**bump 流程**（每次非 trivial 提交）：(1) CHANGELOG.md 顶部加新版本段；(2) 更新本节「当前基准」；(3) 同步 narracat.manifest.json 与 mcp-server/package.json 的 version 字段；(4) 同步 App 层版本闸门 `agent-core/narracat-agent-core.lock.json` 的 `version`——漏改会导致 App 启动报「Agent Core version 应为 X，实际为 Y」、且 `bun --no-cache run verify:narracat-agent-core` 失败。版本历史归 CHANGELOG.md，不在本文件累积。
+**bump 流程**（每次非 trivial 提交，三处版本号 + 本节基准必须逐字一致）：(1) 更新本节「当前基准」；(2) 同步 narracat.manifest.json 与 mcp-server/package.json 的 version 字段；(3) 同步 App 层版本闸门 `agent-core/narracat-agent-core.lock.json` 的 `version`——漏改会导致 App 启动报「Agent Core version 应为 X，实际为 Y」、且 `bun --no-cache run verify:narracat-agent-core` 失败。
+
+**变更说明写进 commit message，不要写 CHANGELOG.md。** 本仓 `.gitignore` 把 `agent-core/narracat/CHANGELOG.md` 归为过程私产（`scripts/check-public-boundary.test.mjs` 的 `FORBIDDEN_TRACKED_PREFIXES` 硬校验它不得被 tracked，根 `CONTEXT.md` 的分发资产分级把它列为「研发痕迹」），**写了也不进版本库**。这个坑踩起来很隐蔽：编辑成功、文件确实改了、`git add -A` 也不报错（git 静默跳过 ignored 文件），只是永远不进 commit；而且它是未跟踪文件，`git checkout` 换分支时原地不动，会把 A 分支写的段带到 B 分支，造出两段同号记录。本地那份留作自己查阅无妨，但它不是交付物——**入仓的变更记录 = commit message（细节）+ `docs/agents/progress.md`（阶段）**。
+
+多条 agent-core PR 并行时：各自从 main 拉出会 bump 到同一个 z，四个版本文件在同一行冲突（`git merge-tree` 可预先确认）。先落一条，另一条 rebase 后重新定 landing 版本；版本号只需单调递增，跳号无害。
 
 ## Agent skills
 


### PR DESCRIPTION
## 问题

`agent-core/narracat/CLAUDE.md` 的 bump 流程第 (1) 步要求「CHANGELOG.md 顶部加新版本段」，但该文件在本仓被 `.gitignore` 排除，**写了永远不进版本库**。

上一轮改 agent-core（#14/#17）时按文档一步步做，第 1 步静默落空才发现。踩法很隐蔽：编辑成功、文件确实改了、`git add -A` 也不报错（git 静默跳过 ignored 文件），只是永远不进 commit。更麻烦的是它是未跟踪文件——`git checkout` 换分支时原地不动，我在 A 分支写的段跟着到了 B 分支，本地那份一度出现两段同号记录。

## 方向选择：为什么是「改文档」而不是「让 CHANGELOG 入仓」

先查了排除的来由，三处证据表明这是**有意决定，不是疏漏**：

| 证据 | 内容 |
|---|---|
| `.gitignore:41` | 归在「private assets: never commit」段，公开仓首发 commit `5c3f12d` 即排除 |
| `scripts/check-public-boundary.test.mjs:19` | 列入 `FORBIDDEN_TRACKED_PREFIXES`，**硬校验它不得被 tracked** |
| 根 `CONTEXT.md:148` | 分发资产分级把 CHANGELOG 列为「研发痕迹⋯不应进入任何分发包」 |

把它加回 git 会让 `check-public-boundary` 变红，等于推翻一个有守卫背书的决定。另外它虽不含守卫的禁词（已逐项 grep 确认），但有 8 处指向私有仓的引用，357KB 要脱敏才能公开，收益也低——内容本就该在 commit message 里。

所以不动 `.gitignore` 和守卫，改文档去对齐现实。

## 改了什么

1. **bump 流程 4 步 → 3 步**，删掉写 CHANGELOG 那步
2. **新增一段**写明为什么不写、以及踩法为何隐蔽（含跨分支污染那个坑）
3. **新增一段**并行 PR 的版本号协调：各自从 main 拉出会 bump 到同一个 z，四个版本文件同一行冲突（`git merge-tree` 可预先确认），先落一条另一条 rebase，跳号无害——这是上一轮 #19/#20 实际踩到并解决的
4. 「四步 bump」引用同步改为「三步」
5. **PR 模板**的 Breaking change 项从「已在 CHANGELOG 标注」改为「已在本 PR 描述写明」——外部贡献者根本拿不到那个文件，原文案是误导

本地那份 CHANGELOG 不动，留作维护者自己查阅。入仓的变更记录 = commit message（细节）+ `docs/agents/progress.md`（阶段）。

## 验证

`bun --no-cache run test` **2990 pass / 0 fail across 297 files**，其中 `check-public-boundary` 3 pass（确认没碰边界规则）。只改两个 markdown 文件，无代码改动。

按 CONTRIBUTING「只碰 UI 文案、文档、测试的改动走快速通道」，不逐条论证三关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)