### PR TITLE
fix(repo): GitHub 账号改名 pantsbang-yannik → yannikzz，更新全部引用

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: signatures/cla.json
-          path-to-document: https://github.com/pantsbang-yannik/narracat-novel-agent/blob/main/docs/CLA.md
+          path-to-document: https://github.com/yannikzz/narracat-novel-agent/blob/main/docs/CLA.md
           branch: signatures
-          allowlist: pantsbang-yannik
+          allowlist: yannikzz
           custom-notsigned-prcomment: 感谢贡献！请先阅读 CLA（上方链接）并按提示回复签署语句。

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 *NarraCat is an AI-powered desktop writing studio for Chinese web-novel authors — plan, draft, and manage million-word serials with an agentic creative engine that keeps long-range plot memory.*
 
-[![CI](https://github.com/pantsbang-yannik/narracat-novel-agent/actions/workflows/app-ci.yml/badge.svg)](https://github.com/pantsbang-yannik/narracat-novel-agent/actions)
+[![CI](https://github.com/yannikzz/narracat-novel-agent/actions/workflows/app-ci.yml/badge.svg)](https://github.com/yannikzz/narracat-novel-agent/actions)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
-[![Release](https://img.shields.io/github/v/release/pantsbang-yannik/narracat-novel-agent)](https://github.com/pantsbang-yannik/narracat-novel-agent/releases)
+[![Release](https://img.shields.io/github/v/release/yannikzz/narracat-novel-agent)](https://github.com/yannikzz/narracat-novel-agent/releases)
 
 *在人类文明中，故事一直来自人的记忆、情感与想象。<br>
 从口述，到书写，再到数字时代，技术不断改变表达方式，但创造故事的，<br>
@@ -34,7 +34,7 @@ NarraCat 让智能先理解你的所想，再协助构建世界观、推进剧�
 
 ## 三步开始写
 
-1. **下载安装**：到 [Releases](https://github.com/pantsbang-yannik/narracat-novel-agent/releases) 下载最新 DMG（目前仅支持 **macOS Apple Silicon**；其他平台暂无时间表，欢迎关注）
+1. **下载安装**：到 [Releases](https://github.com/yannikzz/narracat-novel-agent/releases) 下载最新 DMG（目前仅支持 **macOS Apple Silicon**；其他平台暂无时间表，欢迎关注）
 2. **配置模型**：NarraCat 采用 BYOK（自带 API Key）。推荐 DeepSeek，几分钟即可申请，费用与配置见 [FAQ](./docs/faq.md)
 3. **开一本书**：新建小说 → 立项卡定题材与金手指 → 让 Agent 铺大纲、写第一章
 
@@ -53,7 +53,7 @@ NarraCat 让智能先理解你的所想，再协助构建世界观、推进剧�
 
 ## 参与
 
-- Bug/功能建议/使用求助 → [Issues](https://github.com/pantsbang-yannik/narracat-novel-agent/issues)（**请勿粘贴小说正文与 API Key**）
+- Bug/功能建议/使用求助 → [Issues](https://github.com/yannikzz/narracat-novel-agent/issues)（**请勿粘贴小说正文与 API Key**）
 - 参与开发 → [CONTRIBUTING.md](./CONTRIBUTING.md) · 架构导览 → [ARCHITECTURE.md](./ARCHITECTURE.md)
 - 安全问题 → [SECURITY.md](./SECURITY.md)
 

--- a/scripts/check-public-boundary.test.mjs
+++ b/scripts/check-public-boundary.test.mjs
@@ -33,7 +33,7 @@ const TRACKED_ALLOWLIST = new Set([
   'agent-core/narracat/docs/reports/2026-03-28-system-audit-anti-template.md',
   'agent-core/narracat/docs/reports/2026-04-26-system-debt-analysis.md',
 ])
-// 允许 pantsbang-yannik；禁其余个人标识与私有基础设施标识。
+// 允许 yannikzz；禁其余个人标识与私有基础设施标识。
 // Yannik Zhang / AHRB2HD27M（Apple Team ID）是 2026-08-16 人工扫描才发现的正则盲区，补入防复发。
 // the-lumos-labs / narracat-corpus-service：私有组织名与私有仓名，两道守卫原本都不拦，同日补入。
 // corpus.narracat.com 有意不收：那是客户端真实调用的线上端点，反编译即得，藏不住也不必藏。

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -13,7 +13,7 @@ describe('createReleasePlan', () => {
 
   test('tag 与目标仓正确', () => {
     expect(plan.tag).toBe('v0.1.1880')
-    expect(plan.repo).toBe('pantsbang-yannik/narracat-novel-agent')
+    expect(plan.repo).toBe('yannikzz/narracat-novel-agent')
   })
 
   test('五个资产齐全且清单排在最后', () => {
@@ -83,7 +83,7 @@ describe('formatConfirmation', () => {
   test('列出版本号、目标仓、tag 与每个文件的大小', () => {
     const text = formatConfirmation({
       clientVersion: '0.1.1880',
-      repo: 'pantsbang-yannik/narracat-novel-agent',
+      repo: 'yannikzz/narracat-novel-agent',
       tag: 'v0.1.1880',
       files: [
         { name: 'NarraCat-0.1.1880-mac-arm64.zip', bytes: 288_358_400 },
@@ -91,7 +91,7 @@ describe('formatConfirmation', () => {
       ],
     })
     expect(text).toContain('0.1.1880')
-    expect(text).toContain('pantsbang-yannik/narracat-novel-agent')
+    expect(text).toContain('yannikzz/narracat-novel-agent')
     expect(text).toContain('v0.1.1880')
     expect(text).toContain('275.0 MB')
     expect(text).toContain('0.5 KB')
@@ -103,7 +103,7 @@ describe('formatConfirmation', () => {
   test('提醒 tag 基于发布仓默认分支创建、可能与本次代码不一致', () => {
     const text = formatConfirmation({
       clientVersion: '0.1.1880',
-      repo: 'pantsbang-yannik/narracat-novel-agent',
+      repo: 'yannikzz/narracat-novel-agent',
       tag: 'v0.1.1880',
       files: [],
     })

--- a/scripts/update-feed.mjs
+++ b/scripts/update-feed.mjs
@@ -6,7 +6,7 @@
  */
 export const UPDATE_FEED_BASE_URL = 'https://update.narracat.com'
 /** 安装包发布到的 GitHub 仓库；与开发主仓不同，gh 调用必须显式 --repo。 */
-export const RELEASE_REPO = 'pantsbang-yannik/narracat-novel-agent'
+export const RELEASE_REPO = 'yannikzz/narracat-novel-agent'
 /** 当前只发 macOS arm64；Windows 战役落位时新增 'win-x64'。 */
 export const MAC_PLATFORM_DIR = 'mac-arm64'
 

--- a/scripts/update-feed.test.mjs
+++ b/scripts/update-feed.test.mjs
@@ -38,7 +38,7 @@ describe('update feed 契约', () => {
   })
 
   test('发布仓是那个已 public 的新仓', () => {
-    expect(RELEASE_REPO).toBe('pantsbang-yannik/narracat-novel-agent')
+    expect(RELEASE_REPO).toBe('yannikzz/narracat-novel-agent')
   })
 
   test('tag 是版本号前加 v', () => {

--- a/workers/narracat-update/README.md
+++ b/workers/narracat-update/README.md
@@ -1,7 +1,7 @@
 # narracat-update Worker（开源路线图 ④）
 
 更新源加速代理。把 `update.narracat.com/<平台>/<文件名>` 转发到 GitHub Releases
-（`pantsbang-yannik/narracat-novel-agent`，已 public），让国内用户下载更稳。
+（`yannikzz/narracat-novel-agent`，已 public），让国内用户下载更稳。
 **无密钥**——发布仓资产匿名可下载，本 Worker 不需要任何 secret。
 
 ## 对外分发用哪个链接
@@ -42,7 +42,7 @@ curl -sI https://update.narracat.com/mac-arm64/latest-mac.yml
 
 出了坏版本，**不需要传任何文件、不需要命令行**：
 
-1. 打开 GitHub 网页 → 发布仓（`pantsbang-yannik/narracat-novel-agent`）→ Releases
+1. 打开 GitHub 网页 → 发布仓（`yannikzz/narracat-novel-agent`）→ Releases
 2. 编辑上一个正常的 release → 勾选 "Set as the latest release" → 保存
 3. 随后 `curl https://update.narracat.com/mac-arm64/latest-mac.yml` 应立刻返回旧版本号
 

--- a/workers/narracat-update/src/index.test.ts
+++ b/workers/narracat-update/src/index.test.ts
@@ -7,7 +7,7 @@ import worker, {
   resolveUpstreamUrl,
 } from './index.ts'
 
-const BASE = 'https://github.com/pantsbang-yannik/narracat-novel-agent/releases'
+const BASE = 'https://github.com/yannikzz/narracat-novel-agent/releases'
 
 describe('resolveUpstreamUrl', () => {
   // 清单不带版本号，必须恒指「最新 release」——这是整套更新的入口。

--- a/workers/narracat-update/src/index.ts
+++ b/workers/narracat-update/src/index.ts
@@ -11,7 +11,7 @@
 // 本 Worker 无密钥：发布仓是 public，资产匿名可下载。
 
 /** 安装包所在的公开仓。与开发主仓不是同一个。 */
-const RELEASE_REPO = 'pantsbang-yannik/narracat-novel-agent'
+const RELEASE_REPO = 'yannikzz/narracat-novel-agent'
 const RELEASES_BASE = `https://github.com/${RELEASE_REPO}/releases`
 
 /** 允许的平台目录。Windows 战役落位时无需改这里。 */


### PR DESCRIPTION
## 发现路径

PR #22 的 `cla` 检查失败。日志不是此前几次的 GitHub 503 抖动，而是：

```
allowlist: pantsbang-yannik
##[error]Committers of Pull Request number 22 have to sign the CLA 📝
```

allowlist 写死的旧用户名与改名后的账号对不上，**会卡住之后每一个 PR**。

## 盘点：19 处引用，分两类

**功能性引用（本次全改）**

| 文件 | 影响 |
|---|---|
| `.github/workflows/cla.yml` | allowlist + CLA 文档链接 ← **当前阻塞源** |
| `scripts/update-feed.mjs` `RELEASE_REPO` | 自动更新的上游仓库地址 |
| `workers/narracat-update/src/index.ts` `RELEASE_REPO` | 同上，Worker 侧 |
| `README.md` | 徽章 + 四处链接（新用户第一眼看到的） |
| `workers/narracat-update/README.md` | 发布仓说明 |
| `scripts/release.test.mjs` / `update-feed.test.mjs` / `worker index.test.ts` | 断言 |
| `scripts/check-public-boundary.test.mjs` | 允许名注释 |

**历史记录（刻意不改）**

`docs/agents/progress.md` 的两条 2026-08 记录——它们描述的是**当时的事实**，那时仓库确实叫那个名字。改历史记录等于篡改事实。

## 这批是消技术债，不是救火

先实测确认了改名**没有**造成线上故障（GitHub 对用户改名做 301 重定向）：

| 探测 | 结果 |
|---|---|
| 线上 `update.narracat.com/mac-arm64/latest-mac.yml` | 200，`version: 0.1.1930` |
| 线上 `update.narracat.com/mac-arm64/latest.dmg` | 206（range 正常） |
| 旧名 `releases/latest/download/latest-mac.yml` | 200（3 跳） |
| 新名 同上 | 200（**2 跳**，少一次用户名重定向） |
| 新名 `docs/CLA.md` | 200 |

所以发版与自动更新此前一直正常，改这批只是去掉对重定向的依赖（重定向不保证永久）+ 让 README 不误导新用户。

> 过程中我一度误报「自动更新链路 404 断了」——那是我把 Worker 路径写错了（它要求 `/<平台>/<文件名>` 两段，我只给了一段）。用正确路径复测即 200。

## 合并方式

本 PR 修的就是 CLA 门禁本身，**它自己的 `cla` 检查必然失败**（鸡生蛋）。需要管理员合并；合并后 #21 / #22 重跑 `cla` 即过。

## 验证

- `bun --no-cache run test` **2990 pass / 0 fail across 297 files**
- Worker 自身 `bun test` **25 pass / 0 fail**
- `check-public-boundary` **3 pass**（确认没碰边界规则）

🤖 Generated with [Claude Code](https://claude.com/claude-code)