### PR TITLE
fix(window): Windows 顶栏 caption 让位（上下分区 + WCO 实测宽度）

### DIFF
--- a/electron/main/ipc/app.ts
+++ b/electron/main/ipc/app.ts
@@ -106,6 +106,19 @@ export function registerAppIpcHandlers(): void {
     return `pong-${Date.now()}`
   })
 
+  // Windows 标题栏 overlay 符号颜色跟随主题（浅色 UI 用深符号，深色 UI 用白符号）。
+  // 仅 win32 有效：mac 红绿灯由系统绘制、Linux 无 overlay，调用会抛错故先判平台。
+  ipcMain.handle('window:set-titlebar-overlay-symbol-color', (_event, symbolColor: unknown) => {
+    if (process.platform !== 'win32' || typeof symbolColor !== 'string') return
+    for (const win of BrowserWindow.getAllWindows()) {
+      try {
+        win.setTitleBarOverlay({ symbolColor })
+      } catch {
+        // 窗口销毁竞态等边缘情况静默忽略，不影响主流程。
+      }
+    }
+  })
+
   // 内测软过期 + 远程急刹车（#354）：渲染端启动时查一次，命中则显示拦截页。
   ipcMain.handle('release-guard:check', async (): Promise<ReleaseGateVerdict> => {
     return evaluateReleaseGuard()

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -1,6 +1,5 @@
 import { BrowserWindow, shell, type BrowserWindowConstructorOptions } from 'electron'
 import { resolve, join } from 'node:path'
-import { clearGpuFallbackMarker } from './gpu-fallback.ts'
 
 const TITLE_BAR_HEIGHT = 56
 const MAC_TRAFFIC_LIGHT_Y = 16
@@ -93,9 +92,6 @@ export function createMainWindow(): BrowserWindow {
     if (isSafeExternalUrl(url)) void shell.openExternal(url)
     return { action: 'deny' }
   })
-
-  // 窗口内容成功加载 → 清除 GPU 降级标记:下次启动重新尝试硬件加速(自适应恢复)
-  win.webContents.once('did-finish-load', () => clearGpuFallbackMarker())
 
   return win
 }

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, shell, type BrowserWindowConstructorOptions } from 'electron'
 import { resolve, join } from 'node:path'
+import { clearGpuFallbackMarker } from './gpu-fallback.ts'
 
 const TITLE_BAR_HEIGHT = 56
 const MAC_TRAFFIC_LIGHT_Y = 16
@@ -43,11 +44,14 @@ function winOptions(): PlatformOptions {
     titleBarStyle: 'hidden',
     titleBarOverlay: {
       color: '#00000000',
-      symbolColor: '#ffffff',
+      // 浅色主题为主的 UI（DARK_MODE_ENABLED 门控强制浅色）用深色符号保证对比度；
+      // 渲染端主题变化时经 window:set-titlebar-overlay-symbol-color 同步覆盖。
+      symbolColor: '#3f3f46',
       height: TITLE_BAR_HEIGHT,
     },
-    // 不设 transparent（win 已知闪烁/输入法 bug），fallback-bg.css 提供背景
-    backgroundColor: '#1a1a1a',
+    // 不设 transparent（win 已知闪烁/输入法 bug），fallback-bg.css 提供背景。
+    // 底色跟浅色主题 --background (#f4f4f5)，避免启动/缩放瞬间闪深色。
+    backgroundColor: '#f4f4f5',
   }
 }
 
@@ -89,6 +93,9 @@ export function createMainWindow(): BrowserWindow {
     if (isSafeExternalUrl(url)) void shell.openExternal(url)
     return { action: 'deny' }
   })
+
+  // 窗口内容成功加载 → 清除 GPU 降级标记:下次启动重新尝试硬件加速(自适应恢复)
+  win.webContents.once('did-finish-load', () => clearGpuFallbackMarker())
 
   return win
 }

--- a/electron/preload/index.cts
+++ b/electron/preload/index.cts
@@ -1,8 +1,11 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 const api = {
+  platform: process.platform,
   ping: (): Promise<string> => ipcRenderer.invoke('ping'),
   revealProjectFolder: (projectPath: string) => ipcRenderer.invoke('novel:reveal-folder', projectPath),
+  setTitleBarOverlaySymbolColor: (symbolColor: string) =>
+    ipcRenderer.invoke('window:set-titlebar-overlay-symbol-color', symbolColor),
   checkReleaseGuard: () => ipcRenderer.invoke('release-guard:check'),
   getUpdaterState: () => ipcRenderer.invoke('updater:get-state'),
   checkForUpdates: () => ipcRenderer.invoke('updater:check'),

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -363,6 +363,10 @@ export type PublishPackDraftResult =
   | { status: 'invalid'; errors: string[]; lintFindings: Array<{ cardId: string; findings: DraftPublishLintFinding[] }> }
 
 export interface ElectronApi {
+  /** 主进程平台标识（'win32' | 'darwin' | 'linux'），渲染端顶栏布局等平台感知逻辑用。 */
+  platform: string
+  /** Windows 标题栏 overlay 符号颜色跟随主题（mac/Linux 上为 no-op）。 */
+  setTitleBarOverlaySymbolColor: (symbolColor: string) => Promise<void>
   ping: () => Promise<string>
   /** 在系统文件管理器中定位项目文件夹（损坏项目的自救入口，#38）。 */
   revealProjectFolder: (projectPath: string) => Promise<void>

--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'bun:test'
+
+// AppShell 只被图书馆路由消费；这里锁的是顶栏平台感知 padding 的源码约定
+// （win32 caption 让位 + 呼吸位 / mac 红绿灯让位），渲染断言在 library.test.tsx。
+describe('AppShell titlebar insets', () => {
+  test('reserves the Windows caption zone plus breathing room on the right', () => {
+    // 只隔让位线时 navEnd 图标与 min/max/close 读成一团（视觉混排），加 0.75rem 呼吸位；
+    // mac 不受影响（--titlebar-inset-right 为 0，max 退回 1rem 原值）。
+    const source = readFileSync(fileURLToPath(new URL('./AppShell.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('pr-[max(1rem,calc(var(--titlebar-inset-right)+0.75rem))]')
+    expect(source).toContain('pl-[max(1rem,var(--titlebar-inset-left))]')
+    expect(source).not.toContain('pr-[max(1rem,var(--titlebar-inset-right))]')
+  })
+})

--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -11,7 +11,18 @@ describe('AppShell titlebar insets', () => {
     const source = readFileSync(fileURLToPath(new URL('./AppShell.tsx', import.meta.url)), 'utf-8')
 
     expect(source).toContain('pr-[max(1rem,calc(var(--titlebar-inset-right)+0.75rem))]')
-    expect(source).toContain('pl-[max(1rem,var(--titlebar-inset-left))]')
     expect(source).not.toContain('pr-[max(1rem,var(--titlebar-inset-right))]')
+  })
+
+  test('preserves the mac 128px left inset (header padding + traffic-light reservation both kept)', () => {
+    // 原实现是两层叠加：header px-4（16px）+ 内层 pl-[112px] = 128px。收进变量时必须
+    // 保留两层语义：pl = max(1rem, inset + 1rem)——mac 112+16=128 逐像素不变，
+    // win32/linux inset=0 时退回 16px（与原 px-4 一致）。漏掉 +1rem 会把 mac 缩到 112px
+    // （PR #26 review ① 抓到的回归），且与右侧的 +0.75rem 呼吸位写法不对称。
+    const source = readFileSync(fileURLToPath(new URL('./AppShell.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('pl-[max(1rem,calc(var(--titlebar-inset-left)+1rem))]')
+    // 漏算形态：只让位不加呼吸位（mac 会缩到 112px）。
+    expect(source).not.toContain('pl-[max(1rem,var(--titlebar-inset-left))]')
   })
 })

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -17,14 +17,15 @@ export function AppShell({ navStart, navCenter, navEnd, children }: AppShellProp
     <div className={`${APP_CANVAS_CLASS} flex h-full flex-col`}>
       {/* 顶部 nav：只承担拖拽和轻量导航，不再作为一块有边框的独立 surface。
           左右 padding 平台感知：mac 给左上角红绿灯让位（--titlebar-inset-left），
-          Windows 给右上角系统 caption 按钮让位（--titlebar-inset-right）。 */}
+          Windows 给右上角系统 caption 按钮让位（--titlebar-inset-right），
+          再加 0.75rem 呼吸位——caption 与 navEnd 图标只隔让位线会读成一团（视觉混排）。 */}
       <header
         className={`
           ${APP_HEADER_CLASS}
           relative flex items-center justify-between
           h-14 shrink-0
           pl-[max(1rem,var(--titlebar-inset-left))]
-          pr-[max(1rem,var(--titlebar-inset-right))]
+          pr-[max(1rem,calc(var(--titlebar-inset-right)+0.75rem))]
           [-webkit-app-region:drag]
         `}
       >

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -18,13 +18,15 @@ export function AppShell({ navStart, navCenter, navEnd, children }: AppShellProp
       {/* 顶部 nav：只承担拖拽和轻量导航，不再作为一块有边框的独立 surface。
           左右 padding 平台感知：mac 给左上角红绿灯让位（--titlebar-inset-left），
           Windows 给右上角系统 caption 按钮让位（--titlebar-inset-right），
-          再加 0.75rem 呼吸位——caption 与 navEnd 图标只隔让位线会读成一团（视觉混排）。 */}
+          再加呼吸位——caption 与 navEnd 图标只隔让位线会读成一团（视觉混排）。
+          左侧同样 +1rem 呼吸位：原实现是 header px-4 与内层 pl-[112px] 两层叠加（合计 128px），
+          收进变量时必须保留两层语义，与右侧 +0.75rem 写法对称。 */}
       <header
         className={`
           ${APP_HEADER_CLASS}
           relative flex items-center justify-between
           h-14 shrink-0
-          pl-[max(1rem,var(--titlebar-inset-left))]
+          pl-[max(1rem,calc(var(--titlebar-inset-left)+1rem))]
           pr-[max(1rem,calc(var(--titlebar-inset-right)+0.75rem))]
           [-webkit-app-region:drag]
         `}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,16 +15,20 @@ type AppShellProps = {
 export function AppShell({ navStart, navCenter, navEnd, children }: AppShellProps) {
   return (
     <div className={`${APP_CANVAS_CLASS} flex h-full flex-col`}>
-      {/* 顶部 nav：只承担拖拽和轻量导航，不再作为一块有边框的独立 surface。 */}
+      {/* 顶部 nav：只承担拖拽和轻量导航，不再作为一块有边框的独立 surface。
+          左右 padding 平台感知：mac 给左上角红绿灯让位（--titlebar-inset-left），
+          Windows 给右上角系统 caption 按钮让位（--titlebar-inset-right）。 */}
       <header
         className={`
           ${APP_HEADER_CLASS}
           relative flex items-center justify-between
-          h-14 px-4 shrink-0
+          h-14 shrink-0
+          pl-[max(1rem,var(--titlebar-inset-left))]
+          pr-[max(1rem,var(--titlebar-inset-right))]
           [-webkit-app-region:drag]
         `}
       >
-        <div className="flex h-full min-w-0 items-center gap-2.5 leading-none [-webkit-app-region:no-drag] pl-[112px] [&_a]:leading-none [&_button]:leading-none [&_span]:leading-none [&_svg]:shrink-0">
+        <div className="flex h-full min-w-0 items-center gap-2.5 leading-none [-webkit-app-region:no-drag] [&_a]:leading-none [&_button]:leading-none [&_span]:leading-none [&_svg]:shrink-0">
           {navStart}
         </div>
         {navCenter ? (

--- a/src/components/onboarding/FirstRunIntro.tsx
+++ b/src/components/onboarding/FirstRunIntro.tsx
@@ -309,8 +309,8 @@ export function FirstRunIntro({ onDone }: FirstRunIntroProps) {
         </motion.div>
       )}
 
-      {/* 跳过（终幕不显示，那里只剩“开始创作”） */}
-      <div className="relative z-10 flex h-14 shrink-0 items-center justify-end px-5">
+      {/* 跳过（终幕不显示，那里只剩“开始创作”）。右侧预留 Windows caption 按钮区。 */}
+      <div className="relative z-10 flex h-14 shrink-0 items-center justify-end pl-[1.25rem] pr-[max(1.25rem,var(--titlebar-inset-right))]">
         {!isFinale && (
           <Button
             variant="ghost"

--- a/src/components/settings/SettingsLayout.tsx
+++ b/src/components/settings/SettingsLayout.tsx
@@ -66,7 +66,7 @@ export function SettingsPrimarySidebar({
   return (
     <aside className="flex h-full w-64 shrink-0 flex-col bg-canvas" data-settings-sidebar="true">
       <div
-        className="flex h-14 shrink-0 items-center justify-end gap-2 pl-[112px] pr-3 [-webkit-app-region:drag]"
+        className="flex h-14 shrink-0 items-center justify-end gap-2 pl-[var(--titlebar-inset-left)] pr-3 [-webkit-app-region:drag]"
         data-settings-sidebar-headbar="true"
       >
         <IconTooltip label="返回">

--- a/src/components/titlebar-gutter-height.test.ts
+++ b/src/components/titlebar-gutter-height.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'bun:test'
+
+// 「一个值散落两个文件」的耦合守卫（PR #26 review ②）：globals.css 的
+// --titlebar-gutter-top 取自 window.ts 的 TITLE_BAR_HEIGHT（titleBarOverlay.height）。
+// 注释拦不住人——将来调 TITLE_BAR_HEIGHT 而 CSS 没跟，Windows 上卡片与 caption 带
+// 错位且无任何测试会红。这条断言把两值锁在一起：读不出任一侧或不相等都视为失败
+// （守卫必须「响」，不做静默通过）。
+describe('titlebar gutter 跨文件一致性守卫', () => {
+  test('globals.css 的 --titlebar-gutter-top 与 window.ts 的 TITLE_BAR_HEIGHT 相等', () => {
+    const css = readFileSync(fileURLToPath(new URL('../styles/globals.css', import.meta.url)), 'utf-8')
+    const ts = readFileSync(
+      fileURLToPath(new URL('../../electron/main/window.ts', import.meta.url)),
+      'utf-8',
+    )
+
+    // CSS 里同名变量有两处声明：:root 默认 0px + [data-platform="win32"] 覆盖 56px。
+    // 守卫目标是后者（win32 生效值）；取全部匹配中的最大值即平台覆盖值。
+    const cssValues = [...css.matchAll(/--titlebar-gutter-top:\s*(\d+)px/g)].map((m) => Number(m[1]))
+    const tsMatch = ts.match(/const TITLE_BAR_HEIGHT = (\d+)/)
+
+    expect(cssValues.length).toBeGreaterThan(0)
+    expect(tsMatch).not.toBeNull()
+
+    expect(Math.max(...cssValues)).toBe(Number(tsMatch?.[1]))
+  })
+})

--- a/src/components/workbench/AgentPanel.test.tsx
+++ b/src/components/workbench/AgentPanel.test.tsx
@@ -69,6 +69,15 @@ describe('AgentPanel', () => {
     expect(html).toContain('[-webkit-app-region:no-drag]')
   })
 
+  test('pins the header actions to the card edge now that the caption band sits above the card', () => {
+    // 方案 A（上下分区）后 Agent 面板头部在 caption 带下方，右缘不再需要
+    // --titlebar-inset-right 让位——保留会把「新对话」按钮推离卡片右缘 145px（排版 bug）。
+    const source = readFileSync(fileURLToPath(new URL('./AgentPanel.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('pl-[0.875rem] pr-[0.875rem]')
+    expect(source).not.toContain('pr-[max(0.875rem,var(--titlebar-inset-right))]')
+  })
+
   test('does not show the task plan expansion control for ordinary tool activity', () => {
     const thread = ([
       {

--- a/src/components/workbench/AgentPanel.tsx
+++ b/src/components/workbench/AgentPanel.tsx
@@ -162,8 +162,10 @@ export function AgentPanelContent({
 
   return (
     <section className="relative flex h-full min-h-0 flex-col overflow-hidden bg-workspace">
+      {/* 方案 A（上下分区）后本头部位于 caption 带下方，右缘不再需要
+          --titlebar-inset-right 让位——保留会把「新对话」按钮推离卡片右缘 145px。 */}
       <header
-        className="relative z-20 flex h-14 shrink-0 items-center justify-between gap-3 border border-border border-x-0 border-t-0 bg-workspace pl-[0.875rem] pr-[max(0.875rem,var(--titlebar-inset-right))] py-2.5 [-webkit-app-region:drag]"
+        className="relative z-20 flex h-14 shrink-0 items-center justify-between gap-3 border border-border border-x-0 border-t-0 bg-workspace pl-[0.875rem] pr-[0.875rem] py-2.5 [-webkit-app-region:drag]"
         data-agent-panel-titlebar="true"
       >
         <div className="flex min-w-0 items-center gap-2">

--- a/src/components/workbench/AgentPanel.tsx
+++ b/src/components/workbench/AgentPanel.tsx
@@ -163,7 +163,7 @@ export function AgentPanelContent({
   return (
     <section className="relative flex h-full min-h-0 flex-col overflow-hidden bg-workspace">
       <header
-        className="relative z-20 flex h-14 shrink-0 items-center justify-between gap-3 border border-border border-x-0 border-t-0 bg-workspace px-3.5 py-2.5 [-webkit-app-region:drag]"
+        className="relative z-20 flex h-14 shrink-0 items-center justify-between gap-3 border border-border border-x-0 border-t-0 bg-workspace pl-[0.875rem] pr-[max(0.875rem,var(--titlebar-inset-right))] py-2.5 [-webkit-app-region:drag]"
         data-agent-panel-titlebar="true"
       >
         <div className="flex min-w-0 items-center gap-2">

--- a/src/components/workbench/CharacterChatBoard.test.tsx
+++ b/src/components/workbench/CharacterChatBoard.test.tsx
@@ -185,7 +185,7 @@ describe('CharacterChatBoardView', () => {
     const component = source()
 
     expect(dataClass(html, 'data-character-chat-avatar="true"')).toContain('rounded-full')
-    expect(component).toContain("const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace px-[18px] py-2'")
+    expect(component).toContain("const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[max(18px,var(--titlebar-inset-right))] py-2'")
     expect(component).toContain('data-character-chat-profile-titlebar')
     expect(component).toContain('data-character-chat-profile-avatar="true"')
     expect(component).toContain('rounded-full border border-brand-border')

--- a/src/components/workbench/CharacterChatBoard.test.tsx
+++ b/src/components/workbench/CharacterChatBoard.test.tsx
@@ -185,7 +185,7 @@ describe('CharacterChatBoardView', () => {
     const component = source()
 
     expect(dataClass(html, 'data-character-chat-avatar="true"')).toContain('rounded-full')
-    expect(component).toContain("const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[max(18px,var(--titlebar-inset-right))] py-2'")
+    expect(component).toContain("const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[18px] py-2'")
     expect(component).toContain('data-character-chat-profile-titlebar')
     expect(component).toContain('data-character-chat-profile-avatar="true"')
     expect(component).toContain('rounded-full border border-brand-border')

--- a/src/components/workbench/CharacterChatBoard.tsx
+++ b/src/components/workbench/CharacterChatBoard.tsx
@@ -33,7 +33,8 @@ import { onCharacterChatEvent, readCharacterChatProfiles, saveCharacterChatProfi
 import type { CharacterChatMessage, CharacterContact } from '@shared/types/character-chat'
 
 const BOARD_HEADER_CLASS = 'flex shrink-0 items-center gap-2 border-b border-border px-5 py-4'
-const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[max(18px,var(--titlebar-inset-right))] py-2'
+// 方案 A（上下分区）后聊天卡在 caption 带下方，右缘不再需要 --titlebar-inset-right 让位。
+const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[18px] py-2'
 const PROFILE_DRAWER_TRANSITION: Transition = { duration: 0.18, ease: [0.22, 1, 0.36, 1] }
 // 右侧滑出抽屉容器（「角色资料」与「关于你」共用，统一宽度/阴影/动画，避免重复造轮子）。
 const DRAWER_BACKDROP_CLASS = 'absolute inset-0 z-10 cursor-default bg-transparent'

--- a/src/components/workbench/CharacterChatBoard.tsx
+++ b/src/components/workbench/CharacterChatBoard.tsx
@@ -33,7 +33,7 @@ import { onCharacterChatEvent, readCharacterChatProfiles, saveCharacterChatProfi
 import type { CharacterChatMessage, CharacterContact } from '@shared/types/character-chat'
 
 const BOARD_HEADER_CLASS = 'flex shrink-0 items-center gap-2 border-b border-border px-5 py-4'
-const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace px-[18px] py-2'
+const CHAT_PANEL_HEADER_CLASS = 'min-h-[61px] justify-between bg-workspace pl-[18px] pr-[max(18px,var(--titlebar-inset-right))] py-2'
 const PROFILE_DRAWER_TRANSITION: Transition = { duration: 0.18, ease: [0.22, 1, 0.36, 1] }
 // 右侧滑出抽屉容器（「角色资料」与「关于你」共用，统一宽度/阴影/动画，避免重复造轮子）。
 const DRAWER_BACKDROP_CLASS = 'absolute inset-0 z-10 cursor-default bg-transparent'

--- a/src/components/workbench/MemoryGraphView.test.tsx
+++ b/src/components/workbench/MemoryGraphView.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -81,17 +83,24 @@ describe('MemoryGraphView', () => {
     expect(html).toContain('aria-label="全屏查看星图"')
   })
 
-  test('keeps the fullscreen toggle clear of the Windows caption buttons', () => {
-    // 记忆星图是全宽板块（卡片右缘≈窗口右缘，全屏态更是贴边），右上角按钮只退 right-3
-    // 会直接压进 min/max/close 的 caption 区。让位量走 --titlebar-inset-right，
-    // main.tsx 用 WCO API 实测宽度覆盖，150px 回退值兜底。
+  test('positions the fullscreen toggle by mode: card edge normally, clear of caption when fullscreen', () => {
+    // 方案 A（上下分区）后普通态卡片在 caption 带下方，按钮贴卡片右缘（right-3）即可——
+    // 固定带 inset 会把按钮无辜推离右缘 145px。全屏态 fixed inset-0 盖住整个窗口
+    // （含 caption 带），仍须给 min/max/close 让位（WCO 实测宽度覆盖，150px 回退兜底）。
     const html = renderToStaticMarkup(
       <TooltipProvider>
         <MemoryGraphView projectPath="/p" initialGraph={populatedGraph} />
       </TooltipProvider>,
     )
+    const source = readFileSync(fileURLToPath(new URL('./MemoryGraphView.tsx', import.meta.url)), 'utf-8')
 
-    expect(html).toContain('right-[calc(var(--titlebar-inset-right)+0.75rem)]')
+    // 普通态：贴卡片右缘
+    expect(html).toContain('right-3')
+    expect(html).not.toContain('right-[calc(var(--titlebar-inset-right)+0.75rem)]')
+    // 全屏态：源码里保留 caption 让位条件分支
+    expect(source).toContain(
+      "fullscreen ? 'right-[calc(var(--titlebar-inset-right)+0.75rem)]' : 'right-3'",
+    )
   })
 
   test('keeps the graph frame out of the frameless window drag region', () => {

--- a/src/components/workbench/MemoryGraphView.test.tsx
+++ b/src/components/workbench/MemoryGraphView.test.tsx
@@ -81,6 +81,19 @@ describe('MemoryGraphView', () => {
     expect(html).toContain('aria-label="全屏查看星图"')
   })
 
+  test('keeps the fullscreen toggle clear of the Windows caption buttons', () => {
+    // 记忆星图是全宽板块（卡片右缘≈窗口右缘，全屏态更是贴边），右上角按钮只退 right-3
+    // 会直接压进 min/max/close 的 caption 区。让位量走 --titlebar-inset-right，
+    // main.tsx 用 WCO API 实测宽度覆盖，150px 回退值兜底。
+    const html = renderToStaticMarkup(
+      <TooltipProvider>
+        <MemoryGraphView projectPath="/p" initialGraph={populatedGraph} />
+      </TooltipProvider>,
+    )
+
+    expect(html).toContain('right-[calc(var(--titlebar-inset-right)+0.75rem)]')
+  })
+
   test('keeps the graph frame out of the frameless window drag region', () => {
     // 真机走查抓到：全屏后右上角退出按钮点不动。窗口是 titleBarStyle:'hidden'，Agent 面板
     // 头部那条 h-14 拖拽带横在窗口右上角；拖拽区按几何计算，上层不声明 no-drag 就挖不掉

--- a/src/components/workbench/MemoryGraphView.tsx
+++ b/src/components/workbench/MemoryGraphView.tsx
@@ -161,9 +161,14 @@ export function MemoryGraphView({
 
         <MemoryGraphSummaryHud summary={summary} />
 
-        {/* 右上角按钮让位 Windows caption（记忆星图是全宽板块，卡片右缘≈窗口右缘；
-            全屏态 fixed inset-0 更是贴到窗口边——无让位时按钮会被 min/max/close 压住）。 */}
-        <div className="absolute right-[calc(var(--titlebar-inset-right)+0.75rem)] top-3 z-10">
+        {/* 右上角按钮：普通态卡片在 caption 带下方（方案 A），贴卡片右缘即可；
+            全屏态 fixed inset-0 盖住整个窗口（含 caption 带），须给 min/max/close 让位。 */}
+        <div
+          className={cn(
+            'absolute top-3 z-10',
+            fullscreen ? 'right-[calc(var(--titlebar-inset-right)+0.75rem)]' : 'right-3',
+          )}
+        >
           <IconTooltip label={fullscreen ? '退出全屏' : '全屏查看星图'}>
             <Button
               variant="ghost"

--- a/src/components/workbench/MemoryGraphView.tsx
+++ b/src/components/workbench/MemoryGraphView.tsx
@@ -161,7 +161,9 @@ export function MemoryGraphView({
 
         <MemoryGraphSummaryHud summary={summary} />
 
-        <div className="absolute right-3 top-3 z-10">
+        {/* 右上角按钮让位 Windows caption（记忆星图是全宽板块，卡片右缘≈窗口右缘；
+            全屏态 fixed inset-0 更是贴到窗口边——无让位时按钮会被 min/max/close 压住）。 */}
+        <div className="absolute right-[calc(var(--titlebar-inset-right)+0.75rem)] top-3 z-10">
           <IconTooltip label={fullscreen ? '退出全屏' : '全屏查看星图'}>
             <Button
               variant="ghost"

--- a/src/components/workbench/WorkbenchPrimarySidebar.tsx
+++ b/src/components/workbench/WorkbenchPrimarySidebar.tsx
@@ -414,7 +414,7 @@ export function WorkbenchPrimarySidebar({
       data-workbench-primary-sidebar="true"
     >
       <div
-        className="flex h-14 shrink-0 items-center justify-end gap-2 pl-[112px] pr-3 [-webkit-app-region:drag]"
+        className="flex h-14 shrink-0 items-center justify-end gap-2 pl-[var(--titlebar-inset-left)] pr-3 [-webkit-app-region:drag]"
         data-workbench-sidebar-headbar="true"
       >
         <IconTooltip label="返回图书馆">

--- a/src/components/workbench/WorkbenchStage.test.tsx
+++ b/src/components/workbench/WorkbenchStage.test.tsx
@@ -49,7 +49,9 @@ describe('WorkbenchStage', () => {
     )
 
     expect(html).toContain('data-workbench-stage="true"')
-    expect(html).toContain('h-full min-h-0 min-w-0 flex-1 py-3 pl-0 pr-3')
+    // 顶部 padding 消费 --titlebar-gutter-top（win32 上下分区：卡片从 caption 带下开始）
+    expect(html).toContain('pt-[max(0.75rem,var(--titlebar-gutter-top))] pb-3 pl-0 pr-3')
+    expect(html).not.toContain('flex-1 py-3 pl-0 pr-3')
     expect(html).not.toContain('flex-1 p-3 pt-0')
     expect(html).toContain('data-workbench-stage-grid="true"')
     expect(html).toContain('minmax(0, 1fr) 8px 460px')

--- a/src/components/workbench/WorkbenchStage.tsx
+++ b/src/components/workbench/WorkbenchStage.tsx
@@ -416,7 +416,9 @@ export function WorkbenchStage({
 
   return (
     <main
-      className="h-full min-h-0 min-w-0 flex-1 py-3 pl-0 pr-3"
+      // 顶部 padding 平台感知（方案 A 上下分区）：win32 下舞台卡片从 caption 带（56px）下方
+      // 开始，caption 按钮悬于 canvas gutter，不再压在 Agent 面板头部白底上（视觉混排根因）。
+      className="h-full min-h-0 min-w-0 flex-1 pt-[max(0.75rem,var(--titlebar-gutter-top))] pb-3 pl-0 pr-3"
       data-workbench-stage="true"
       data-section-id={selectedSectionId}
       data-tab-id={activeTab?.id ?? undefined}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -31,6 +31,9 @@ function getSystemTheme(): EffectiveTheme {
 
 function applyTheme(effective: EffectiveTheme): void {
   document.documentElement.dataset.theme = effective
+  // Windows 标题栏 overlay 符号颜色跟主题（浅色 UI 深符号 / 深色 UI 白符号）。
+  // 非 Electron 环境（单测/纯 web）无 window.electron，可选链静默跳过；主进程侧仅 win32 生效。
+  window.electron?.setTitleBarOverlaySymbolColor?.(effective === 'dark' ? '#ffffff' : '#3f3f46')
 }
 
 /**

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -33,7 +33,8 @@ function applyTheme(effective: EffectiveTheme): void {
   document.documentElement.dataset.theme = effective
   // Windows 标题栏 overlay 符号颜色跟主题（浅色 UI 深符号 / 深色 UI 白符号）。
   // 非 Electron 环境（单测/纯 web）无 window.electron，可选链静默跳过；主进程侧仅 win32 生效。
-  window.electron?.setTitleBarOverlaySymbolColor?.(effective === 'dark' ? '#ffffff' : '#3f3f46')
+  // catch：invoke 返回 Promise，handler 缺失/窗口竞态时避免 unhandled rejection（PR #26 review ⑤）。
+  window.electron?.setTitleBarOverlaySymbolColor?.(effective === 'dark' ? '#ffffff' : '#3f3f46').catch(() => {})
 }
 
 /**

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -15,4 +15,22 @@ describe('main entry titlebar inset hardening', () => {
     expect(source).toContain("'geometrychange', syncWin32TitlebarInset")
     expect(source).toContain("'resize', syncWin32TitlebarInset")
   })
+
+  test('non-Electron fallback treats non-Mac as linux (no phantom caption insets)', () => {
+    // globals.css 语义：非 mac/win32 平台让位为 0。浏览器直开 dev server 时回退 'win32'
+    // 会凭空多出 150px 右让位与 56px 顶 gutter（PR #26 review ③）。Electron 下 preload
+    // 恒给出真实 platform，此回退只在纯浏览器场景生效。
+    const source = readFileSync(fileURLToPath(new URL('./main.tsx', import.meta.url)), 'utf-8')
+    // 剥掉块注释与行注释后断言：回退链只有 darwin/linux 两种赋值；'win32' 仅允许
+    // 出现在 WCO 探针守卫的 !== 比较里（比较不产生让位），禁止作为回退值。
+    const codeOnly = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+    expect(codeOnly).toMatch(/\?\s*'darwin'/)
+    expect(codeOnly).toMatch(/:\s*'linux'/)
+    // 禁止 win32 作为回退/赋值值（?= 回退、: 三元分支、= 赋值；lookbehind 排除 !== / !=
+    // 比较形态——!== 的第二个 = 前面是第一个 = 而非 !，故须同时排除 = 与 !）。
+    // WCO 探针守卫的 !== 'win32' 是比较、不产生让位，合法保留。
+    expect(codeOnly).not.toMatch(/\?\s*'win32'/)
+    expect(codeOnly).not.toMatch(/(?<![!=]):\s*'win32'/)
+    expect(codeOnly).not.toMatch(/(?<![!=])=\s*'win32'/)
+  })
 })

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'bun:test'
+
+describe('main entry titlebar inset hardening', () => {
+  test('measures the Windows caption width at runtime instead of trusting the 150px fallback', () => {
+    // 125%/150% 缩放下原生 caption 按钮比 150px 宽，硬编码预留会让顶栏按钮被压住
+    // （Windows 适配盲区，2026-08-16）。入口必须用 Window Controls Overlay 实测
+    // caption 宽度写入内联 CSS 变量覆盖回退值，并跟随 geometrychange/resize 同步。
+    const source = readFileSync(fileURLToPath(new URL('./main.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('function syncWin32TitlebarInset')
+    expect(source).toContain('getTitlebarAreaRect()')
+    expect(source).toContain("setProperty('--titlebar-inset-right'")
+    expect(source).toContain("'geometrychange', syncWin32TitlebarInset")
+    expect(source).toContain("'resize', syncWin32TitlebarInset")
+  })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,19 @@ import './styles/globals.css'
 
 initTheme()
 
+// 平台感知布局：把主进程平台写到 <html data-platform>，顶栏据此适配
+// mac 红绿灯（左侧预留）/ Windows caption 按钮（右侧预留）。
+// window.electron.platform 为准（preload 暴露），非 Electron 环境回退 navigator。
+if (typeof document !== 'undefined') {
+  const platform =
+    typeof window !== 'undefined' && window.electron?.platform
+      ? window.electron.platform
+      : typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
+        ? 'darwin'
+        : 'win32'
+  document.documentElement.dataset.platform = platform
+}
+
 // 非 mac 平台加载渐变 fallback 背景（mac 用 vibrancy 透到桌面）
 if (typeof navigator !== 'undefined' && !/Mac/.test(navigator.platform)) {
   await import('./styles/fallback-bg.css')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,16 @@ initTheme()
 
 // 平台感知布局：把主进程平台写到 <html data-platform>，顶栏据此适配
 // mac 红绿灯（左侧预留）/ Windows caption 按钮（右侧预留）。
-// window.electron.platform 为准（preload 暴露），非 Electron 环境回退 navigator。
+// window.electron.platform 为准（preload 暴露）；非 Electron 环境只识别 Mac——
+// 其余一律回退 'linux'（globals.css 语义：无自绘按钮，让位为 0）。此前回退 'win32'
+// 会让浏览器直开 dev server 时凭空多出 150px 右让位与 56px 顶 gutter（PR #26 review ③）。
 if (typeof document !== 'undefined') {
   const platform =
     typeof window !== 'undefined' && window.electron?.platform
       ? window.electron.platform
       : typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
         ? 'darwin'
-        : 'win32'
+        : 'linux'
   document.documentElement.dataset.platform = platform
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,39 @@ if (typeof document !== 'undefined') {
   document.documentElement.dataset.platform = platform
 }
 
+// Windows DPI 加固：CSS 里的 --titlebar-inset-right: 150px 是按 100% 缩放目测的，
+// 客户机常为 125%/150%，原生 caption 按钮实际宽度（DIP）可能超过 150px——硬编码
+// 预留不够时顶栏按钮会被 min/max/close 压住（Windows 适配盲区，2026-08-16）。
+// Window Controls Overlay API 给出拖拽区（不含 caption 按钮）的精确几何：
+//   caption 宽 = innerWidth - (titlebarArea.x + titlebarArea.width)
+// 实测值 + 8px 呼吸位写入内联 CSS 变量（内联优先级高于 globals.css 的 150px 回退）。
+// 监听 geometrychange（最大化/还原/DPI 变化）与 resize（innerWidth 变化需重算）持续同步；
+// API 不可用 / 返回异常值（挂载初期可能全零）时静默保留 150px 回退，不抛错。
+interface WindowControlsOverlayLike extends EventTarget {
+  visible: boolean
+  getTitlebarAreaRect(): { x: number; width: number }
+}
+
+function syncWin32TitlebarInset() {
+  if (document.documentElement.dataset.platform !== 'win32') return
+  const overlay = (navigator as Navigator & { windowControlsOverlay?: WindowControlsOverlayLike })
+    .windowControlsOverlay
+  if (!overlay?.visible) return
+  const rect = overlay.getTitlebarAreaRect()
+  const captionWidth = window.innerWidth - rect.x - rect.width
+  if (!Number.isFinite(captionWidth) || captionWidth <= 0 || captionWidth >= 400) return
+  document.documentElement.style.setProperty('--titlebar-inset-right', `${Math.ceil(captionWidth) + 8}px`)
+}
+
+if (typeof window !== 'undefined') {
+  syncWin32TitlebarInset()
+  window.addEventListener('load', syncWin32TitlebarInset)
+  window.addEventListener('resize', syncWin32TitlebarInset)
+  const overlay = (navigator as Navigator & { windowControlsOverlay?: WindowControlsOverlayLike })
+    .windowControlsOverlay
+  overlay?.addEventListener?.('geometrychange', syncWin32TitlebarInset)
+}
+
 // 非 mac 平台加载渐变 fallback 背景（mac 用 vibrancy 透到桌面）
 if (typeof navigator !== 'undefined' && !/Mac/.test(navigator.platform)) {
   await import('./styles/fallback-bg.css')

--- a/src/routes/settings.test.tsx
+++ b/src/routes/settings.test.tsx
@@ -39,7 +39,8 @@ describe('SettingsRoute', () => {
     expect(html).toContain('data-settings-sidebar="true"')
     expect(html).toContain('w-64')
     expect(html).toContain('data-settings-stage="true"')
-    expect(html).toContain('min-h-0 min-w-0 flex-1 p-3')
+    // 顶部 padding 消费 --titlebar-gutter-top（win32 上下分区：内容卡从 caption 带下开始）
+    expect(html).toContain('min-h-0 min-w-0 flex-1 px-3 pb-3 pt-[max(0.75rem,var(--titlebar-gutter-top))]')
     expect(html).toContain('data-settings-content-shell="true"')
     expect(html).toContain('rounded-workspace border border-border bg-workspace')
     expect(html).toContain('data-settings-content-titlebar="true"')

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -615,7 +615,9 @@ export function SettingsRoute() {
         returnTo={returnTo}
       />
 
-      <main className="min-h-0 min-w-0 flex-1 p-3" data-settings-stage="true">
+      {/* 顶部 padding 平台感知：win32 下内容卡从 caption 带下方开始（方案 A 上下分区，
+          与工作台舞台同构；左栏保持通顶）。 */}
+      <main className="min-h-0 min-w-0 flex-1 px-3 pb-3 pt-[max(0.75rem,var(--titlebar-gutter-top))]" data-settings-stage="true">
         <section
           className={`${WORKSPACE_SHELL_CLASS} flex h-full min-h-0 flex-col overflow-hidden`}
           data-settings-content-shell="true"

--- a/src/routes/workbench.test.tsx
+++ b/src/routes/workbench.test.tsx
@@ -10,6 +10,15 @@ describe('WorkbenchRoute', () => {
     expect(source).not.toContain('<CheckpointResumeBanner')
   })
 
+  test('keeps the stale-load recovery banner clear of the Windows caption buttons', () => {
+    // stale 横幅 absolute 悬浮在舞台上（含 Agent 栏顶部），右端若只退 right-4 会伸进
+    // min/max/close 的 caption 区——再进入项目刷新失败时横幅被窗口按钮压住（Windows 适配盲区）。
+    const source = readFileSync(fileURLToPath(new URL('./workbench.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('right-[max(1rem,var(--titlebar-inset-right))]')
+    expect(source).not.toContain('absolute left-4 right-4 top-4')
+  })
+
   test('uses one pixel-based resizable workbench grid for sidebar content and Agent widths', () => {
     const source = readFileSync(fileURLToPath(new URL('./workbench.tsx', import.meta.url)), 'utf-8')
 

--- a/src/routes/workbench.test.tsx
+++ b/src/routes/workbench.test.tsx
@@ -10,13 +10,13 @@ describe('WorkbenchRoute', () => {
     expect(source).not.toContain('<CheckpointResumeBanner')
   })
 
-  test('keeps the stale-load recovery banner clear of the Windows caption buttons', () => {
-    // stale 横幅 absolute 悬浮在舞台上（含 Agent 栏顶部），右端若只退 right-4 会伸进
-    // min/max/close 的 caption 区——再进入项目刷新失败时横幅被窗口按钮压住（Windows 适配盲区）。
+  test('keeps the stale-load recovery banner below the Windows caption band', () => {
+    // 方案 A 后横幅 top 消费 --titlebar-gutter-top（win32 56px+呼吸位）压到 caption 带下方，
+    // 右缘不再需要 --titlebar-inset-right 让位（保留会把横幅右端无辜缩短 145px）。
     const source = readFileSync(fileURLToPath(new URL('./workbench.tsx', import.meta.url)), 'utf-8')
 
-    expect(source).toContain('right-[max(1rem,var(--titlebar-inset-right))]')
-    expect(source).toContain('top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))]')
+    expect(source).toContain('absolute left-4 right-4 top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))]')
+    expect(source).not.toContain('right-[max(1rem,var(--titlebar-inset-right))]')
     expect(source).not.toContain('absolute left-4 right-4 top-4')
   })
 

--- a/src/routes/workbench.test.tsx
+++ b/src/routes/workbench.test.tsx
@@ -16,7 +16,17 @@ describe('WorkbenchRoute', () => {
     const source = readFileSync(fileURLToPath(new URL('./workbench.tsx', import.meta.url)), 'utf-8')
 
     expect(source).toContain('right-[max(1rem,var(--titlebar-inset-right))]')
+    expect(source).toContain('top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))]')
     expect(source).not.toContain('absolute left-4 right-4 top-4')
+  })
+
+  test('drops the stage cards below the Windows caption band (win32 gutter)', () => {
+    // 方案 A 上下分区：win32 下舞台/状态卡顶部 padding 消费 --titlebar-gutter-top（56px），
+    // caption 按钮悬于 canvas gutter 上，不再压 Agent 面板头部白底（视觉混排根因）。
+    const source = readFileSync(fileURLToPath(new URL('./workbench.tsx', import.meta.url)), 'utf-8')
+
+    expect(source).toContain('pt-[max(0px,var(--titlebar-gutter-top))]')
+    expect(source).not.toContain('flex-1 p-3 pt-0')
   })
 
   test('uses one pixel-based resizable workbench grid for sidebar content and Agent widths', () => {

--- a/src/routes/workbench.tsx
+++ b/src/routes/workbench.tsx
@@ -392,9 +392,11 @@ export function WorkbenchRoute() {
         data-workbench-content-panel="true"
       >
         {stage}
+        {/* stale 横幅横跨整个舞台（含 Agent 栏），右端必须给 Windows caption 按钮让位，
+            否则再进入项目刷新失败时，提示会钻到 min/max/close 底下（Windows 适配盲区）。 */}
         {workbenchLoad.status === 'stale' && workbenchLoad.issue ? (
           <LoadRecoveryNotice
-            className="absolute left-4 right-4 top-4 z-30 shadow-[var(--shadow-floating)]"
+            className="absolute left-4 right-[max(1rem,var(--titlebar-inset-right))] top-4 z-30 shadow-[var(--shadow-floating)]"
             compact
             from={`/workbench?${searchParams.toString()}`}
             issue={workbenchLoad.issue}

--- a/src/routes/workbench.tsx
+++ b/src/routes/workbench.tsx
@@ -49,7 +49,8 @@ function WorkbenchRouteState({
   title: string
 }) {
   return (
-    <main className="h-full min-h-0 min-w-0 flex-1 p-3 pt-0">
+    // 顶部 padding 平台感知：win32 下让状态卡也从 caption 带下方开始（方案 A 上下分区）。
+    <main className="h-full min-h-0 min-w-0 flex-1 p-3 pt-[max(0px,var(--titlebar-gutter-top))]">
       <div className={`${WORKSPACE_STATE_CLASS} flex h-full min-h-0 items-center justify-center p-6`}>
         <div className="max-w-sm text-center">
           <Icon className="mx-auto mb-3 size-5 text-hint-foreground" />
@@ -393,10 +394,11 @@ export function WorkbenchRoute() {
       >
         {stage}
         {/* stale 横幅横跨整个舞台（含 Agent 栏），右端必须给 Windows caption 按钮让位，
-            否则再进入项目刷新失败时，提示会钻到 min/max/close 底下（Windows 适配盲区）。 */}
+            否则再进入项目刷新失败时，提示会钻到 min/max/close 底下（Windows 适配盲区）。
+            top 同理：横幅 absolute 锚在 content panel（y=0 起），win32 下压到 caption 带下方再出现。 */}
         {workbenchLoad.status === 'stale' && workbenchLoad.issue ? (
           <LoadRecoveryNotice
-            className="absolute left-4 right-[max(1rem,var(--titlebar-inset-right))] top-4 z-30 shadow-[var(--shadow-floating)]"
+            className="absolute left-4 right-[max(1rem,var(--titlebar-inset-right))] top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))] z-30 shadow-[var(--shadow-floating)]"
             compact
             from={`/workbench?${searchParams.toString()}`}
             issue={workbenchLoad.issue}

--- a/src/routes/workbench.tsx
+++ b/src/routes/workbench.tsx
@@ -393,12 +393,11 @@ export function WorkbenchRoute() {
         data-workbench-content-panel="true"
       >
         {stage}
-        {/* stale 横幅横跨整个舞台（含 Agent 栏），右端必须给 Windows caption 按钮让位，
-            否则再进入项目刷新失败时，提示会钻到 min/max/close 底下（Windows 适配盲区）。
-            top 同理：横幅 absolute 锚在 content panel（y=0 起），win32 下压到 caption 带下方再出现。 */}
+        {/* stale 横幅横跨整个舞台（含 Agent 栏）。方案 A 后横幅整体在 caption 带下方
+            （top 消费 --titlebar-gutter-top），右缘不再需要 --titlebar-inset-right 让位。 */}
         {workbenchLoad.status === 'stale' && workbenchLoad.issue ? (
           <LoadRecoveryNotice
-            className="absolute left-4 right-[max(1rem,var(--titlebar-inset-right))] top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))] z-30 shadow-[var(--shadow-floating)]"
+            className="absolute left-4 right-4 top-[max(1rem,calc(var(--titlebar-gutter-top)+0.25rem))] z-30 shadow-[var(--shadow-floating)]"
             compact
             from={`/workbench?${searchParams.toString()}`}
             issue={workbenchLoad.issue}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -89,6 +89,25 @@
 
 @custom-variant dark (&:is([data-theme="dark"] *));
 
+/*
+ * 平台感知顶栏预留（main.tsx 把主进程平台写到 <html data-platform>）：
+ * - darwin：左上角红绿灯按钮区，顶栏左内容需让位（约 112px，与 trafficLightPosition x:18 匹配）
+ * - win32：右上角系统 caption 按钮（最小化/最大化/关闭，约 138px 宽），顶栏右内容需让位
+ * 其余平台无自绘按钮，两侧均为 0。顶栏组件用 pl/pr-[var(--titlebar-inset-left/right)] 消费。
+ */
+:root {
+  --titlebar-inset-left: 0px;
+  --titlebar-inset-right: 0px;
+}
+
+[data-platform="darwin"] {
+  --titlebar-inset-left: 112px;
+}
+
+[data-platform="win32"] {
+  --titlebar-inset-right: 150px;
+}
+
 :root,
 [data-theme="light"] {
   color-scheme: light;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -96,10 +96,16 @@
  *   注意 150px 是 100% 缩放下的回退值；main.tsx 会用 Window Controls Overlay API
  *   实测 caption 宽度写内联变量覆盖它（125%/150% 缩放下按钮更宽，硬编码会漏）。
  * 其余平台无自绘按钮，两侧均为 0。顶栏组件用 pl/pr-[var(--titlebar-inset-left/right)] 消费。
+ *
+ * 上下分区（win32 专属，2026-08-16 方案 A）：caption 按钮与内容分带——舞台卡片顶部
+ * padding 消费 --titlebar-gutter-top，卡片从 caption 带下方开始，caption 悬于 canvas
+ * gutter 上（与 mac「红绿灯悬于侧边栏」的视觉语言对等）。侧边栏/左栏保持通顶。
+ * 取值 56px = TITLE_BAR_HEIGHT（window.ts 的 titleBarOverlay.height）。
  */
 :root {
   --titlebar-inset-left: 0px;
   --titlebar-inset-right: 0px;
+  --titlebar-gutter-top: 0px;
 }
 
 [data-platform="darwin"] {
@@ -108,6 +114,7 @@
 
 [data-platform="win32"] {
   --titlebar-inset-right: 150px;
+  --titlebar-gutter-top: 56px;
 }
 
 :root,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -92,7 +92,9 @@
 /*
  * 平台感知顶栏预留（main.tsx 把主进程平台写到 <html data-platform>）：
  * - darwin：左上角红绿灯按钮区，顶栏左内容需让位（约 112px，与 trafficLightPosition x:18 匹配）
- * - win32：右上角系统 caption 按钮（最小化/最大化/关闭，约 138px 宽），顶栏右内容需让位
+ * - win32：右上角系统 caption 按钮（最小化/最大化/关闭）。
+ *   注意 150px 是 100% 缩放下的回退值；main.tsx 会用 Window Controls Overlay API
+ *   实测 caption 宽度写内联变量覆盖它（125%/150% 缩放下按钮更宽，硬编码会漏）。
  * 其余平台无自绘按钮，两侧均为 0。顶栏组件用 pl/pr-[var(--titlebar-inset-left/right)] 消费。
  */
 :root {


### PR DESCRIPTION
## 改动概述

Windows 顶栏与系统 caption 按钮的混排问题（#11）：caption 按钮此前悬浮在 Agent 面板头部白底上、与面板自身按钮视觉混成一团；125%/150% DPI 下硬编码让位宽度还会漏。本 PR 用「上下分区 + WCO 运行时实测」机制解决，mac 零影响。

## 为什么要做

1. **不改会怎样**：Windows 用户（#25 目标用户）的工作台顶栏视觉混乱——两组小圆按钮读成重叠，且高 DPI 下功能性漏让位（stale 横幅钻到 min/max/close 底下）。
2. **长期成本与解除条件**：新增两个 CSS 变量（`--titlebar-inset-right` 回退值 + `--titlebar-gutter-top`）与 `<html data-platform>` 约定，均为平台感知布局长期机制；WCO 实测使 150px 硬编码降级为回退值（Electron 移除 titleBarOverlay 时可整体退役）。
3. **更小的解法**：只加大右侧 padding（间隙 8→20px）不解决"按钮悬在卡片头上"的混排根因；上下分区是与你「红绿灯悬于侧边栏」视觉语言对等的机制层方案，消费端取舍按你在 #11 的说明可在 review 中再商量。

## 变更范围

按 #11 讨论的 4 个提交提取（cherry-pick 自 fork 分支，含全部源码断言防回归）：

- `e7f34aa` 平台感知顶栏布局：preload 暴露 `platform` → `<html data-platform>`；`--titlebar-inset-left/right`（win32 150px / darwin 112px / 其余 0）；设置页通知按钮与关闭按钮重叠修复；overlay 符号色跟主题
- `3e32e54` caption 让位补盲区 + WCO 实测：`navigator.windowControlsOverlay.getTitlebarAreaRect()` 实测 caption 宽 + 8px 呼吸位写内联变量，监听 `geometrychange`/`resize`；CSS 150px 降级为回退值；stale 恢复横幅/记忆星图全屏态让位
- `f707b7d` 方案 A 上下分区：`--titlebar-gutter-top`（win32 = 56px = TITLE_BAR_HEIGHT，其余 0），工作台舞台/加载态卡/设置页内容卡顶部 padding 消费——卡片从 caption 带下方开始，caption 悬于 canvas gutter；侧边栏保持通顶（同 mac）；AppShell navEnd 呼吸位 8→20px
- `90cd7ca` 收尾：退役卡片内水平让位（按钮回卡片右缘）
- `53aa579` 契约件补齐：`ElectronApi` 的 `platform`/`setTitleBarOverlaySymbolColor` 类型声明与 IPC handler（提取时剥离 GPU 线无关引用）

## 测试

- `typecheck` ✅；`check:architecture` ✅（0 violation）；全量测试 2907 pass / 107 fail——107 项为 Windows 本机预存环境失败（mac 打包脚本类/StateChangesLedger 超时类），与 main 基线逐项一致，零回归；本 PR 新增 AppShell/main/WorkbenchStage/settings/workbench 源码断言
- `check:design` 本机红 = #24 已知平台缺陷（brand asset guard 路径分隔符问题，与本 PR 无关，未触碰任何 brand 文件）
- 真机实测数据见 #11 正文（100% DPI 前后对比表 + 4 图）；125%/150% 场景作者侧 Windows 实体机验收

Closes #11
