### PR TITLE
fix(agent): 子会话异常终止 fail-loud，不再被当成「正常但没说话」

### DIFF
--- a/electron/main/agent/runtime/adapters/pi/pi-event-mapper.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-event-mapper.test.ts
@@ -99,6 +99,25 @@ describe('mapPiMessageToAgentEvents', () => {
     ])
   })
 
+  test('Task 结果 details 带异常终态标记 → tool.failed（子会话异常终止，任务卡不谎报成功）', () => {
+    for (const [abnormalStop, error] of [
+      ['length', '子 agent 单次回复达到输出上限被截断，本次派发未完成，请重试或把任务拆小。'],
+      ['error', '子 agent 因模型或服务端错误异常终止，本次派发未完成。'],
+    ] as const) {
+      const events = mapPiMessageToAgentEvents(ctx, {
+        type: 'tool_execution_end',
+        toolCallId: 'task-1',
+        toolName: 'Task',
+        isError: false,
+        result: {
+          content: [{ type: 'text', text: '⚠️ 子 agent …' }],
+          details: { narracatSubagentAbnormalStop: abnormalStop },
+        },
+      })
+      expect(events).toEqual([{ type: 'tool.failed', runId: 'run-1', toolCallId: 'task-1', error, createdAt: ctx.createdAt }])
+    }
+  })
+
   test('message_end stopReason=error → run.failed（errorMessage 透传，含 provider 原始错误串）', () => {
     const events = mapPiMessageToAgentEvents(ctx, {
       type: 'message_end',

--- a/electron/main/agent/runtime/adapters/pi/pi-event-mapper.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-event-mapper.ts
@@ -25,6 +25,25 @@ export const PI_SUBAGENT_EVENT_MESSAGE_TYPE = 'narracat_pi_subagent_event'
 
 export const PI_SESSION_MESSAGE_TYPE = 'narracat_pi_session'
 
+/**
+ * 子会话异常终止（stopReason='length' / 'error'）时 Task 工具在结果 details 上打的标记。
+ * pi 的 AgentToolResult 没有 isError 字段，工具唯一的失败通道是 throw——但 throw 会连同已产出
+ * 部分与质量门反馈一起丢掉，于是走 details 侧信道分两路收口：交回模型的结果文本带 ⚠️ 前缀（主
+ * 会话据此确定性重派），交给 UI 的任务卡则映射成 tool.failed。
+ * 键名带 narracat 前缀避免与任何第三方工具的 details 撞名（本映射对全部工具生效）。
+ *
+ * UI 上的实际口径（别过度承诺）：tool.failed 复用工具级失败的既有通用呈现——执行过程流里逐项徽章
+ * 是「已跳过」+ 失败原因（展开可见），而不是「完成」；折叠态汇总行仍读作「执行过程已完成 · N 项
+ * （自动调整 M 次）」。汇总行那句是「工具级错误属自愈型瞬时事件」的既有产品决策
+ * （见 AgentProcessStream.tsx），子会话异常终止（烧掉数分钟与整章 token 的实质失败）是否该在
+ * 汇总行破例，留给产品单独决定，本刀不动（#29）。渲染端断言见
+ * src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx。
+ */
+export type PiSubagentAbnormalStop = 'length' | 'error'
+export interface PiSubagentAbnormalStopDetails {
+  narracatSubagentAbnormalStop: PiSubagentAbnormalStop
+}
+
 /** 会话桥在持久化会话建立后首发的合成消息（切片⑦）：只供 adapter readSessionId 消费——
  * run-manager 借它把 session id 记进 sdkSessionsByThread（resume 消费面），不映射任何 AgentEvent。 */
 export interface PiSessionMessage {
@@ -49,6 +68,11 @@ const TOOL_FAILED_FALLBACK_TEXT = '工具调用失败'
 /** stopReason='length'（单次回复触输出上限被截断）fail-loud 文案：截断稿静默入库是写作链最坏
  * 路径，宁可失败重试（生产接线门前项①）。 */
 const LENGTH_TRUNCATED_ERROR_TEXT = '模型单次回复长度达到上限，本次运行已中止，请重试或把任务拆小。'
+/** 子会话异常终止时任务卡的失败文案：区分 length / error，事后能从落盘事件查出是哪一种。 */
+const SUBAGENT_ABNORMAL_STOP_ERROR_TEXT: Record<PiSubagentAbnormalStop, string> = {
+  length: '子 agent 单次回复达到输出上限被截断，本次派发未完成，请重试或把任务拆小。',
+  error: '子 agent 因模型或服务端错误异常终止，本次派发未完成。',
+}
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -141,18 +165,28 @@ function mapToolExecutionStart(context: RuntimeMapContext, message: UnknownRecor
   return [event]
 }
 
+/** Task 工具结果 details 上的子会话异常终态标记（无标记/非法值返回 undefined）。 */
+function readSubagentAbnormalStop(result: unknown): PiSubagentAbnormalStop | undefined {
+  if (!isRecord(result) || !isRecord(result.details)) return undefined
+  const value = result.details.narracatSubagentAbnormalStop
+  return value === 'length' || value === 'error' ? value : undefined
+}
+
 function mapToolExecutionEnd(context: RuntimeMapContext, message: UnknownRecord): AgentEvent[] {
   const toolCallId = readString(message, 'toolCallId')
   if (!toolCallId) return []
 
   const text = readToolResultText(message.result)
-  if (message.isError === true) {
+  // 子会话异常终止对 pi 是「工具正常返回」，只有 details 标记能揭穿——不认这一层，跑满几分钟却
+  // 什么都没干成的派发就会挂着「完成」徽章、失败原因一个字都不显示（#29）。
+  const abnormalStop = readSubagentAbnormalStop(message.result)
+  if (message.isError === true || abnormalStop) {
     return [
       {
         type: 'tool.failed',
         runId: context.runId,
         toolCallId,
-        error: text ?? TOOL_FAILED_FALLBACK_TEXT,
+        error: abnormalStop ? SUBAGENT_ABNORMAL_STOP_ERROR_TEXT[abnormalStop] : (text ?? TOOL_FAILED_FALLBACK_TEXT),
         createdAt: context.createdAt,
       },
     ]

--- a/electron/main/agent/runtime/adapters/pi/pi-subagent.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-subagent.test.ts
@@ -22,8 +22,8 @@ const definitions: Record<string, EngineAgentDefinition> = {
 }
 
 /** pi 0.73.1 的 assistant 收笔消息形态（本映射只取 content 里的 text 块）。 */
-function assistantMessageEnd(text: string): Record<string, unknown> {
-  return { type: 'message_end', message: { role: 'assistant', stopReason: 'stop', content: [{ type: 'text', text }] } }
+function assistantMessageEnd(text: string, stopReason = 'stop'): Record<string, unknown> {
+  return { type: 'message_end', message: { role: 'assistant', stopReason, content: [{ type: 'text', text }] } }
 }
 
 type FakeRunSession = CreateTaskToolArgs['runSession']
@@ -70,9 +70,10 @@ function runTool(
   toolCallId: string,
   params: Record<string, unknown>,
   signal?: AbortSignal,
-): Promise<{ content: Array<{ type: string; text?: string }> }> {
+): Promise<{ content: Array<{ type: string; text?: string }>; details?: unknown }> {
   return tool.execute(toolCallId, params as never, signal, undefined, {} as never) as Promise<{
     content: Array<{ type: string; text?: string }>
+    details?: unknown
   }>
 }
 
@@ -239,6 +240,46 @@ describe('createTaskTool 派发', () => {
     const { tool } = makeTaskTool({ runSession: makeScriptedSession([{ type: 'agent_start' }]).runSession })
     const result = await runTool(tool, 'tc-1', { subagent_type: 'chapter-writer', prompt: '写' })
     expect(result.content[0].text).toBe('（子 agent 未产出文本）')
+  })
+
+  test('子会话 stopReason=length：结果带截断说明并保留已产出部分，details 打异常终态标记', async () => {
+    const { tool } = makeTaskTool({
+      runSession: makeScriptedSession([assistantMessageEnd('写到一半就被截断了', 'length')]).runSession,
+    })
+    const result = await runTool(tool, 'tc-1', { subagent_type: 'chapter-writer', prompt: '写' })
+    expect(result.content[0].text).toContain('输出上限')
+    expect(result.content[0].text).toContain('写到一半就被截断了')
+    expect(result.details).toEqual({ narracatSubagentAbnormalStop: 'length' })
+  })
+
+  test('子会话 stopReason=error 且零文本：结果明确区别于「正常但没说话」', async () => {
+    const { tool } = makeTaskTool({
+      runSession: makeScriptedSession([
+        { type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: '502', content: [] } },
+      ]).runSession,
+    })
+    const result = await runTool(tool, 'tc-1', { subagent_type: 'chapter-writer', prompt: '写' })
+    expect(result.content[0].text).not.toBe('（子 agent 未产出文本）')
+    expect(result.content[0].text).toContain('异常终止')
+    expect(result.content[0].text).toContain('（子 agent 未产出文本）')
+    expect(result.details).toEqual({ narracatSubagentAbnormalStop: 'error' })
+  })
+
+  test('异常终态粘住：后续正常收笔不把它洗回成功（这一遍交付已不可信）', async () => {
+    const { tool } = makeTaskTool({
+      runSession: makeScriptedSession([assistantMessageEnd('半章', 'length'), assistantMessageEnd('补了一句', 'stop')])
+        .runSession,
+    })
+    const result = await runTool(tool, 'tc-1', { subagent_type: 'chapter-writer', prompt: '写' })
+    expect(result.content[0].text).toContain('输出上限')
+    expect(result.details).toEqual({ narracatSubagentAbnormalStop: 'length' })
+  })
+
+  test('正常收笔零文本不误报异常终止：文案与 details 均与既有行为一致', async () => {
+    const { tool } = makeTaskTool({ runSession: makeScriptedSession([assistantMessageEnd('')]).runSession })
+    const result = await runTool(tool, 'tc-1', { subagent_type: 'chapter-writer', prompt: '写' })
+    expect(result.content[0].text).toBe('（子 agent 未产出文本）')
+    expect(result.details).toBeUndefined()
   })
 
   test('结果回流：gate 反馈追加在文本尾部（Task 6 质量门缝，本 Task 以注入假 gate 覆盖）', async () => {

--- a/electron/main/agent/runtime/adapters/pi/pi-subagent.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-subagent.ts
@@ -18,6 +18,7 @@ import { Type } from 'typebox'
 import { NARRACAT_ENGINE_AGENT_IDS } from '../../../../engine/agent-core-contract.ts'
 import type { EngineAgentDefinition } from '../../../../engine/engine-agent-registry.ts'
 import { PI_MAX_TURNS_MESSAGE_TYPE, PI_SUBAGENT_EVENT_MESSAGE_TYPE } from './pi-event-mapper.ts'
+import type { PiSubagentAbnormalStop, PiSubagentAbnormalStopDetails } from './pi-event-mapper.ts'
 import { runPiSession } from './pi-session.ts'
 import type { PiRunOptions } from './pi-session.ts'
 
@@ -30,6 +31,15 @@ export { PI_SUBAGENT_EVENT_MESSAGE_TYPE }
 /** 进程内并发派发上限（照 pi 官方 subagent 示例的编排常数）：超出的 execute 排 FIFO 队列。 */
 const DEFAULT_MAX_CONCURRENCY = 4
 const MAX_TURNS_RESULT_PREFIX = '⚠️ 子 agent 达到回合上限，以下为已完成部分：'
+/**
+ * 子会话异常终止的结果前缀（与 MAX_TURNS_RESULT_PREFIX 同构）：不加这层，异常终止与「正常结束但
+ * 没产出 text 块」在主会话看来完全一样，都是下面那句 EMPTY_RESULT_TEXT——真机上跑满四分钟、烧掉
+ * 整章 token 却什么都没干成的派发就这么被当成「干完了不爱说话」放行（#29）。
+ */
+const ABNORMAL_STOP_RESULT_PREFIX: Record<PiSubagentAbnormalStop, string> = {
+  length: '⚠️ 子 agent 单次回复达到输出上限被截断，本次派发未完成，交付不可信：请核实产物，按需重新派发或把任务拆小。以下为已产出部分：',
+  error: '⚠️ 子 agent 因模型或服务端错误异常终止，本次派发未完成，交付不可信：请核实产物后重新派发。以下为已产出部分：',
+}
 const EMPTY_RESULT_TEXT = '（子 agent 未产出文本）'
 const ABORTED_ERROR_TEXT = '子 agent 任务已随主任务中止'
 /** `Task(narracat:x)` 与 `Task(x)` 两种写法都认（命令文本里的命名空间前缀零改动）。 */
@@ -95,6 +105,17 @@ function readAssistantText(message: UnknownRecord): string | undefined {
     .map((item) => (isRecord(item) && item.type === 'text' && typeof item.text === 'string' ? item.text : ''))
     .join('')
   return text || undefined
+}
+
+/**
+ * assistant `message_end` 的异常终态（'length' 输出截断 / 'error' 模型或服务端报错）。
+ * 'aborted' 不算异常终态：中止由 childAbort 分支报错收口，与父会话映射器口径一致。
+ */
+function readAbnormalStop(message: UnknownRecord): PiSubagentAbnormalStop | undefined {
+  const inner = message.message
+  if (!isRecord(inner) || inner.role !== 'assistant') return undefined
+  const stopReason = inner.stopReason
+  return stopReason === 'length' || stopReason === 'error' ? stopReason : undefined
 }
 
 /** 并发闸：计数器 + FIFO 唤醒队列。while 复检而非唤醒即占位，避免唤醒与新 acquire 抢同一个名额。 */
@@ -167,6 +188,9 @@ export function createTaskTool({
         await gateConcurrency.acquire()
         let finalText = ''
         let maxTurnsTripped = false
+        // 与 maxTurnsTripped 同为「一旦命中就粘住」：任何一轮撞上截断/报错，这一遍交付就已不可信，
+        // 后续正常收笔不该把它洗回成功。
+        let abnormalStop: PiSubagentAbnormalStop | undefined
         try {
           for await (const message of runSession({
             prompt: String(params.prompt ?? ''),
@@ -178,6 +202,9 @@ export function createTaskTool({
               // 多轮会有多条 assistant message_end，最后一条非空的才是子 agent 的交付文本。
               const text = readAssistantText(message)
               if (text) finalText = text
+              // 子会话终态只在这里可见：pi-session 的桥虽已判出 sawErrorStop，那是它的 run 级私有
+              // 状态，而映射器服务的是父 run 的事件流——子会话路径上没人接这层信号。
+              abnormalStop ??= readAbnormalStop(message)
               continue
             }
             if (message.type === PI_MAX_TURNS_MESSAGE_TYPE) maxTurnsTripped = true
@@ -190,6 +217,12 @@ export function createTaskTool({
         if (childAbort.signal.aborted) throw new Error(ABORTED_ERROR_TEXT)
 
         const parts: string[] = []
+        if (abnormalStop) {
+          // 这个信号此前不落任何地方（#29「未确认项」正是因此无从复盘）：主进程日志留一条，
+          // 事后能查出是 length 还是 error。
+          console.warn(`[narracat] pi 子 agent 异常终止（stopReason=${abnormalStop}）：${agentId}`)
+          parts.push(ABNORMAL_STOP_RESULT_PREFIX[abnormalStop])
+        }
         if (maxTurnsTripped) parts.push(MAX_TURNS_RESULT_PREFIX)
         parts.push(finalText || EMPTY_RESULT_TEXT)
         if (gate) {
@@ -202,7 +235,13 @@ export function createTaskTool({
           }
           if (feedback.length > 0) parts.push(feedback.join('\n'))
         }
-        return { content: [{ type: 'text', text: parts.join('\n\n') }], details: undefined }
+        // details 是给 UI 的侧信道（见 PiSubagentAbnormalStopDetails，那里记着 UI 上的确切口径）：
+        // 模型收到的是带 ⚠️ 前缀的成功结果（保住已产出部分与质量门反馈），任务卡则据此收口成
+        // tool.failed——逐项呈现从「完成」变「已跳过」+ 失败原因，不再一声不吭地放行。
+        const details: PiSubagentAbnormalStopDetails | undefined = abnormalStop
+          ? { narracatSubagentAbnormalStop: abnormalStop }
+          : undefined
+        return { content: [{ type: 'text', text: parts.join('\n\n') }], details }
       } catch (error) {
         // agent-loop 把 throw 转成 isError 工具结果，主会话可改派/补救，run 不崩（spec §2.2 故障隔离）。
         console.warn(`[narracat] pi 子 agent 派发失败：${agentId}`, error)

--- a/src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx
+++ b/src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { mapPiMessageToAgentEvents } from '../../../../electron/main/agent/runtime/adapters/pi/pi-event-mapper'
+import type { PiSubagentAbnormalStopDetails } from '../../../../electron/main/agent/runtime/adapters/pi/pi-event-mapper'
+import { createEmptyAgentThread, reduceAgentEvent } from '@/lib/agent-events'
+import { AgentMessageItem } from './AgentMessageItem'
+import { AgentProcessStream, isAgentProcessPart } from './AgentProcessStream'
+import type { AgentEvent, AgentMessage } from '@shared/types/agent'
+
+/**
+ * 子会话异常终止（#29）的**渲染端**兜底：pi Task 工具结果 → 事件映射器 → 渲染端 reducer → 组件，
+ * 整条链路一次跑通。跨层 import 主进程映射器是有意为之——刀 2 的唯一用户可见收益就落在这条链上，
+ * 只测映射器（主进程侧）或只测组件（喂手写 part）都会漏掉中间任何一环断掉的情况：details 侧信道
+ * 一旦读不出来，工具就是「正常返回」，卡片会退回「完成」且失败原因彻底不显示。
+ */
+describe('子会话异常终止的任务卡渲染（#29 刀 2）', () => {
+  const RUN_ID = 'run-1'
+  const CREATED_AT = '2026-08-19T09:00:00.000Z'
+  const ctx = { runId: RUN_ID, messageId: `assistant-${RUN_ID}`, createdAt: CREATED_AT }
+  /** 与 pi-subagent 产出的 details 同型：键名若改，这里先编译不过（生产者/消费者的类型级绑定）。 */
+  const ABNORMAL_STOP_DETAILS: PiSubagentAbnormalStopDetails = { narracatSubagentAbnormalStop: 'length' }
+  const RESULT_TEXT = '⚠️ 子 agent 单次回复达到输出上限被截断，本次派发未完成，交付不可信：请核实产物，按需重新派发或把任务拆小。\n\n（子 agent 未产出文本）'
+  const ABNORMAL_STOP_REASON = '子 agent 单次回复达到输出上限被截断，本次派发未完成，请重试或把任务拆小。'
+
+  /** 跑一次真实链路：run.started 建消息 → Task 派发开始 → Task 结果落地，返回助手消息。 */
+  function reduceTaskDispatch(result: unknown): AgentMessage {
+    const runStarted: AgentEvent = {
+      type: 'run.started',
+      runId: RUN_ID,
+      threadId: 'thread-1',
+      command: 'write-next',
+      prompt: '写第 3 章',
+      createdAt: CREATED_AT,
+    }
+    const events: AgentEvent[] = [
+      runStarted,
+      ...mapPiMessageToAgentEvents(ctx, {
+        type: 'tool_execution_start',
+        toolCallId: 'task-1',
+        toolName: 'Task',
+        args: { subagent_type: 'narracat:chapter-writer', description: '写第 3 章' },
+      }),
+      ...mapPiMessageToAgentEvents(ctx, {
+        type: 'tool_execution_end',
+        toolCallId: 'task-1',
+        toolName: 'Task',
+        // pi 的工具结果没有 isError 字段：异常终止在这一层看起来与成功完全一样。
+        isError: false,
+        result,
+      }),
+    ]
+
+    const thread = events.reduce(reduceAgentEvent, createEmptyAgentThread('thread-1'))
+    const assistant = thread.messages.find((message) => message.role === 'assistant')
+    if (!assistant) throw new Error('助手消息未生成')
+    return assistant
+  }
+
+  function renderProcessStream(message: AgentMessage): string {
+    return renderToStaticMarkup(<AgentProcessStream parts={message.parts.filter(isAgentProcessPart)} defaultOpen />)
+  }
+
+  test('异常终止的派发不显示成「完成」，展开后能看到失败原因', () => {
+    const html = renderProcessStream(
+      reduceTaskDispatch({ content: [{ type: 'text', text: RESULT_TEXT }], details: ABNORMAL_STOP_DETAILS }),
+    )
+
+    // 逐项徽章：已跳过（工具级失败的既有中性呈现），绝不能是「完成」
+    expect(html).toContain('>已跳过<')
+    expect(html).not.toContain('>完成<')
+    expect(html).toContain('章节写手Agent 写第 3 章')
+    // 失败原因对用户可见，且能看出是 length（截断）而非 error
+    expect(html).toContain(ABNORMAL_STOP_REASON)
+  })
+
+  test('正常收笔的派发照旧显示「完成」（异常终止的呈现只对带标记的结果生效）', () => {
+    const html = renderProcessStream(
+      reduceTaskDispatch({ content: [{ type: 'text', text: '第 3 章已交付' }], details: undefined }),
+    )
+
+    expect(html).toContain('>完成<')
+    expect(html).not.toContain('>已跳过<')
+    expect(html).not.toContain(ABNORMAL_STOP_REASON)
+  })
+
+  test('现状留档：折叠态汇总行仍读作「已完成」，失败原因要展开才看得到', () => {
+    // 这条不是目标态，是如实记录刀 2 到此为止的边界：执行过程流的汇总行沿用「工具级错误是自愈型
+    // 瞬时事件」的既有产品口径（AgentProcessStream:56），把异常终止一并算进「自动调整 N 次」。
+    // 子会话异常终止（烧掉几分钟与整章 token 的实质失败）是否该在汇总行破例，留给产品决定（#29）。
+    const message = reduceTaskDispatch({
+      content: [{ type: 'text', text: RESULT_TEXT }],
+      details: ABNORMAL_STOP_DETAILS,
+    })
+    const html = renderToStaticMarkup(<AgentMessageItem message={message} />)
+
+    expect(html).toContain('执行过程已完成 · 0 项（自动调整 1 次）')
+    expect(html).not.toContain(ABNORMAL_STOP_REASON)
+  })
+})


### PR DESCRIPTION
**Refs #29**（刀 3 未做，issue 保持开启）

## 问题

子会话异常终止的信号被完整吞掉：`pi-subagent.ts` 的消费循环只识别回合上限，对子会话 `message_end` 上的 `stopReason === 'length' | 'error'` 完全不感知。`pi-session.ts` 其实已经判出 `sawErrorStop`，但那是 session 私有状态，不 yield 给调用方；映射器服务的是父 run 的事件流。

结果：异常终止与「正常结束但没说话」不可区分，都兜底成「（子 agent 未产出文本）」。

真机证据（一次 `/write` 的 10 次派发）：chapter-writer 跑满 273s / 250s（与成功的 291s 持平，**不是秒退**）却返回空——模型把整章生成完了，时间和 token 都花了，倒在最后交付那一步。

## 改动

- 消费循环读取 `message_end` 的 stopReason，`length` / `error` 时比照现有 `MAX_TURNS_RESULT_PREFIX` 加明确前缀，主会话能确定性区分「异常终止」与「正常但没说话」
- 经 `details` 侧信道把异常终态透到事件层，模型侧仍收到带 ⚠️ 前缀的成功结果（保住已产出部分与质量门反馈）
- `'aborted'` 不算异常终态（中止由 childAbort 分支报错收口，与父会话映射器口径一致）

## ⚠️ UI 上的真实效果（此处修正本 PR 初版描述的过头话）

初版描述写的是「任务卡收口成失败，不再谎报『工具执行完成』」。**这是过头话**，实际链路核实后如下：

Task 卡不走 `AgentToolCallRow`，而是被整组折进 `AgentProcessStream`（`AgentMessageItem.tsx:96` 对所有 tool-call 无条件归入执行过程流）。所以：

| 位置 | 修复前 | 修复后 |
|---|---|---|
| 逐项徽章 | `完成` | `已跳过` |
| 失败原因文案 | **一个字都不进 DOM** | 进 DOM，**展开态可见** |
| 折叠态汇总行 | `执行过程已完成 · N 项` | `执行过程已完成 · N 项（自动调整 1 次）` |

**净增益是真的**（错误原文此前根本不存在于 DOM），但**折叠态汇总行仍然读作「已完成」**。对一次烧掉 4-5 分钟和整章 token 的失败派发，「自动调整 1 次」仍有误导性。

**为什么不在本 PR 里改掉**：`AgentPartStatus` 只有 running / complete / failed 三态，要把「子会话异常终止」与「工具级可自愈瞬时错误」在呈现上分开，得新开跨进程契约字段并改 reducer + 组件；而 `AgentProcessStream.tsx:56` 与 `AgentProcessRow.tsx:19` 都写明「红色保留给 run 级终态失败」——这是既有产品决策，破例属于新的视觉/产品判断，不该夹带进修复 PR。

现状已用测试**如实钉住并标注「这不是目标态」**（`AgentSubagentAbnormalStop.test.tsx` 第 3 条显式断言折叠态仍读「已完成」），产品拍板要改时这条测试就是提醒。

## 可观测性（此处同样修正初版描述）

初版说「主进程日志留一条」。实测全仓 `electron-log` 零命中，`console.warn` 只进 stdout——**打包后从 Finder 启动的用户拿不到**。真正让异常终态可事后复盘的是 **durable 事件里 length / error 两串不同的错误文案**，与日志无关。

## 验证

```
bun --no-cache run typecheck          → 通过
bun --no-cache run check:design       → Design-system contracts present.
bun --no-cache run check:architecture → 0 violation(s)
定向（workbench/agent + adapters/pi）  → 281 pass / 0 fail，Ran 281 tests across 23 files
全量 bun run test                      → 3016 pass / 0 fail，Ran 3016 tests across 298 files
```

**变异测试**（两处独立验证，均已还原）：
- `readAbnormalStop` 恒返回 undefined（还原原 bug）→ **3 红**
- `readSubagentAbnormalStop` 恒返回 undefined（斩断侧信道）→ **2 红**，且变异后 DOM 里徽章挂着「完成」、⚠️ 文案一个字都没有——等价于修复前的用户所见

## 已知限制

1. **另一条 error 路径未覆盖**：pi 的 `handleRunFailure` 在 agent-loop 执行体自身抛错时只发 `agent_end`、不发 `message_end`，本次看不到那条路径。属稀有路径；现状是两条都吞，本 PR 堵住了真机实际撞到的那条。
2. **异常终态「粘住」可能误报**：`length` 不终止 agent-loop，模型有可能下一轮重试并正常交付，此时仍带 ⚠️ 前缀。刻意的保守选择——漏报会退回原症状，误报时文案是「请核实产物，按需重新派发」，主会话仍有判断空间。
3. 子 agent 分组卡（含 children 明细）在当前主干上实际渲染不到，属 pre-existing 的 UX 问题，本 PR 未动。

## 未做

- **刀 3（`commands/write.md` 的流程侧兜底）**：prompt 层改动要单独走 A/B 纪律，issue #29 保持开启
- 不碰 `pi-eager-toolcall-args.ts`、不调 `DEFAULT_MAX_TOKENS`
- **真机未验收**。建议的关键一步：临时把 `DEFAULT_MAX_TOKENS` 调到 2000 制造截断，跑一次热写，**记录主会话拿到 ⚠️ 前缀后的实际反应**（会不会自己去核实产物）——这是判断刀 3 是否必需的唯一实证依据

🤖 Generated with [Claude Code](https://claude.com/claude-code)
