### PR TITLE
feat(library): 新建默认全自动，并支持在书架「更多」菜单切换模式

### DIFF
--- a/electron/main/ipc/novel-metadata-input.test.ts
+++ b/electron/main/ipc/novel-metadata-input.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+
+import { readAutomationLevel, readUpdateNovelProjectMetadataInput } from './novel-metadata-input.ts'
+
+describe('readUpdateNovelProjectMetadataInput', () => {
+  test('放行 automationLevel：书架切档只有走通这条通道才落得进 config.yaml（#27）', () => {
+    expect(readUpdateNovelProjectMetadataInput({ projectPath: '/novels/stars', automationLevel: 'auto' })).toEqual({
+      projectPath: '/novels/stars',
+      automationLevel: 'auto',
+    })
+    expect(
+      readUpdateNovelProjectMetadataInput({ projectPath: '/novels/stars', automationLevel: 'collaborative' }),
+    ).toEqual({ projectPath: '/novels/stars', automationLevel: 'collaborative' })
+  })
+
+  test('只带 automationLevel 也算「有可更新的信息」，不该被空写检查挡掉', () => {
+    expect(() =>
+      readUpdateNovelProjectMetadataInput({ projectPath: '/novels/stars', automationLevel: 'auto' }),
+    ).not.toThrow()
+    expect(() => readUpdateNovelProjectMetadataInput({ projectPath: '/novels/stars' })).toThrow(
+      '没有可更新的小说信息。',
+    )
+  })
+
+  test('三个字段可以同时改，projectPath 缺了就拒绝', () => {
+    expect(
+      readUpdateNovelProjectMetadataInput({
+        projectPath: '/novels/stars',
+        title: '星辰大海',
+        coverPreset: 'cover-08',
+        automationLevel: 'collaborative',
+      }),
+    ).toEqual({
+      projectPath: '/novels/stars',
+      title: '星辰大海',
+      coverPreset: 'cover-08',
+      automationLevel: 'collaborative',
+    })
+    expect(() => readUpdateNovelProjectMetadataInput({ automationLevel: 'auto' })).toThrow('缺少项目路径。')
+  })
+
+  test('白名单外的 key 一律丢弃，不原样透传给落盘', () => {
+    expect(
+      readUpdateNovelProjectMetadataInput({
+        projectPath: '/novels/stars',
+        automationLevel: 'auto',
+        novel_id: 'forged',
+        language: 'en-US',
+      }),
+    ).toEqual({ projectPath: '/novels/stars', automationLevel: 'auto' })
+  })
+
+  test('非法的自动化档拒绝落盘：引擎只认 auto / collaborative 两个死值', () => {
+    for (const bad of ['Auto', 'AUTO', '', 'semi', 0, null, {}]) {
+      expect(() => readUpdateNovelProjectMetadataInput({ projectPath: '/novels/stars', automationLevel: bad })).toThrow(
+        '自动化级别非法。',
+      )
+    }
+  })
+
+  test('入参不是对象直接拒绝', () => {
+    expect(() => readUpdateNovelProjectMetadataInput(null)).toThrow('小说信息参数非法。')
+    expect(() => readUpdateNovelProjectMetadataInput(['/novels/stars'])).toThrow('小说信息参数非法。')
+  })
+})
+
+describe('readAutomationLevel', () => {
+  test('新建小说走同一把尺子', () => {
+    expect(readAutomationLevel('auto')).toBe('auto')
+    expect(readAutomationLevel('collaborative')).toBe('collaborative')
+    expect(() => readAutomationLevel(undefined)).toThrow('自动化级别非法。')
+  })
+})

--- a/electron/main/ipc/novel-metadata-input.ts
+++ b/electron/main/ipc/novel-metadata-input.ts
@@ -1,0 +1,55 @@
+/**
+ * 小说信息更新 IPC 边界校验（独立模块，供测试直接导入，无重型依赖）。
+ *
+ * 与 pack-draft-input.ts 同一个理由拆出来：novel.ts 顶部 import 了 electron 与整条小说主进程链路，
+ * 测试根本 import 不进去，白名单少放一个字段全仓没有一条断言拦得住——而这条通道决定的是渲染端能
+ * 改 `.narracat/config.yaml` 里的哪几个 key，`automationLevel` 更是直接改变 Agent 之后怎么跑。
+ *
+ * 白名单只认 title / coverPreset / automationLevel 三个字段，其余 key 一律丢弃；三个全缺则拒绝，
+ * 不让一次不带任何改动的空写把 config.yaml 重排一遍。字段的内容合法性（标题空白、封面预设是否存在）
+ * 由 novel-project.ts 的落盘校验兜底，这里只管形状与放行范围。
+ */
+import type { NovelAutomationLevel, UpdateNovelProjectMetadataInput } from '@shared/types/novel'
+
+function readInputRecord(input: unknown, message: string): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error(message)
+  return input as Record<string, unknown>
+}
+
+function readRequiredString(parent: Record<string, unknown>, key: string, message: string): string {
+  const value = parent[key]
+  if (typeof value !== 'string' || !value.trim()) throw new Error(message)
+  return value
+}
+
+function readOptionalString(parent: Record<string, unknown>, key: string, message: string): string | undefined {
+  const value = parent[key]
+  if (value === undefined) return undefined
+  if (typeof value !== 'string') throw new Error(message)
+  return value
+}
+
+/** 自动化档只有两个合法取值；写歪一个字都会让引擎按另一档跑，所以这里认死值而不是认字符串。 */
+export function readAutomationLevel(value: unknown): NovelAutomationLevel {
+  if (value !== 'collaborative' && value !== 'auto') throw new Error('自动化级别非法。')
+  return value
+}
+
+export function readUpdateNovelProjectMetadataInput(input: unknown): UpdateNovelProjectMetadataInput {
+  const value = readInputRecord(input, '小说信息参数非法。')
+  const title = readOptionalString(value, 'title', '小说标题参数非法。')
+  const coverPreset = readOptionalString(value, 'coverPreset', '封面预设参数非法。')
+  const automationLevel =
+    value.automationLevel === undefined ? undefined : readAutomationLevel(value.automationLevel)
+
+  if (title === undefined && coverPreset === undefined && automationLevel === undefined) {
+    throw new Error('没有可更新的小说信息。')
+  }
+
+  return {
+    projectPath: readRequiredString(value, 'projectPath', '缺少项目路径。'),
+    ...(title !== undefined ? { title } : {}),
+    ...(coverPreset !== undefined ? { coverPreset } : {}),
+    ...(automationLevel !== undefined ? { automationLevel } : {}),
+  }
+}

--- a/electron/main/ipc/novel.ts
+++ b/electron/main/ipc/novel.ts
@@ -93,6 +93,7 @@ import {
 import type {
   CreateNovelProjectInput,
   DeleteNovelProjectInput,
+  NovelAutomationLevel,
   PasteReferenceSourceInput,
   RemoveReferenceSourceInput,
   UpdateNovelProjectMetadataInput,
@@ -242,18 +243,20 @@ function readWorkbenchArtifactInput(input: unknown): {
   return { projectPath, objectId, volumeNumber }
 }
 
+function readAutomationLevel(value: unknown): NovelAutomationLevel {
+  if (value !== 'collaborative' && value !== 'auto') throw new Error('自动化级别非法。')
+  return value
+}
+
 function readCreateNovelInput(input: unknown): CreateNovelProjectInput {
   const value = readInputRecord(input, '新建小说参数非法。')
   const title = readRequiredString(value, 'title', '缺少小说标题。')
   const genre = readRequiredString(value, 'genre', '缺少小说类型。')
-  const { automationLevel } = value
-
-  if (automationLevel !== 'collaborative' && automationLevel !== 'auto') throw new Error('自动化级别非法。')
 
   return {
     title,
     genre,
-    automationLevel,
+    automationLevel: readAutomationLevel(value.automationLevel),
   }
 }
 
@@ -261,13 +264,18 @@ function readUpdateNovelProjectMetadataInput(input: unknown): UpdateNovelProject
   const value = readInputRecord(input, '小说信息参数非法。')
   const title = readOptionalString(value, 'title', '小说标题参数非法。')
   const coverPreset = readOptionalString(value, 'coverPreset', '封面预设参数非法。')
+  const automationLevel =
+    value.automationLevel === undefined ? undefined : readAutomationLevel(value.automationLevel)
 
-  if (title === undefined && coverPreset === undefined) throw new Error('没有可更新的小说信息。')
+  if (title === undefined && coverPreset === undefined && automationLevel === undefined) {
+    throw new Error('没有可更新的小说信息。')
+  }
 
   return {
     projectPath: readRequiredString(value, 'projectPath', '缺少项目路径。'),
     ...(title !== undefined ? { title } : {}),
     ...(coverPreset !== undefined ? { coverPreset } : {}),
+    ...(automationLevel !== undefined ? { automationLevel } : {}),
   }
 }
 

--- a/electron/main/ipc/novel.ts
+++ b/electron/main/ipc/novel.ts
@@ -7,10 +7,10 @@ import {
   configPath,
   readCurrentConfig,
   readInputRecord,
-  readOptionalString,
   readRequiredString,
   userDataPath,
 } from './inputs.ts'
+import { readAutomationLevel, readUpdateNovelProjectMetadataInput } from './novel-metadata-input.ts'
 import { getAgentRuntimeCoordinator, runProjectMutation } from './agent.ts'
 import { pruneMissingRecentNovelPaths, scanNovelProjects } from '../novel/novel-index.ts'
 import {
@@ -93,10 +93,8 @@ import {
 import type {
   CreateNovelProjectInput,
   DeleteNovelProjectInput,
-  NovelAutomationLevel,
   PasteReferenceSourceInput,
   RemoveReferenceSourceInput,
-  UpdateNovelProjectMetadataInput,
 } from '@shared/types/novel'
 import type {
   CreateNovelProjectBackupDialogResult,
@@ -243,11 +241,6 @@ function readWorkbenchArtifactInput(input: unknown): {
   return { projectPath, objectId, volumeNumber }
 }
 
-function readAutomationLevel(value: unknown): NovelAutomationLevel {
-  if (value !== 'collaborative' && value !== 'auto') throw new Error('自动化级别非法。')
-  return value
-}
-
 function readCreateNovelInput(input: unknown): CreateNovelProjectInput {
   const value = readInputRecord(input, '新建小说参数非法。')
   const title = readRequiredString(value, 'title', '缺少小说标题。')
@@ -257,25 +250,6 @@ function readCreateNovelInput(input: unknown): CreateNovelProjectInput {
     title,
     genre,
     automationLevel: readAutomationLevel(value.automationLevel),
-  }
-}
-
-function readUpdateNovelProjectMetadataInput(input: unknown): UpdateNovelProjectMetadataInput {
-  const value = readInputRecord(input, '小说信息参数非法。')
-  const title = readOptionalString(value, 'title', '小说标题参数非法。')
-  const coverPreset = readOptionalString(value, 'coverPreset', '封面预设参数非法。')
-  const automationLevel =
-    value.automationLevel === undefined ? undefined : readAutomationLevel(value.automationLevel)
-
-  if (title === undefined && coverPreset === undefined && automationLevel === undefined) {
-    throw new Error('没有可更新的小说信息。')
-  }
-
-  return {
-    projectPath: readRequiredString(value, 'projectPath', '缺少项目路径。'),
-    ...(title !== undefined ? { title } : {}),
-    ...(coverPreset !== undefined ? { coverPreset } : {}),
-    ...(automationLevel !== undefined ? { automationLevel } : {}),
   }
 }
 

--- a/electron/main/novel/novel-project.test.ts
+++ b/electron/main/novel/novel-project.test.ts
@@ -125,6 +125,36 @@ describe('novel project loading', () => {
     expect(config).toContain('cover_preset: cover-08')
   })
 
+  test('reports the current automation level and treats a missing one as collaborative', async () => {
+    const root = await makeNovelProject('automation-level')
+
+    expect((await loadNovelProjectSummary(root)).automationLevel).toBe('auto')
+
+    await writeNovelFixtureFile(
+      root,
+      join('.narracat', 'config.yaml'),
+      ['novel_id: novel-1', 'title: 星辰大海', 'language: zh-CN', ''].join('\n'),
+    )
+
+    expect((await loadNovelProjectSummary(root)).automationLevel).toBe('collaborative')
+  })
+
+  test('switches the automation level and keeps the rest of config.yaml untouched', async () => {
+    const root = await makeNovelProject('switch-automation')
+
+    const updated = await updateNovelProjectMetadata({ projectPath: root, automationLevel: 'collaborative' })
+    const config = await readFile(join(root, '.narracat', 'config.yaml'), 'utf-8')
+
+    expect(updated.automationLevel).toBe('collaborative')
+    expect(config).toContain('automation_level: collaborative')
+    expect(config).toContain('novel_id: novel-1')
+    expect(config).toContain('title: 星辰大海')
+    expect(config).toContain('language: zh-CN')
+    expect(config).toContain('estimated_total_chapters: null')
+    expect(config).toContain('words_per_chapter: null')
+    expect(config).toContain('style_profile: null')
+  })
+
   test('rejects blank titles and unknown cover presets when updating metadata', async () => {
     const root = await makeNovelProject('reject-metadata')
 

--- a/electron/main/novel/novel-project.ts
+++ b/electron/main/novel/novel-project.ts
@@ -166,7 +166,15 @@ function readProjectCoverPreset(config: Record<string, unknown>, identity: strin
   )
 }
 
-/** 引擎按 `automation_level == "auto"` 分支，缺省/非法值一律当协作档（`commands/plan.md`、`commands/write.md`）。 */
+/**
+ * 缺省/非法值一律当协作档。与引擎只对得上一半，别把这条注释读成「处处一致」：
+ * `commands/plan.md` 判 `== "auto"`（`docs/contracts/new-character-intake.md` 同款），缺 key 时
+ * 确实退回逐步确认，与这里一致；但 `commands/write.md` 判的是 `== "collaborative"`，缺 key 时两个
+ * 分支都不命中、写作确认门根本不触发，行为等同全自动——这处引擎侧不一致要单独走引擎层修，App 侧
+ * 只如实显示当前档，不在这里替引擎兜。
+ * 新建（novel-create.ts）与切档（updateNovelProjectMetadata）都会写入显式值，缺 key 只出现在历史
+ * 项目或被手工改过的 config.yaml 上。
+ */
 function readProjectAutomationLevel(config: Record<string, unknown>): NovelAutomationLevel {
   return readString(config, 'automation_level')?.trim() === 'auto' ? 'auto' : 'collaborative'
 }

--- a/electron/main/novel/novel-project.ts
+++ b/electron/main/novel/novel-project.ts
@@ -22,6 +22,7 @@ import {
 import { parseYamlRecord, readNumber, readRecord, readString, stringifyYamlRecord } from './yaml'
 import { hasNarratorVoiceSection as containsNarratorVoiceSection } from '@shared/lib/narrator-voice'
 import type {
+  NovelAutomationLevel,
   NovelChapterStatus,
   NovelCheckpoint,
   NovelProjectDetail,
@@ -163,6 +164,11 @@ function readProjectCoverPreset(config: Record<string, unknown>, identity: strin
     readString(config, 'coverPreset')?.trim() ||
     deterministicCoverPreset(identity)
   )
+}
+
+/** 引擎按 `automation_level == "auto"` 分支，缺省/非法值一律当协作档（`commands/plan.md`、`commands/write.md`）。 */
+function readProjectAutomationLevel(config: Record<string, unknown>): NovelAutomationLevel {
+  return readString(config, 'automation_level')?.trim() === 'auto' ? 'auto' : 'collaborative'
 }
 
 function normalizeMetadataTitle(title: string): string {
@@ -690,6 +696,7 @@ export async function loadNovelProjectSummary(projectPath: string): Promise<Nove
     title: (readString(config, 'title') ?? basename(projectPath)) || '未命名小说',
     genre: readProjectGenre(config),
     coverPreset: readProjectCoverPreset(config, id),
+    automationLevel: readProjectAutomationLevel(config),
     path: projectPath,
     status,
     chapterProgress: `${completed} / ${planned} 章`,
@@ -789,6 +796,11 @@ export async function updateNovelProjectMetadata(
 
   if (input.coverPreset !== undefined) {
     config.cover_preset = normalizeMetadataCoverPreset(input.coverPreset)
+    changed = true
+  }
+
+  if (input.automationLevel !== undefined) {
+    config.automation_level = input.automationLevel
     changed = true
   }
 

--- a/shared/types/novel.ts
+++ b/shared/types/novel.ts
@@ -1,6 +1,8 @@
 import type { NarraCatArtifactKind } from './narracat'
 
 export type NovelProjectStatus = 'ready' | 'needs-setup' | 'needs-outline' | 'in-progress' | 'invalid'
+/** 落盘为 `.narracat/config.yaml` 顶层 `automation_level`；控制状态，不外露到对话流（ADR-0016）。 */
+export type NovelAutomationLevel = 'collaborative' | 'auto'
 export type NovelTocItemKind = 'volume' | 'chapter'
 export type NovelChapterStatus =
   | 'completed'
@@ -47,6 +49,8 @@ export interface NovelProjectSummary {
   wordCountLabel: string
   /** 原始总字数（纯文字）。首页 banner 聚合用此精确求和，不从 wordCountLabel 反解。 */
   wordCountTotal?: number
+  /** 当前自动化模式；config.yaml 读不到（项目损坏）时缺省，UI 据此隐藏切换入口。 */
+  automationLevel?: NovelAutomationLevel
   updatedAt?: string
   problem?: string
   checkpoint?: NovelCheckpoint | null
@@ -287,7 +291,7 @@ export interface NovelStatusSnapshot {
 export interface CreateNovelProjectInput {
   title: string
   genre: string
-  automationLevel: 'collaborative' | 'auto'
+  automationLevel: NovelAutomationLevel
 }
 
 export interface CreatedNovelProject {
@@ -299,6 +303,7 @@ export interface UpdateNovelProjectMetadataInput {
   projectPath: string
   title?: string
   coverPreset?: string
+  automationLevel?: NovelAutomationLevel
 }
 
 export interface DeleteNovelProjectInput {

--- a/src/components/library/CreateNovelDialog.interactions.test.tsx
+++ b/src/components/library/CreateNovelDialog.interactions.test.tsx
@@ -1,0 +1,73 @@
+// 自动化分档按钮的真实点击测试：证明每一块回传的正是它自己那一档。
+//
+// 为什么单独一个文件、且不并进 CreateNovelDialog.test.tsx：那份走 renderToStaticMarkup，只能证明
+// 选中态挂对了块，证不了 onClick 的实参；而全局挂载必须发生在 @testing-library/react 被 import
+// 之前，ES import 又会提升到模块顶部——只能靠「先同步挂全局，再顶层 await 动态 import」，这条纪律
+// 会污染同文件里的普通用例。
+//
+// 手动挂 happy-dom（而非 GlobalRegistrator）、查询一律走 container.querySelector（screen 是进程级
+// 单例，会被同进程里先 import 的那个 DOM 测试焊死）的完整理由见 ui/disclosure.interactions.test.tsx
+// 与 settings/UpdateRow.test.tsx 顶部注释。
+import { Window } from 'happy-dom'
+
+const happyWindow = new Window()
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document')
+Object.defineProperty(globalThis, 'window', { configurable: true, value: happyWindow })
+Object.defineProperty(globalThis, 'document', { configurable: true, value: happyWindow.document })
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const { afterAll, afterEach, describe, expect, test } = await import('bun:test')
+const { cleanup, fireEvent, render } = await import('@testing-library/react')
+const { Dialog } = await import('@/components/ui/dialog')
+const {
+  CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
+  CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
+  CreateNovelDialogPanel,
+} = await import('./CreateNovelDialog.tsx')
+
+afterEach(() => {
+  cleanup()
+})
+
+afterAll(async () => {
+  if (originalWindowDescriptor) Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+  else Reflect.deleteProperty(globalThis, 'window')
+  if (originalDocumentDescriptor) Object.defineProperty(globalThis, 'document', originalDocumentDescriptor)
+  else Reflect.deleteProperty(globalThis, 'document')
+  await happyWindow.happyDOM.close()
+})
+
+describe('新建小说的自动化分档', () => {
+  test('点哪一块就回传哪一档（接反了作者会以为选了协作却建出全自动项目）', () => {
+    const picked: string[] = []
+    const { container } = render(
+      <Dialog open>
+        <CreateNovelDialogPanel
+          automationLevel="auto"
+          creating={false}
+          formError={null}
+          genre="赛博朋克悬疑"
+          title="星辰大海"
+          onAutomationLevelChange={(value) => picked.push(value)}
+          onGenreChange={() => {}}
+          onSubmit={() => {}}
+          onTitleChange={() => {}}
+        />
+      </Dialog>,
+    )
+    const options = [
+      ...container.querySelectorAll<HTMLButtonElement>('[data-create-novel-automation="segmented"] button'),
+    ]
+
+    // 先锁死「第几块是哪个标签」，下面按同一顺序点击，标签与实参才对得上号。
+    expect(options.map((option) => option.querySelector('span')?.textContent)).toEqual([
+      CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
+      CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
+    ])
+
+    for (const option of options) fireEvent.click(option)
+
+    expect(picked).toEqual(['auto', 'collaborative'])
+  })
+})

--- a/src/components/library/CreateNovelDialog.test.tsx
+++ b/src/components/library/CreateNovelDialog.test.tsx
@@ -15,6 +15,20 @@ import {
   buildCreatedNovelWorkbenchHref,
 } from './CreateNovelDialog'
 
+/**
+ * 分档按钮按渲染顺序还原成「标签 → 选中态」。选中态与点击回调分别写在两个块上，最容易的手误就是
+ * 把它们在两块之间对调，而顺序/徽标那几条断言全都照样绿——所以这里逐块锁死配对。
+ */
+function readAutomationOptions(html: string): { active: string; label: string }[] {
+  const start = html.indexOf('data-create-novel-automation="segmented"')
+  const end = html.indexOf('data-create-novel-automation-help="true"')
+  const segmented = html.slice(start, end)
+
+  return [...segmented.matchAll(/data-active="(true|false)"[^>]*><span>([^<]*)<\/span>/g)].map(
+    ([, active, label]) => ({ active, label }),
+  )
+}
+
 describe('CreateNovelDialogPanel', () => {
   test('opens a newly created novel on the core premise tab', () => {
     expect(buildCreatedNovelWorkbenchHref('/novels/星辰大海')).toBe(
@@ -80,8 +94,13 @@ describe('CreateNovelDialogPanel', () => {
     expect(html.indexOf('data-create-novel-automation-recommended="true"')).toBeLessThan(
       html.indexOf(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL),
     )
+    // automationLevel="auto" → 只有「全自动」那块高亮（接反了这条会红）。
+    expect(readAutomationOptions(html)).toEqual([
+      { active: 'true', label: CREATE_NOVEL_AUTOMATION_AUTO_LABEL },
+      { active: 'false', label: CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL },
+    ])
     expect(html).toContain('data-create-novel-automation-help="true"')
-    // 传入 automationLevel="auto" 时，说明文案应讲清"全程不打断"的后果。
+    // 传入 automationLevel="auto" 时，说明文案应讲清全程不打断换来的代价（时间与花费）。
     expect(html).toContain(CREATE_NOVEL_AUTOMATION_AUTO_HELP)
     expect(html).not.toContain(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP)
     expect(html).toContain('rounded-row bg-active p-1')
@@ -121,6 +140,11 @@ describe('CreateNovelDialogPanel', () => {
       </Dialog>,
     )
 
+    // automationLevel="collaborative" → 高亮跟着换到「协作模式」那块，「推荐」徽标不跟着跑。
+    expect(readAutomationOptions(html)).toEqual([
+      { active: 'false', label: CREATE_NOVEL_AUTOMATION_AUTO_LABEL },
+      { active: 'true', label: CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL },
+    ])
     expect(html).toContain(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP)
     expect(html).not.toContain(CREATE_NOVEL_AUTOMATION_AUTO_HELP)
   })

--- a/src/components/library/CreateNovelDialog.test.tsx
+++ b/src/components/library/CreateNovelDialog.test.tsx
@@ -8,6 +8,7 @@ import {
   CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
   CREATE_NOVEL_GENRE_HELP,
   CREATE_NOVEL_GENRE_PLACEHOLDER,
+  CREATE_NOVEL_INITIAL_AUTOMATION_LEVEL,
   CREATE_NOVEL_INITIAL_GENRE,
   CREATE_NOVEL_TITLE_PLACEHOLDER,
   CreateNovelDialogPanel,
@@ -69,12 +70,15 @@ describe('CreateNovelDialogPanel', () => {
     expect(html).toContain('推荐')
     expect(html).toContain(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL)
     expect(html).toContain(CREATE_NOVEL_AUTOMATION_AUTO_LABEL)
-    // 推荐徽标挂在协作模式选项上，且协作模式排在自动前面（默认档=协作模式）。
-    expect(html.indexOf(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL)).toBeLessThan(
-      html.indexOf(CREATE_NOVEL_AUTOMATION_AUTO_LABEL),
+    // 推荐徽标挂在全自动选项上，且全自动排在协作模式前面（默认档=全自动，#27）。
+    expect(html.indexOf(CREATE_NOVEL_AUTOMATION_AUTO_LABEL)).toBeLessThan(
+      html.indexOf(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL),
+    )
+    expect(html.indexOf(CREATE_NOVEL_AUTOMATION_AUTO_LABEL)).toBeLessThan(
+      html.indexOf('data-create-novel-automation-recommended="true"'),
     )
     expect(html.indexOf('data-create-novel-automation-recommended="true"')).toBeLessThan(
-      html.indexOf(CREATE_NOVEL_AUTOMATION_AUTO_LABEL),
+      html.indexOf(CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL),
     )
     expect(html).toContain('data-create-novel-automation-help="true"')
     // 传入 automationLevel="auto" 时，说明文案应讲清"全程不打断"的后果。
@@ -94,6 +98,10 @@ describe('CreateNovelDialogPanel', () => {
 
   test('does not prefill a genre before the author chooses one', () => {
     expect(CREATE_NOVEL_INITIAL_GENRE).toBe('')
+  })
+
+  test('defaults a new novel to the recommended fully automatic mode (#27)', () => {
+    expect(CREATE_NOVEL_INITIAL_AUTOMATION_LEVEL).toBe('auto')
   })
 
   test('collaborative automation shows its own consequence copy (dogfood #5 default)', () => {

--- a/src/components/library/CreateNovelDialog.tsx
+++ b/src/components/library/CreateNovelDialog.tsx
@@ -31,7 +31,8 @@ export const CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL = '协作模式'
 export const CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP =
   '关键节点先和你确认再继续：大纲分段生成、写作前过目。'
 export const CREATE_NOVEL_AUTOMATION_AUTO_LABEL = '全自动'
-export const CREATE_NOVEL_AUTOMATION_AUTO_HELP = '全程不打断，大纲和写作一口气跑完，适合想直接看结果。'
+export const CREATE_NOVEL_AUTOMATION_AUTO_HELP =
+  '中途不再停下来问你：大纲和写作一口气跑完，一章大约要 20 分钟，花费也更高。'
 
 function Field({
   asLabel = true,

--- a/src/components/library/CreateNovelDialog.tsx
+++ b/src/components/library/CreateNovelDialog.tsx
@@ -32,7 +32,7 @@ export const CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP =
   '关键节点先和你确认再继续：大纲分段生成、写作前过目。'
 export const CREATE_NOVEL_AUTOMATION_AUTO_LABEL = '全自动'
 export const CREATE_NOVEL_AUTOMATION_AUTO_HELP =
-  '中途不再停下来问你：大纲和写作一口气跑完，一章大约要 20 分钟，花费也更高。'
+  '中途不再停下来问你：大纲和写作一口气跑完，适合想直接看结果。'
 
 function Field({
   asLabel = true,

--- a/src/components/library/CreateNovelDialog.tsx
+++ b/src/components/library/CreateNovelDialog.tsx
@@ -22,6 +22,8 @@ import type { CreateNovelProjectInput } from '@shared/types/novel'
 type ButtonProps = ComponentProps<typeof Button>
 
 export const CREATE_NOVEL_INITIAL_GENRE = ''
+/** 默认推荐档：先让作者拿到整章成品，再决定要不要把手伸回流程里（#27）。 */
+export const CREATE_NOVEL_INITIAL_AUTOMATION_LEVEL: CreateNovelProjectInput['automationLevel'] = 'auto'
 export const CREATE_NOVEL_TITLE_PLACEHOLDER = '输入小说标题'
 export const CREATE_NOVEL_GENRE_PLACEHOLDER = '例如：仙侠、都市异能、悬疑推理'
 export const CREATE_NOVEL_GENRE_HELP = '可以填写单一题材或复合题材，Agent 会据此调整后续问题。'
@@ -163,17 +165,17 @@ export function CreateNovelDialogPanel({
             <div className="grid gap-1.5">
               <div data-create-novel-automation="segmented" className="grid grid-cols-2 rounded-row bg-active p-1">
                 <AutomationOption
-                  active={automationLevel === 'collaborative'}
-                  recommended
-                  onClick={() => onAutomationLevelChange('collaborative')}
-                >
-                  {CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL}
-                </AutomationOption>
-                <AutomationOption
                   active={automationLevel === 'auto'}
+                  recommended
                   onClick={() => onAutomationLevelChange('auto')}
                 >
                   {CREATE_NOVEL_AUTOMATION_AUTO_LABEL}
+                </AutomationOption>
+                <AutomationOption
+                  active={automationLevel === 'collaborative'}
+                  onClick={() => onAutomationLevelChange('collaborative')}
+                >
+                  {CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL}
                 </AutomationOption>
               </div>
               <p data-create-novel-automation-help="true" className="text-xs font-normal leading-5 text-hint-foreground">
@@ -221,8 +223,7 @@ export function CreateNovelDialog({
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [genre, setGenre] = useState(CREATE_NOVEL_INITIAL_GENRE)
-  const [automationLevel, setAutomationLevel] =
-    useState<CreateNovelProjectInput['automationLevel']>('collaborative')
+  const [automationLevel, setAutomationLevel] = useState(CREATE_NOVEL_INITIAL_AUTOMATION_LEVEL)
   const [formError, setFormError] = useState<string | null>(null)
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {

--- a/src/routes/library.test.tsx
+++ b/src/routes/library.test.tsx
@@ -18,6 +18,7 @@ import {
   LibraryProjectGrid,
   LibraryRoute,
   isLibraryProjectDeleteConfirmationValid,
+  libraryAutomationMenuLabel,
   summarizeLibraryProjects,
 } from './library'
 import { getLibraryCoverPreset } from '@/lib/library-covers'
@@ -350,6 +351,12 @@ describe('LibraryRoute presentation', () => {
     expect(html).toContain('完结')
     expect(html).not.toContain('可写作')
     expect(html).not.toContain('未完成')
+  })
+
+  test('shows the current automation mode in the card menu and explains why it can be locked (#27)', () => {
+    expect(libraryAutomationMenuLabel('auto', false)).toBe('自动化：全自动')
+    expect(libraryAutomationMenuLabel('collaborative', false)).toBe('自动化：协作模式')
+    expect(libraryAutomationMenuLabel('auto', true)).toBe('Agent 运行中，不能切换模式')
   })
 
   test('requires the visible title before deleting a project', () => {

--- a/src/routes/library.test.tsx
+++ b/src/routes/library.test.tsx
@@ -359,6 +359,26 @@ describe('LibraryRoute presentation', () => {
     expect(libraryAutomationMenuLabel('auto', true)).toBe('Agent 运行中，不能切换模式')
   })
 
+  // 菜单本身渲染在 portal 里，静态渲染的卡片 HTML 抓不到——照删除菜单项的先例读源码锁住。
+  test('wires the automation switch as a run-guarded card menu entry that spells out each mode (#27)', () => {
+    const source = readFileSync('src/routes/library.tsx', 'utf8')
+    const anchor = source.indexOf('data-library-project-automation-menu-item="true"')
+
+    expect(anchor).toBeGreaterThan(-1)
+
+    // 取该属性所在的那个 SubTrigger 元素，不认「文件里第一个 SubTrigger」，免得日后加了别的子菜单就测错块。
+    const trigger = source.slice(
+      source.lastIndexOf('<DropdownMenuSubTrigger', anchor),
+      source.indexOf('</DropdownMenuSubTrigger>', anchor),
+    )
+
+    // 与备份/删除同一道闸：Agent 正在跑就不让改档。
+    expect(trigger).toContain('disabled={deleteBlocked}')
+    // 两档各自的后果说明必须挂进选项，不能只给光秃秃的单选项让作者盲选。
+    expect(source).toContain('{LIBRARY_AUTOMATION_LEVEL_HELP.auto}')
+    expect(source).toContain('{LIBRARY_AUTOMATION_LEVEL_HELP.collaborative}')
+  })
+
   test('requires the visible title before deleting a project', () => {
     expect(isLibraryProjectDeleteConfirmationValid('星辰大海', ' 星辰大海 ')).toBe(true)
     expect(isLibraryProjectDeleteConfirmationValid('星辰大海', '星辰')).toBe(false)

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -14,6 +14,7 @@ import {
   Search,
   Settings as SettingsIcon,
   Trash2,
+  Wand2,
   X,
 } from 'lucide-react'
 import { BrandIllustration, BrandLockup } from '@/components/brand'
@@ -33,12 +34,21 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { AppShell } from '@/components/AppShell'
-import { CreateNovelDialog } from '@/components/library/CreateNovelDialog'
+import {
+  CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
+  CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
+  CreateNovelDialog,
+} from '@/components/library/CreateNovelDialog'
 import { UpdateReadyBanner } from '@/components/settings/UpdateReadyBanner'
 import {
   DESTRUCTIVE_INLINE_CLASS,
@@ -72,7 +82,7 @@ import {
   saveLibraryProjectMetadata,
   useLibraryProjects,
 } from '@/lib/use-novel-project'
-import type { NovelProjectSummary } from '@shared/types/novel'
+import type { NovelAutomationLevel, NovelProjectSummary } from '@shared/types/novel'
 
 type LibrarySummary = {
   total: number
@@ -97,6 +107,16 @@ export const LIBRARY_PROJECT_METADATA_DIALOG_CONTENT_CLASS =
 
 export const LIBRARY_PROJECT_DELETE_DIALOG_CONTENT_CLASS = 'bg-workspace sm:max-w-[520px]'
 export const LIBRARY_PROJECT_BACKUP_DIALOG_CONTENT_CLASS = 'bg-workspace sm:max-w-[520px]'
+
+const LIBRARY_AUTOMATION_LEVEL_LABELS: Record<NovelAutomationLevel, string> = {
+  auto: CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
+  collaborative: CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
+}
+
+/** 「更多」菜单里的自动化入口文案：常态显示当前档，Agent 运行中改成说明原因（与备份/删除一致）。 */
+export function libraryAutomationMenuLabel(automationLevel: NovelAutomationLevel, blocked: boolean): string {
+  return blocked ? 'Agent 运行中，不能切换模式' : `自动化：${LIBRARY_AUTOMATION_LEVEL_LABELS[automationLevel]}`
+}
 
 export function statusLabel(status: NovelProjectSummary['status']): string {
   if (status === 'ready') return '可写作'
@@ -838,6 +858,18 @@ export function LibraryProjectManagementMenu({ project }: { project: NovelProjec
 
     return Object.values(state.threadsById).some((thread) => thread.activeRun?.projectPath === project.path)
   })
+  const automationLevel = project.automationLevel
+
+  async function switchAutomationLevel(nextLevel: NovelAutomationLevel) {
+    if (nextLevel === automationLevel) return
+
+    try {
+      await saveLibraryProjectMetadata({ projectPath: project.path, automationLevel: nextLevel })
+      toast.success(`已切换到${LIBRARY_AUTOMATION_LEVEL_LABELS[nextLevel]}，下一次规划大纲或写作时生效。`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '切换自动化模式失败，请重试。')
+    }
+  }
 
   return (
     <>
@@ -863,6 +895,31 @@ export function LibraryProjectManagementMenu({ project }: { project: NovelProjec
             <ImageIcon className="size-4" />
             更换封面
           </DropdownMenuItem>
+          {automationLevel && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                disabled={deleteBlocked}
+                data-library-project-automation-menu-item="true"
+                className="data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+              >
+                <Wand2 className="size-4" />
+                {libraryAutomationMenuLabel(automationLevel, deleteBlocked)}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup
+                  value={automationLevel}
+                  onValueChange={(value) => void switchAutomationLevel(value as NovelAutomationLevel)}
+                >
+                  <DropdownMenuRadioItem value="auto">
+                    {LIBRARY_AUTOMATION_LEVEL_LABELS.auto}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="collaborative">
+                    {LIBRARY_AUTOMATION_LEVEL_LABELS.collaborative}
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
           <DropdownMenuSeparator />
           <DropdownMenuItem
             disabled={deleteBlocked}

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -45,7 +45,9 @@ import {
 import { Input } from '@/components/ui/input'
 import { AppShell } from '@/components/AppShell'
 import {
+  CREATE_NOVEL_AUTOMATION_AUTO_HELP,
   CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
+  CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP,
   CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
   CreateNovelDialog,
 } from '@/components/library/CreateNovelDialog'
@@ -111,6 +113,15 @@ export const LIBRARY_PROJECT_BACKUP_DIALOG_CONTENT_CLASS = 'bg-workspace sm:max-
 const LIBRARY_AUTOMATION_LEVEL_LABELS: Record<NovelAutomationLevel, string> = {
   auto: CREATE_NOVEL_AUTOMATION_AUTO_LABEL,
   collaborative: CREATE_NOVEL_AUTOMATION_COLLABORATIVE_LABEL,
+}
+
+/**
+ * 切换入口的后果说明与新建对话框同源（同一份文案常量）：改档改的是 Agent 之后怎么跑，
+ * 光给两个单选项等于让作者盲选，这里必须把「换来什么、代价是什么」摆在选项里。
+ */
+const LIBRARY_AUTOMATION_LEVEL_HELP: Record<NovelAutomationLevel, string> = {
+  auto: CREATE_NOVEL_AUTOMATION_AUTO_HELP,
+  collaborative: CREATE_NOVEL_AUTOMATION_COLLABORATIVE_HELP,
 }
 
 /** 「更多」菜单里的自动化入口文案：常态显示当前档，Agent 运行中改成说明原因（与备份/删除一致）。 */
@@ -905,16 +916,26 @@ export function LibraryProjectManagementMenu({ project }: { project: NovelProjec
                 <Wand2 className="size-4" />
                 {libraryAutomationMenuLabel(automationLevel, deleteBlocked)}
               </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
+              <DropdownMenuSubContent className="w-72">
                 <DropdownMenuRadioGroup
                   value={automationLevel}
                   onValueChange={(value) => void switchAutomationLevel(value as NovelAutomationLevel)}
                 >
-                  <DropdownMenuRadioItem value="auto">
-                    {LIBRARY_AUTOMATION_LEVEL_LABELS.auto}
+                  <DropdownMenuRadioItem value="auto" className="items-start">
+                    <span className="grid gap-0.5">
+                      <span>{LIBRARY_AUTOMATION_LEVEL_LABELS.auto}</span>
+                      <span className="text-xs font-normal leading-5 text-hint-foreground">
+                        {LIBRARY_AUTOMATION_LEVEL_HELP.auto}
+                      </span>
+                    </span>
                   </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="collaborative">
-                    {LIBRARY_AUTOMATION_LEVEL_LABELS.collaborative}
+                  <DropdownMenuRadioItem value="collaborative" className="items-start">
+                    <span className="grid gap-0.5">
+                      <span>{LIBRARY_AUTOMATION_LEVEL_LABELS.collaborative}</span>
+                      <span className="text-xs font-normal leading-5 text-hint-foreground">
+                        {LIBRARY_AUTOMATION_LEVEL_HELP.collaborative}
+                      </span>
+                    </span>
                   </DropdownMenuRadioItem>
                 </DropdownMenuRadioGroup>
               </DropdownMenuSubContent>


### PR DESCRIPTION
Closes #27

## 改动

### 刀 1 — 新建默认推荐「全自动」
- 两档顺序对调（全自动在左）、`recommended` 角标移到全自动，默认值改为 `auto`
- 协作模式仍是平等的第二个分段按钮，**没有**收进折叠区
- 同步更新 `CreateNovelDialog.test.tsx` 里原本断言「协作在前 + 角标在协作上」的两条，并补一条把角标钉死在全自动上

### 刀 2 — 书架「更多」菜单切换模式
- **读出路径此前完全缺失**（`NovelProjectSummary` / `NovelProjectDetail` 都不带该字段，UI 根本不知道一本书是哪种模式）：新增 `readProjectAutomationLevel()`，由 summary 回传；缺 key 或非法值一律回落 `collaborative`，与引擎侧 `automation_level == "auto"` 的分支语义一致，**旧项目不会被悄悄升级成全自动**
- 写入路径：复用 `updateNovelProjectMetadata` 现成的 read-modify-write，其余键原样保留
- **IPC 白名单同步放行**（不登记会被静默剥掉且不报错，是本仓点名的历史 footgun）
- UI：`DropdownMenuSub` + RadioGroup（都是仓里已有的 ui 原语），Agent 运行中禁用并把文案换成「Agent 运行中，不能切换模式」，与「不能备份 / 不能删除」的现有约定一致
- 切换成功 toast 明确写「下一次规划大纲或写作时生效」——对应 issue Notes 里 collaborative→auto 中间态的措辞张力，用文案说清而不是加特判改引擎语义
- 菜单标签直接引用 `CreateNovelDialog` 导出的 label 常量，避免以后改文案漏改一处

## 验证

```
bun --no-cache run typecheck        → 通过
bun --no-cache run check:design     → Design-system contracts present.
bun --no-cache run check:architecture → 0 violation(s) / 散文块守卫通过 / 182 个 tsx 零原生 details
定向测试（4 文件）                   → 73 pass / 0 fail，Ran 73 tests across 4 files
全量 bun run test                    → 3012 pass / 0 fail（基线 3009，本次 +3）
```

新增 3 条测试：summary 正确回传当前档、缺 key 回落协作、切换后其余键（novel_id / title / language / estimated_total_chapters / words_per_chapter / style_profile）全部原样保留；渲染层一条覆盖菜单文案三态。

## 评审后追加的第二个 commit

外部审核做了 7 组变异测试，发现**核心数据链路有牙，但本 PR 风险最高的两处零覆盖**——这次改动的核心动作就是把 `active=` 与 `onClick=` 在「全自动」「协作模式」两个块之间对调，而接反了测试一条都抓不到。已全部补上：

| # | 补了什么 | 变异验证 |
|---|---|---|
| ① | 分档选中态断言（两个方向）+ 真实 DOM 点击断言回调实参 | `active` 对调 → **2 红**；`onClick` 对调 → **1 红**（`picked` 收到 `["collaborative","auto"]`） |
| ② | 全自动 HELP 补上代价侧 | — |
| ③ | 书架切档子菜单补后果说明（复用同一批文案常量，两处不会漂） | — |
| ④ | IPC 白名单抽成 `novel-metadata-input.ts` 独立模块 + 7 条测试 | 摘掉放行行 → **3 红**（此前是 60 pass 全绿） |
| ⑤ | 切换菜单项存在性 + `disabled` 绑定锁定 | 整块删掉 → **1 红**；拆掉 disabled → **1 红** |
| ⑥ | 修正 `readProjectAutomationLevel` 的注释断言 | — |

**② 的文案改动**：

```
初版：全程不打断，大纲和写作一口气跑完，适合想直接看结果。
评审后：中途不再停下来问你：大纲和写作一口气跑完，一章大约要 20 分钟，花费也更高。
定稿：  中途不再停下来问你：大纲和写作一口气跑完，适合想直接看结果。
```

推荐角标是产品替作者拍板，就有责任把另一面也说清——初版只讲了体验好。但评审版写死的「20 分钟 / 花费更高」被产品主人否掉了：**这两个数字依赖模型与章节长度，换个模型就不准**，写死在 UI 里会误导，也不符合「基调简约、少解释」的界面约定。

定稿保留「中途不再停下来问你」——代价侧仍有定性交代，只是不给会过期的数字。

## 修正初版描述里的两条「已知限制」

初版把**选择**包装成了**约束**，这里更正：

- ~~「IPC 入参读取层无直接测试：为测试单独导出会破坏该文件既有惯例」~~ → **说法不成立**。`electron/main/ipc/` 下就有 `pack-draft-input.ts` / `author-requests.ts` / `prose-blocks.ts` 三个为可测性抽出的独立入参校验模块，其中一个头部注释写着「独立模块，供测试直接导入」。已按此先例补齐（④）。
- ~~「菜单项本身无测试锁定：portal 默认关闭测不到」~~ → **说法不成立**。同一个测试文件里早就用 `readFileSync + toContain` 锁住了删除菜单项。已按此先例补齐（⑤）。

## 仍然成立的已知限制

1. **后端不拦 Agent 运行中的切换**：`runProjectMutation` 只检查备份锁、不检查 run 锁（编辑标题 / 更换封面本来也如此），所以「Agent 运行中禁用」的唯一防线是渲染端。行为与既有元数据编辑一致，未在本 PR 扩大改动面。
2. **YAML 往返丢注释**：外部审核做了真实往返实测——`novel_id` / `style_profile` / `genre` / `estimated_total_chapters` / `words_per_chapter` 等**所有机器消费的键零损失**，引擎正则照样命中；唯一损失是 YAML 注释，且这是 pre-existing（编辑标题 / 更换封面早就走同一条路径），config.yaml 也是机器管理文件。
3. **config.yaml 写入非原子**：pre-existing，但本 PR 新增了一个两次点击就触发的写入入口，建议后续统一改 write-temp-then-rename。

## 顺带发现的引擎侧不一致（未在本 PR 修）

核实 ⑥ 时发现：`commands/plan.md:18` 判 `== "auto"`（缺 key → 走协作，有确认门），但 `commands/write.md:50` 判 `== "collaborative"` 才确认、`== "auto"` 才跳过——**缺 key 时两个分支都不命中，写作确认门根本不触发**。即历史项目（config.yaml 缺该 key）在协作模式下也会跳过写作前确认。

属引擎 prompt 层，另开 issue 处理，本 PR 只把注释改准。

## 真机验收（产品主人已验，2026-08-20）

在本分支上起 dev 实测：

- ✅ **切换模式功能通过**：把「一个人的武侠」从 `auto` 切到 `collaborative`，落盘生效
- ✅ **用户资产保全通过**（本 PR 最需要担心的一条）：切换后 `novel_id` / `title` / `genre` / `language` / `estimated_total_chapters` / `words_per_chapter` / `style_profile` **8 个引擎字段一个不少**，正文文件未被触碰
- ✅ 新建对话框的默认档、顺序、推荐角标、说明文案均已目视确认
- ⏭️ 「手动点协作再创建、确认落盘是 collaborative」这一步未做人工复核——该行为已由 `CreateNovelDialog.interactions.test.tsx` 覆盖（真实 DOM 点击断言回调实参，且做过接反变异验证：对调 `onClick` → 测试红）
- ⏭️ 两档行为真的分叉（切协作后跑 `/write` 看确认门）未做，需要一次完整章节的时间与费用

## 原验收清单（供后续参考）

1. 新建 → 确认默认高亮「全自动」且角标在其上 → `cat config.yaml` 确认 `automation_level: auto`
2. **手动点「协作模式」再创建 → 确认落盘是 `collaborative`**（变异 M5/M6 的人肉替身，必做）
3. `cp config.yaml config.yaml.bak` → 切档 → `diff`，确认只有 `automation_level` 一行变化
4. 切协作跑 `/write` 确认确认门出现；切回全自动确认不打断
5. 起一个 run → 确认菜单项灰掉且显示「Agent 运行中，不能切换模式」
6. 老书（PR 之前建的协作档）确认显示「协作模式」且不被偷偷升级

🤖 Generated with [Claude Code](https://claude.com/claude-code)

