### PR TITLE
feat(agent): 写作链耗时归因仪表（issue #28 刀 D）

### DIFF
--- a/electron/main/agent/runtime/adapters/pi/pi-run-timing.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-run-timing.test.ts
@@ -1,0 +1,229 @@
+/**
+ * 耗时归因仪表测试（issue #28 刀 D）：时钟经 DI 注入，逐毫秒钉死 prefill/decode 切分、
+ * 子 agent 分组、工具明细与落盘形态。
+ */
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createPiRunTimingRecorder,
+  isEmptyPiRunTimingReport,
+  piRunTimingFileName,
+  writePiRunTimingReport,
+} from './pi-run-timing.ts'
+import type { PiRunTimingReport } from './pi-run-timing.ts'
+
+/** 可手拨的假时钟：每个 observe 前把 t 拨到该事件发生的时刻。 */
+function makeClock(start = 1_000) {
+  let t = start
+  return {
+    now: () => t,
+    at(next: number) {
+      t = next
+    },
+  }
+}
+
+function assistantMessageEnd(
+  overrides: { model?: string; usage?: Record<string, number>; stopReason?: string } = {},
+): Record<string, unknown> {
+  return {
+    type: 'message_end',
+    message: {
+      role: 'assistant',
+      model: overrides.model ?? 'deepseek-v4-pro',
+      stopReason: overrides.stopReason ?? 'stop',
+      usage: overrides.usage ?? { input: 100, output: 20, cacheRead: 5, cacheWrite: 1 },
+    },
+  }
+}
+
+const assistantMessageStart = { type: 'message_start', message: { role: 'assistant' } }
+const textDelta = { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: '正' } }
+
+describe('createPiRunTimingRecorder 主会话计账', () => {
+  test('一次模型调用切成 prefill（请求发出→首 token）与 decode（首 token→收笔）', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    recorder.observe({ type: 'agent_start' })
+    clock.at(1_010)
+    recorder.observe(assistantMessageStart)
+    clock.at(1_050)
+    recorder.observe(textDelta)
+    clock.at(1_060)
+    recorder.observe(textDelta)
+    clock.at(1_200)
+    recorder.observe(assistantMessageEnd())
+    clock.at(1_300)
+
+    const report = recorder.report('sess-1')
+    expect(report.main.modelCalls).toBe(1)
+    // 请求发出时刻取「上一条事件」（agent_start@1000），不是 message_start@1010——否则连线与排队算漏
+    expect(report.main.prefillMs).toBe(50)
+    expect(report.main.decodeMs).toBe(150)
+    expect(report.main.model).toBe('deepseek-v4-pro')
+    expect(report.main.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 5,
+      cacheCreationTokens: 1,
+    })
+    expect(report.main.wallMs).toBe(300)
+    expect(report.wallMs).toBe(300)
+    expect(report.sessionId).toBe('sess-1')
+    expect(report.subagents).toEqual([])
+  })
+
+  test('用户 prompt / 工具结果的 message_start·message_end 不算模型调用', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    recorder.observe({ type: 'message_start', message: { role: 'user' } })
+    recorder.observe({ type: 'message_end', message: { role: 'user' } })
+    recorder.observe({ type: 'message_end', message: { role: 'toolResult', toolName: 'Read' } })
+    clock.at(2_000)
+
+    expect(recorder.report().main.modelCalls).toBe(0)
+  })
+
+  test('无 delta 的模型调用（未流式/秒错）不产出负数，decode 记 0', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    recorder.observe({ type: 'agent_start' })
+    clock.at(1_100)
+    recorder.observe(assistantMessageStart)
+    clock.at(1_400)
+    recorder.observe(assistantMessageEnd({ stopReason: 'error' }))
+
+    const report = recorder.report()
+    expect(report.main.prefillMs).toBe(400)
+    expect(report.main.decodeMs).toBe(0)
+  })
+
+  test('工具明细：start/end 配对出 durationMs 与 toolMs，孤儿 end 忽略', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    recorder.observe({ type: 'tool_execution_start', toolCallId: 'tc-1', toolName: 'Read' })
+    clock.at(1_400)
+    recorder.observe({ type: 'tool_execution_end', toolCallId: 'tc-1', toolName: 'Read' })
+    recorder.observe({ type: 'tool_execution_end', toolCallId: 'tc-unknown', toolName: 'Write' })
+    clock.at(1_500)
+
+    const report = recorder.report()
+    expect(report.main.toolMs).toBe(400)
+    expect(report.main.tools).toEqual([
+      { toolName: 'Read', toolCallId: 'tc-1', startedAt: new Date(1_000).toISOString(), durationMs: 400 },
+    ])
+  })
+})
+
+describe('createPiRunTimingRecorder 子 agent 归因', () => {
+  const alpha = { agentId: 'chapter-writer', parentToolCallId: 'task-1' }
+  const beta = { agentId: 'memory-keeper', parentToolCallId: 'task-2' }
+
+  test('按 parentToolCallId 分组：同名 agent 的两次派发各成一条 span，token 各记各的', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    // 主会话派发 Task（工具明细的 toolCallId 就是子 span 的 parentToolCallId，瀑布靠它拼）
+    recorder.observe({ type: 'tool_execution_start', toolCallId: 'task-1', toolName: 'Task' })
+    clock.at(1_100)
+    recorder.observe(assistantMessageStart, alpha)
+    clock.at(1_150)
+    recorder.observe(textDelta, alpha)
+    clock.at(1_450)
+    recorder.observe(assistantMessageEnd({ model: 'deepseek-v4-pro', usage: { input: 10, output: 2 } }), alpha)
+    clock.at(1_500)
+    recorder.observe({ type: 'tool_execution_end', toolCallId: 'task-1', toolName: 'Task' })
+
+    clock.at(1_600)
+    recorder.observe(assistantMessageStart, beta)
+    clock.at(1_700)
+    recorder.observe(assistantMessageEnd({ model: 'deepseek-v4-lite', usage: { input: 7, output: 3 } }), beta)
+    clock.at(2_000)
+
+    const report = recorder.report()
+    expect(report.subagents.map((span) => span.agentId)).toEqual(['chapter-writer', 'memory-keeper'])
+
+    const [writer, keeper] = report.subagents
+    expect(writer!.parentToolCallId).toBe('task-1')
+    expect(writer!.prefillMs).toBe(50)
+    expect(writer!.decodeMs).toBe(300)
+    expect(writer!.wallMs).toBe(350)
+    expect(writer!.usage).toEqual({ inputTokens: 10, outputTokens: 2, cacheReadTokens: 0, cacheCreationTokens: 0 })
+    expect(keeper!.model).toBe('deepseek-v4-lite')
+    expect(keeper!.usage.inputTokens).toBe(7)
+
+    // 主会话的 Task 工具明细覆盖整段子会话墙钟，与子 span 的 parentToolCallId 对得上
+    expect(report.main.tools).toEqual([
+      { toolName: 'Task', toolCallId: 'task-1', startedAt: new Date(1_000).toISOString(), durationMs: 500 },
+    ])
+    // 子会话的账不并进主会话 span（并账口径归 pi-session 的 usageTotals）
+    expect(report.main.modelCalls).toBe(0)
+  })
+
+  test('报告只装标识与数字：prompt、正文、工具参数一概不入账', () => {
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+
+    recorder.observe({ type: 'tool_execution_start', toolCallId: 'tc-1', toolName: 'Write', args: { file_path: '/Users/me/novel/ch-001.md', content: '楚河抬起头。' } })
+    clock.at(1_200)
+    recorder.observe({ type: 'tool_execution_end', toolCallId: 'tc-1', toolName: 'Write', result: { content: [{ type: 'text', text: '楚河抬起头。' }] } })
+    recorder.observe(
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: '楚河抬起头。' } },
+      alpha,
+    )
+
+    const serialized = JSON.stringify(recorder.report())
+    expect(serialized).not.toContain('楚河抬起头')
+    expect(serialized).not.toContain('/Users/me')
+  })
+})
+
+describe('writePiRunTimingReport 落盘', () => {
+  function makeReport(overrides: Partial<PiRunTimingReport> = {}): PiRunTimingReport {
+    const recorder = createPiRunTimingRecorder({ now: () => 1_300 })
+    return { ...recorder.report('sess-abc'), ...overrides }
+  }
+
+  test('文件名对齐 pi 会话文件的 ${timestamp}_${sessionId} 命名，内容是完整报告', async () => {
+    const dir = join(mkdtempSync(join(tmpdir(), 'narracat-pi-timing-')), 'timing')
+    const report = makeReport()
+    const path = await writePiRunTimingReport({ dir, report })
+
+    expect(path).toBe(join(dir, piRunTimingFileName(report)))
+    expect(piRunTimingFileName(report)).toBe('1970-01-01T00-00-01-300Z_sess-abc.json')
+    expect(existsSync(path!)).toBe(true)
+    expect(JSON.parse(readFileSync(path!, 'utf8'))).toEqual(report)
+  })
+
+  test('sessionId 里的路径分隔符不会带进文件名', () => {
+    expect(piRunTimingFileName(makeReport({ sessionId: '../../escape' }))).toBe('1970-01-01T00-00-01-300Z_escape.json')
+  })
+
+  test('空报告（一次模型/工具调用都没有）被判空，调用方据此不落盘', () => {
+    const empty = createPiRunTimingRecorder({ now: () => 1_300 }).report()
+    expect(isEmptyPiRunTimingReport(empty)).toBe(true)
+
+    const clock = makeClock()
+    const recorder = createPiRunTimingRecorder({ now: clock.now })
+    recorder.observe(assistantMessageStart)
+    clock.at(1_200)
+    recorder.observe(assistantMessageEnd())
+    expect(isEmptyPiRunTimingReport(recorder.report())).toBe(false)
+  })
+
+  test('写失败只留警告不冒泡（仪表坏了不许把 run 带下水）', async () => {
+    const dir = join(mkdtempSync(join(tmpdir(), 'narracat-pi-timing-')), 'timing')
+    const path = await writePiRunTimingReport({
+      dir,
+      report: makeReport(),
+      writeFile: () => Promise.reject(new Error('磁盘满了')),
+    })
+    expect(path).toBeUndefined()
+  })
+})

--- a/electron/main/agent/runtime/adapters/pi/pi-run-timing.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-run-timing.ts
@@ -1,0 +1,315 @@
+/**
+ * Pi run 耗时归因仪表（issue #28 刀 D，"没有度量就没有优化"的那把尺）。
+ *
+ * 把一次 run 的墙钟按 span 切开——主会话一条、每次子 agent 派发各一条——每条再拆成三份：
+ * 等模型（连线 + 排队 + prefill）、解码（首 token → 收笔）、本地工具，配上 token 账与模型 id。
+ * 主会话 span 的工具明细里 `Task` 调用的 toolCallId 即子 agent span 的 parentToolCallId，据此
+ * 能事后重建一次 /write 的耗时瀑布：哪个子 agent 花了多久、烧了多少 token、慢在解码还是等模型。
+ *
+ * 三条纪律：
+ * - **只进机器通道**：报告落 userData/pi-agent/timing 的独立文件，不映射成任何 AgentEvent，
+ *   不进对话流也不进任务列表（ADR-0016 机器字段不入用户通道）。
+ * - **只记标识与数字**：agentId / toolName / model / 时间戳 / token 数；prompt、正文、工具参数
+ *   一律不记，落盘前标识串再过一遍 sanitizeDurableText。
+ * - **恒不阻断**：观测只做属性读与计数，落盘吞掉一切异常——仪表坏了不许把 run 带下水。
+ */
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { sanitizeDurableText } from '@shared/lib/agent-durable-events'
+import type { AgentTokenUsage } from '@shared/types/agent'
+import { atomicWriteFile } from '../../../../atomic-write.ts'
+
+/** 主会话 span 的分组键与 agentId 占位（引擎 agent id 里没有 main，不会撞名）。 */
+const MAIN_SPAN_KEY = 'main'
+/** 标识串落盘长度上限：agentId/toolName/model 都是短标识，超长即视为异常输入，截断。 */
+const MAX_LABEL_LENGTH = 120
+/** 单 span 工具明细条数上限：瀑布图够用即可，异常长的 run 不许把报告撑爆。 */
+const MAX_TOOL_SPANS = 500
+
+/** 耗时报告文件后缀（陈旧清扫按它筛，见 pi-session.ts resolveTimingDir）。 */
+export const PI_TIMING_FILE_SUFFIX = '.json'
+
+export interface PiTimingToolSpan {
+  toolName: string
+  /** 主会话里 Task 调用的 toolCallId = 对应子 agent span 的 parentToolCallId（瀑布拼接键）。 */
+  toolCallId: string
+  startedAt: string
+  durationMs: number
+}
+
+export interface PiTimingSpan {
+  /** 主会话恒为 main；子会话为引擎 agent id。 */
+  agentId: string
+  /** 子会话才有：派发它的 Task 工具调用号。 */
+  parentToolCallId?: string
+  /** 最后一次 assistant 回复用的模型 id（刀 A 验模型分层是否真的生效）。 */
+  model?: string
+  startedAt: string
+  finishedAt: string
+  wallMs: number
+  /** 模型调用次数（assistant message 条数）。 */
+  modelCalls: number
+  /** 发出请求 → 首个 token：连线 + 排队 + prefill。 */
+  prefillMs: number
+  /** 首个 token → 收笔：纯解码。 */
+  decodeMs: number
+  /** 本地工具执行累计（子会话的工具记在子会话自己的 span 上）。 */
+  toolMs: number
+  usage: AgentTokenUsage
+  tools: PiTimingToolSpan[]
+}
+
+export interface PiRunTimingReport {
+  schemaVersion: 1
+  /** pi 原生会话 id：拿它能对回 userData/pi-agent/sessions 下的那份完整会话 JSONL。 */
+  sessionId?: string
+  recordedAt: string
+  wallMs: number
+  main: PiTimingSpan
+  subagents: PiTimingSpan[]
+}
+
+/** 子会话事件的归属（来自 PiSubagentEventMessage；此处不 import 以免与 pi-session 成环）。 */
+export interface PiTimingSubagentScope {
+  agentId: string
+  parentToolCallId: string
+}
+
+export interface PiRunTimingRecorder {
+  /** 观测一条会话事件；子会话事件传 scope 归到自己的 span。 */
+  observe: (event: unknown, scope?: PiTimingSubagentScope) => void
+  report: (sessionId?: string) => PiRunTimingReport
+}
+
+type UnknownRecord = Record<string, unknown>
+
+interface UsageTotals {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+}
+
+interface SpanState {
+  agentId: string
+  parentToolCallId?: string
+  model?: string
+  startedAtMs: number
+  lastEventAtMs: number
+  modelCalls: number
+  prefillMs: number
+  decodeMs: number
+  toolMs: number
+  usage: UsageTotals
+  tools: PiTimingToolSpan[]
+  /** 本次模型调用的游标：请求发出时刻 / 首个 token 时刻。 */
+  requestedAtMs?: number
+  firstTokenAtMs?: number
+  pendingTools: Map<string, { toolName: string; startedAtMs: number }>
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function label(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value) return undefined
+  return sanitizeDurableText(value, '', MAX_LABEL_LENGTH) || undefined
+}
+
+/** assistant 之外的 message_start/message_end（用户 prompt、工具结果回填）不是模型调用，不计账。 */
+function isAssistantMessage(event: UnknownRecord): boolean {
+  return isRecord(event.message) && event.message.role === 'assistant'
+}
+
+function hasDelta(event: UnknownRecord): boolean {
+  const sub = event.assistantMessageEvent
+  return isRecord(sub) && typeof sub.delta === 'string'
+}
+
+function addUsage(totals: UsageTotals, value: unknown): void {
+  if (!isRecord(value)) return
+  for (const key of ['input', 'output', 'cacheRead', 'cacheWrite'] as const) {
+    const amount = value[key]
+    if (typeof amount === 'number') totals[key] += amount
+  }
+}
+
+function toTokenUsage(totals: UsageTotals): AgentTokenUsage {
+  return {
+    inputTokens: totals.input,
+    outputTokens: totals.output,
+    cacheReadTokens: totals.cacheRead,
+    cacheCreationTokens: totals.cacheWrite,
+  }
+}
+
+/**
+ * 记录器：全部状态是 run 级闭包，观测只做属性读、计数与 Map 存取，不抛。
+ * 时钟经 now 注入（单测要确定性的毫秒切分）。
+ */
+export function createPiRunTimingRecorder({ now = Date.now }: { now?: () => number } = {}): PiRunTimingRecorder {
+  const runStartedAtMs = now()
+  const spans = new Map<string, SpanState>()
+
+  function ensureSpan(key: string, at: number, scope?: PiTimingSubagentScope): SpanState {
+    const existing = spans.get(key)
+    if (existing) return existing
+    const span: SpanState = {
+      agentId: scope ? (label(scope.agentId) ?? 'unknown') : MAIN_SPAN_KEY,
+      ...(scope ? { parentToolCallId: scope.parentToolCallId } : {}),
+      // 主会话 span 从 run 起点算（建会话/装配也是墙钟的一部分）；子会话从首条事件算。
+      startedAtMs: scope ? at : runStartedAtMs,
+      lastEventAtMs: at,
+      modelCalls: 0,
+      prefillMs: 0,
+      decodeMs: 0,
+      toolMs: 0,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      tools: [],
+      pendingTools: new Map(),
+    }
+    spans.set(key, span)
+    return span
+  }
+
+  function observe(event: unknown, scope?: PiTimingSubagentScope): void {
+    if (!isRecord(event)) return
+    const at = now()
+    const span = ensureSpan(scope?.parentToolCallId ?? MAIN_SPAN_KEY, at, scope)
+    // 请求发出的时刻取「上一条事件」：pi 的 message_start 由 provider 首个响应事件触发（见
+    // pi-agent-core agent-loop.js 的 stream "start" 分支），拿它当起点会把连线与排队时间算漏。
+    const previousEventAtMs = span.lastEventAtMs
+    span.lastEventAtMs = at
+
+    if (event.type === 'message_start') {
+      if (!isAssistantMessage(event)) return
+      span.requestedAtMs = previousEventAtMs
+      span.firstTokenAtMs = undefined
+      return
+    }
+
+    if (event.type === 'message_update') {
+      if (span.firstTokenAtMs === undefined && hasDelta(event)) span.firstTokenAtMs = at
+      return
+    }
+
+    if (event.type === 'message_end') {
+      if (!isAssistantMessage(event)) return
+      const message = event.message as UnknownRecord
+      const firstTokenAtMs = span.firstTokenAtMs ?? at
+      const requestedAtMs = span.requestedAtMs ?? firstTokenAtMs
+      span.modelCalls += 1
+      span.prefillMs += Math.max(0, firstTokenAtMs - requestedAtMs)
+      span.decodeMs += Math.max(0, at - firstTokenAtMs)
+      span.requestedAtMs = undefined
+      span.firstTokenAtMs = undefined
+      span.model = label(message.model) ?? span.model
+      addUsage(span.usage, message.usage)
+      return
+    }
+
+    if (event.type === 'tool_execution_start') {
+      const toolCallId = event.toolCallId
+      if (typeof toolCallId !== 'string' || !toolCallId) return
+      span.pendingTools.set(toolCallId, { toolName: label(event.toolName) ?? 'unknown', startedAtMs: at })
+      return
+    }
+
+    if (event.type === 'tool_execution_end') {
+      const toolCallId = event.toolCallId
+      if (typeof toolCallId !== 'string' || !toolCallId) return
+      const pending = span.pendingTools.get(toolCallId)
+      if (!pending) return
+      span.pendingTools.delete(toolCallId)
+      const durationMs = Math.max(0, at - pending.startedAtMs)
+      span.toolMs += durationMs
+      if (span.tools.length < MAX_TOOL_SPANS) {
+        span.tools.push({
+          toolName: pending.toolName,
+          toolCallId,
+          startedAt: new Date(pending.startedAtMs).toISOString(),
+          durationMs,
+        })
+      }
+    }
+  }
+
+  function finalize(span: SpanState, finishedAtMs: number): PiTimingSpan {
+    return {
+      agentId: span.agentId,
+      ...(span.parentToolCallId ? { parentToolCallId: span.parentToolCallId } : {}),
+      ...(span.model ? { model: span.model } : {}),
+      startedAt: new Date(span.startedAtMs).toISOString(),
+      finishedAt: new Date(finishedAtMs).toISOString(),
+      wallMs: Math.max(0, finishedAtMs - span.startedAtMs),
+      modelCalls: span.modelCalls,
+      prefillMs: span.prefillMs,
+      decodeMs: span.decodeMs,
+      toolMs: span.toolMs,
+      usage: toTokenUsage(span.usage),
+      tools: span.tools,
+    }
+  }
+
+  function report(sessionId?: string): PiRunTimingReport {
+    const finishedAtMs = now()
+    const main = spans.get(MAIN_SPAN_KEY) ?? ensureSpan(MAIN_SPAN_KEY, finishedAtMs)
+    const subagents = [...spans.entries()]
+      .filter(([key]) => key !== MAIN_SPAN_KEY)
+      .map(([, span]) => finalize(span, span.lastEventAtMs))
+      .sort((a, b) => a.startedAt.localeCompare(b.startedAt))
+    return {
+      schemaVersion: 1,
+      ...(sessionId ? { sessionId } : {}),
+      recordedAt: new Date(finishedAtMs).toISOString(),
+      wallMs: Math.max(0, finishedAtMs - runStartedAtMs),
+      // 主会话 span 的墙钟就是整个 run 的墙钟（子 agent 派发是它的一次工具调用）。
+      main: finalize(main, finishedAtMs),
+      subagents,
+    }
+  }
+
+  return { observe, report }
+}
+
+/**
+ * 空报告：一次模型调用与工具调用都没发生（建会话即被取消、连通性探活之类）。这种报告只有墙钟
+ * 没有归因，落盘只会把 timing 目录淹掉，不写。
+ */
+export function isEmptyPiRunTimingReport(report: PiRunTimingReport): boolean {
+  return report.main.modelCalls === 0 && report.main.tools.length === 0 && report.subagents.length === 0
+}
+
+/** 报告文件名：对齐 pi 原生会话文件的 `${timestamp}_${sessionId}` 命名，好一眼对上同一次 run。 */
+export function piRunTimingFileName(report: PiRunTimingReport): string {
+  const stamp = report.recordedAt.replace(/[:.]/g, '-')
+  const sessionId = (report.sessionId ?? '').replace(/[^A-Za-z0-9-]/g, '') || 'unknown'
+  return `${stamp}_${sessionId}${PI_TIMING_FILE_SUFFIX}`
+}
+
+export interface WritePiRunTimingReportArgs {
+  dir: string
+  report: PiRunTimingReport
+  writeFile?: typeof atomicWriteFile
+}
+
+/**
+ * 落盘：尽力而为——目录建不了/写不进只留一行警告，绝不冒泡进 run（仪表不是正确性前提）。
+ * 返回写成的路径，失败返回 undefined。
+ */
+export async function writePiRunTimingReport({
+  dir,
+  report,
+  writeFile = atomicWriteFile,
+}: WritePiRunTimingReportArgs): Promise<string | undefined> {
+  const path = join(dir, piRunTimingFileName(report))
+  try {
+    await mkdir(dir, { recursive: true })
+    await writeFile(path, `${JSON.stringify(report, null, 2)}\n`)
+    return path
+  } catch (error) {
+    console.warn('[narracat] pi 耗时报告落盘失败（不阻断 run）', error)
+    return undefined
+  }
+}

--- a/electron/main/agent/runtime/adapters/pi/pi-session.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-session.test.ts
@@ -423,6 +423,32 @@ describe('runPiSession 子会话事件通道（切片⑤）', () => {
     })
   })
 
+  test('子会话事件经 channel 归因到子 agent 自己的 span（issue #28 刀 D 的唯一数据入口）', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'narracat-pi-timing-sub-'))
+    const channel = createSubagentEventChannel()
+    const fake = makeFakeSession([
+      parentMessageEnd,
+      { type: 'channel:push', payload: wrapped({ type: 'message_start', message: { role: 'assistant' } }) },
+      { type: 'channel:push', payload: childMessageEnd({ input: 7, output: 3, cacheRead: 0, cacheWrite: 0 }) },
+    ])
+    await collectWithChannel(
+      channel,
+      makeOptions({ subagentChannel: channel, agentDir, sessionStore: { dir: join(agentDir, 'sessions') } }),
+      fake.createSession,
+    )
+
+    const timingDir = join(agentDir, 'timing')
+    const report = JSON.parse(readFileSync(join(timingDir, readdirSync(timingDir)[0]!), 'utf8'))
+    // 子会话事件在 channel 上是包了一层的 PiSubagentEventMessage：接线漏掉解包（传 wrapped 而非
+    // wrapped.message）时，recorder 只看见未知事件，下面三条断言全塌——刀 D 的子 agent 归因正是
+    // 靠这一层，坏了整份报告只剩主会话，且不报错。
+    expect(report.subagents.length).toBe(1)
+    expect(report.subagents[0].agentId).toBe('chapter-writer')
+    expect(report.subagents[0].parentToolCallId).toBe('tc-1')
+    expect(report.subagents[0].modelCalls).toBe(1)
+    expect(report.subagents[0].usage).toEqual({ inputTokens: 7, outputTokens: 3, cacheReadTokens: 0, cacheCreationTokens: 0 })
+  })
+
   test('子会话失败路径（触 maxTurns / 报错 / 被中止，全都不发 run_end）token 仍并账——最贵的三条路径不漏计', async () => {
     for (const failure of [
       // 触回合上限：桥只补 narracat_pi_max_turns，无 run_end

--- a/electron/main/agent/runtime/adapters/pi/pi-session.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-session.test.ts
@@ -3,7 +3,7 @@
  * abort 传播、未支持面 fail-loud。真 createAgentSession 需打网络，不进单测（spike 已实测）。
  */
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
@@ -554,6 +554,45 @@ describe('runPiSession 会话持久化与 resume（切片⑦）', () => {
     writeFileSync(join(dir, '2026-02-01T00-00-00_abcd1234-x.jsonl'), '{}\n')
     expect(findPiSessionFile(dir, 'abcd1234-x')).toBe(join(dir, '2026-02-01T00-00-00_abcd1234-x.jsonl'))
     expect(findPiSessionFile(dir, 'missing-id')).toBeUndefined()
+  })
+
+  test('主会话跑完落一份耗时报告，且报告不进事件流（issue #28 刀 D）', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'narracat-pi-agent-'))
+    const dir = join(agentDir, 'sessions')
+    const fake = makeFakeSession([
+      { type: 'agent_start' },
+      { type: 'message_start', message: { role: 'assistant' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: '正' } },
+      {
+        type: 'message_end',
+        message: { role: 'assistant', model: 'deepseek-v4-pro', stopReason: 'stop', usage: { input: 9, output: 4 } },
+      },
+    ])
+    const got = await collect(
+      runPiSession({
+        prompt: 'hi',
+        options: makeOptions({ agentDir, sessionStore: { dir } }),
+        createSession: fake.createSession,
+      }),
+    )
+    // 机器字段不入用户通道（ADR-0016）：报告只落盘，事件流里一条都没有
+    expect(got.some((message) => JSON.stringify(message).includes('prefillMs'))).toBe(false)
+
+    const reports = readdirSync(join(agentDir, 'timing'))
+    expect(reports.length).toBe(1)
+    const report = JSON.parse(readFileSync(join(agentDir, 'timing', reports[0]!), 'utf8'))
+    expect(report.schemaVersion).toBe(1)
+    expect(report.sessionId).toBe((fake.capturedArgs().sessionManager as SessionManager).getSessionId())
+    expect(report.main.modelCalls).toBe(1)
+    expect(report.main.model).toBe('deepseek-v4-pro')
+    expect(report.main.usage).toEqual({ inputTokens: 9, outputTokens: 4, cacheReadTokens: 0, cacheCreationTokens: 0 })
+  })
+
+  test('子会话（无 sessionStore）不记耗时：账已由父会话按 parentToolCallId 归一，不重复计', async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'narracat-pi-agent-'))
+    const fake = makeFakeSession([{ type: 'agent_start' }])
+    await collect(runPiSession({ prompt: 'hi', options: makeOptions({ agentDir }), createSession: fake.createSession }))
+    expect(existsSync(join(agentDir, 'timing'))).toBe(false)
   })
 
   test('sweepStalePiSessionFiles：删超期 jsonl，留新鲜文件与非 jsonl', () => {

--- a/electron/main/agent/runtime/adapters/pi/pi-session.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-session.ts
@@ -20,6 +20,12 @@ import type { Extension, ToolDefinition } from '@mariozechner/pi-coding-agent'
 import type { AgentTokenUsage } from '@shared/types/agent'
 import { PI_MAX_TURNS_MESSAGE_TYPE, PI_RUN_END_MESSAGE_TYPE, PI_SESSION_MESSAGE_TYPE } from './pi-event-mapper.ts'
 import type { PiMaxTurnsMessage, PiRunEndMessage, PiSessionMessage } from './pi-event-mapper.ts'
+import {
+  createPiRunTimingRecorder,
+  isEmptyPiRunTimingReport,
+  PI_TIMING_FILE_SUFFIX,
+  writePiRunTimingReport,
+} from './pi-run-timing.ts'
 // 类型导入（编译期擦除）：pi-subagent 反向依赖本模块的 runPiSession，值导入会成环。
 import type { PiSubagentEventChannel, PiSubagentEventMessage } from './pi-subagent.ts'
 
@@ -109,15 +115,25 @@ function createIsolatedResourceLoader(systemPrompt: string | undefined, extensio
  * 30 天会话清理的同族衰减）。 */
 const SESSION_FILE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
+/** 耗时报告 TTL（issue #28 刀 D）：报告是纯数字账、体积极小，比会话 JSONL 留久些——优化收益要
+ *  跨天比对改动前后的耗时瀑布。 */
+const TIMING_FILE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
 /** pi session id 形状（randomUUID 及其变体的宽松面）：跨层来的 id 先过这道，不让脏值进文件名匹配。 */
 const SESSION_ID_SHAPE = /^[A-Za-z0-9-]{8,64}$/
 
 /**
  * 陈旧会话文件清扫：JSONL 里是含小说全文的完整对话，不清扫会在 userData 无限积累。TTL 判 mtime
- * （活跃会话每次 append 都会刷新），每进程每目录只扫一次（见 sweptSessionDirs）；尽力而为，
+ * （活跃会话每次 append 都会刷新），每进程每目录只扫一次（见 sweptDirs）；尽力而为，
  * 任何失败都不阻断 run。一次性惰性清扫，不常驻定时任务。
+ * suffix 可换（耗时报告目录复用同一套清扫，见 resolveTimingDir）。
  */
-export function sweepStalePiSessionFiles(dir: string, ttlMs = SESSION_FILE_TTL_MS, now = Date.now()): void {
+export function sweepStalePiSessionFiles(
+  dir: string,
+  ttlMs = SESSION_FILE_TTL_MS,
+  now = Date.now(),
+  suffix = '.jsonl',
+): void {
   let entries: string[]
   try {
     entries = readdirSync(dir)
@@ -125,7 +141,7 @@ export function sweepStalePiSessionFiles(dir: string, ttlMs = SESSION_FILE_TTL_M
     return
   }
   for (const name of entries) {
-    if (!name.endsWith('.jsonl')) continue
+    if (!name.endsWith(suffix)) continue
     try {
       const path = join(dir, name)
       if (statSync(path).mtimeMs < now - ttlMs) unlinkSync(path)
@@ -152,7 +168,21 @@ export function findPiSessionFile(dir: string, sessionId: string): string | unde
   return latest ? join(dir, latest) : undefined
 }
 
-const sweptSessionDirs = new Set<string>()
+/** 已惰性清扫过的目录（会话目录与耗时报告目录共用一份，键是绝对路径不会撞）。 */
+const sweptDirs = new Set<string>()
+
+/**
+ * 耗时报告目录（userData/pi-agent/timing，issue #28 刀 D）：与会话 JSONL 分开放——两者 TTL 不同，
+ * 且不能让报告落进 findPiSessionFile 的匹配面。首次使用时惰性清扫一次陈旧报告。
+ */
+function resolveTimingDir(agentDir: string): string {
+  const dir = join(agentDir, 'timing')
+  if (!sweptDirs.has(dir)) {
+    sweptDirs.add(dir)
+    sweepStalePiSessionFiles(dir, TIMING_FILE_TTL_MS, Date.now(), PI_TIMING_FILE_SUFFIX)
+  }
+  return dir
+}
 
 /** 跨会话进程内单调计数：合成 toolCallId 必须全进程唯一——sink 按 toolCallId 归并是 run 级全局，
  * 并发子会话若各自从 1 计数就把撞号问题原样搬回来。 */
@@ -190,8 +220,8 @@ function resolveSessionManager(options: PiRunOptions): SessionManager {
   const store = options.sessionStore
   if (!store) return SessionManager.inMemory(options.cwd)
   mkdirSync(store.dir, { recursive: true })
-  if (!sweptSessionDirs.has(store.dir)) {
-    sweptSessionDirs.add(store.dir)
+  if (!sweptDirs.has(store.dir)) {
+    sweptDirs.add(store.dir)
     sweepStalePiSessionFiles(store.dir)
   }
   if (store.resumeSessionId) {
@@ -229,6 +259,14 @@ export async function* runPiSession({
 
   // 会话装配（切片⑦）：resume 定位失败在这里就抛（未发起任何网络调用），fail-loud 早于建会话。
   const sessionManager = resolveSessionManager(options)
+
+  /**
+   * 耗时归因仪表（issue #28 刀 D）：只主会话记（sessionStore 即主/子会话的既有判别式）——子会话
+   * 每条事件都经 subagentChannel 流到父会话侧按 parentToolCallId 分组归账，子会话自己再记一份就是
+   * 重复计账。报告只落 timing 目录，不进事件流，见 pi-run-timing.ts 的三条纪律。
+   */
+  const timingDir = options.sessionStore ? resolveTimingDir(options.agentDir) : undefined
+  const timing = timingDir ? createPiRunTimingRecorder() : undefined
 
   const { session } = await createSession({
     cwd: options.cwd,
@@ -340,12 +378,14 @@ export async function* runPiSession({
     const normalized = normalizeToolCallId(event)
     queue.push(normalized)
     if (isRecord(normalized)) accumulate(normalized)
+    timing?.observe(normalized)
     notify?.()
   })
   const unsubscribe = typeof maybeUnsubscribe === 'function' ? (maybeUnsubscribe as () => void) : undefined
   const unsubscribeChannel = options.subagentChannel?.subscribe((wrapped) => {
     queue.push(wrapped)
     accumulateSubagent(wrapped)
+    timing?.observe(wrapped.message, { agentId: wrapped.agentId, parentToolCallId: wrapped.parentToolCallId })
     notify?.()
   })
 
@@ -404,5 +444,10 @@ export async function* runPiSession({
     unsubscribe?.()
     unsubscribeChannel?.()
     if (!settled) await safeAbort(session)
+    // 耗时报告落在 finally：中止/失败的 run 同样出报告——最贵的那几条路径正是最该量的。
+    if (timing && timingDir) {
+      const report = timing.report(sessionManager.getSessionId())
+      if (!isEmptyPiRunTimingReport(report)) await writePiRunTimingReport({ dir: timingDir, report })
+    }
   }
 }


### PR DESCRIPTION
Refs #28（**只实现刀 D**，issue 保持开启）

## 为什么只做刀 D

issue #28 的结论是「没有度量就没有优化」：此前只有 run 级 `startedAt` / `finishedAt`，没有步骤级或子 agent 级归因，刀 A/B/C 的收益无法验证。刀 A 看起来最诱人（改两行 frontmatter），但如果抽取本来只占墙钟 10%，那就是白忙。

**本 PR 不关闭 issue #28** —— 刀 A（模型分层）、刀 B（审校与抽取乐观并行）、刀 C（前缀缓存）、刀 E（体感）都还开着。

## 改动

- 新增 `pi-run-timing.ts`：按 span 记录墙钟拆解（prefill / decode / 本地工具）、模型调用次数、usage、最后使用的模型 id（刀 A 将来要靠它验模型分层是否真的生效）
- 主会话一个 span，每个子 agent 按 `parentToolCallId` 一个 span
- 报告落盘到 `agentDir/timing`，**不进事件流**（ADR-0016：机器字段不进用户通道），有测试钉死这一条
- 只记标识与数字：agentId / toolName / model / 时间戳 / token 数，**不记** prompt、正文、工具参数

## 验证

```
bun --no-cache run typecheck          → 通过
bun --no-cache run check:architecture → 0 violation(s) / 散文块守卫通过
定向测试                               → 41 pass / 0 fail，Ran 41 tests across 2 files
补测后 pi-session.test.ts              → 32 pass / 0 fail，Ran 32 tests across 1 file
```

**第二个 commit 是补测**：外部审查指出 `pi-session → recorder` 的子会话接线零覆盖。实测确认属实——把 `timing?.observe(wrapped.message, …)` 误写成 `observe(wrapped, …)`（这类解包最典型的改坏方式）后，41 条测试**依然全绿**，而子 agent 归因已经静默失效、整份报告只剩主会话。这条线是刀 D 的唯一数据入口，坏了整个仪表白做，所以补了一条测试并用变异验证它有牙（注入该变异后立刻失败）。

## 已知限制（外部审查提出，均判定不阻断）

1. **`toolMs` 口径需要注意**：主会话 span 的 Task 派发本身也是一次 tool_execution，所以子 agent 的整段 LLM 墙钟会计进 `main.toolMs`；并行工具的重叠区间是直接相加、不是并集。读这份数据时不能把 `main.toolMs` 当成「本地工具/MCP 耗时」。
2. **主会话内的步骤级只能间接推**：主会话把一次 run 内所有模型调用聚合成两个总数，`write.md` 步骤 3a（压缩任务书）这类主会话内的环节无法单独定位。子 agent 级归因是完整的。
3. **空串 toolCallId 的分组**：在不回 tool call id 的第三方兼容端点上，多个子 agent 可能落到同一个 key。本仓已有 `createToolCallIdNormalizer` 处理这个场景，后续可以接上。
4. **口径全部由假时钟单测钉死，未跑过真实事件流**。

## 未做

- **真机验收未做**（刀 D 的第一条 AC）：需要真跑一次单章 `/write`，确认报告能重建耗时瀑布、且数字符合直觉。这一条是后续动刀 A/B/C 的前提——如果真实事件流上口径有系统性偏斜，后面所有优化判断都建立在错的数字上。
- 刀 A / B / C / E 均未实现。
- `docs/agents/progress.md` 未更新（三条线并行，改同一份文档必冲突，留待统一收口）。

## 关联

#29 是墙钟白烧的一大来源（实测一次 `/write` 里 273s + 250s ≈ 8.7 分钟白跑，约占单章 1/3）。合完 #29 后，这份仪表正好可以用来量它到底回收了多少。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
