### PR TITLE
feat(ops): 单章写作耗时瀑布脚本（替代 PR #32 的生产埋点）

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ops:status": "node scripts/ops-status.mjs",
     "ops:issues": "node scripts/ops-issues.mjs",
     "ops:check": "node scripts/ops-check.mjs",
+    "ops:write-timing": "node scripts/ops-write-timing.mjs",
     "perf:baseline": "tsx scripts/performance-baseline.ts",
     "check:design": "node scripts/check-design-system.mjs",
     "check:architecture": "node scripts/check-architecture.mjs --enforce && node scripts/check-prose-blocks.mjs && node scripts/check-no-native-details.mjs",

--- a/scripts/ops-write-timing.mjs
+++ b/scripts/ops-write-timing.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * 单章写作耗时瀑布（issue #28）：读 pi 已经在写的会话记录，把一次 run 的墙钟拆成
+ * 「子 agent 派发 / 主会话模型调用 / 本地工具」三类，回答「这一章的时间到底花在哪」。
+ *
+ * 为什么是只读脚本而不是生产埋点：pi 的 `sessions/*.jsonl` 每条 message 本就带 timestamp、
+ * model、usage，Task 的 subagent_type 也在调用参数里——重建瀑布不需要再往**用户磁盘**写一份
+ * 仪表产物。issue #29 的诊断就是这么做出来的（PR #32 据此关闭，分支
+ * feat/28-write-timing-instrumentation 保留，里面有 JSONL 给不了的 prefill/decode 拆分）。
+ *
+ * 口径三点须知（都是真机数据上撞出来的，别想当然）：
+ * - 并发派发（write.md 步骤 6 一次 4 个 memory-keeper）按**区间并集**算挂钟，不是逐个相加，
+ *   否则 4 路各 81s 会记成 324s。
+ * - 一条 assistant 消息的 timestamp 是它**写完**的时刻，所以「模型调用耗时」取它与上一条消息
+ *   的间隔（含连线、排队、prefill、解码）。
+ * - **同一条 assistant 消息里发出的工具是一批，整批的 toolResult 共用一个写入时刻**，于是批内
+ *   每个工具的「耗时」都等于批次挂钟。模型常在派发 Task 的同时调 TaskUpdate，若照单全收，
+ *   4 个 TaskUpdate 会各自背上 273s，把「本地工具」算成 709s——实测真值是 4.8s。因此混批
+ *   （含 Task）里的本地工具一律不计入本地工具耗时，只计数并在报告里标注。
+ *
+ * 只读：不写、不删任何文件。
+ *
+ * 用法：
+ *   node scripts/ops-write-timing.mjs                  最近一次会话
+ *   node scripts/ops-write-timing.mjs --list           列出可选会话
+ *   node scripts/ops-write-timing.mjs <file.jsonl>     指定会话文件
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const TASK_TOOL_NAME = 'Task'
+const NAMESPACE_PREFIX = /^narracat:/
+
+/** pi 会话目录：Electron `app.getPath('userData')` 在脚本里跑不到，按平台惯例推。 */
+export function piSessionsDir(platform = process.platform, env = process.env, home = homedir()) {
+  if (platform === 'win32') {
+    const appData = env.APPDATA || join(home, 'AppData', 'Roaming')
+    return join(appData, 'NarraCat', 'pi-agent', 'sessions')
+  }
+  if (platform === 'darwin') return join(home, 'Library', 'Application Support', 'NarraCat', 'pi-agent', 'sessions')
+  return join(env.XDG_CONFIG_HOME || join(home, '.config'), 'NarraCat', 'pi-agent', 'sessions')
+}
+
+/** 坏行跳过而不是整份放弃：会话文件可能被中断写坏最后一行。 */
+export function parseSessionLines(text) {
+  const records = []
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      records.push(JSON.parse(trimmed))
+    } catch {
+      // 忽略半行
+    }
+  }
+  return records
+}
+
+/** 区间并集总长：并发派发的重叠部分只算一次。 */
+export function mergeIntervalsMs(intervals) {
+  const sorted = [...intervals].filter((i) => i.end > i.start).sort((a, b) => a.start - b.start)
+  let total = 0
+  let cursor = -Infinity
+  for (const { start, end } of sorted) {
+    const from = Math.max(start, cursor)
+    if (end > from) total += end - from
+    cursor = Math.max(cursor, end)
+  }
+  return total
+}
+
+function readToolCalls(message) {
+  if (!Array.isArray(message?.content)) return []
+  return message.content.filter((block) => block?.type === 'toolCall' && typeof block.id === 'string')
+}
+
+export function summarizeSession(records) {
+  const messages = records.filter((record) => record?.type === 'message' && record.message)
+  const pending = new Map()
+  const spans = []
+  const usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+  const models = new Set()
+  let modelCalls = 0
+  let modelMs = 0
+  let previousMs
+
+  for (const record of messages) {
+    const at = Date.parse(record.timestamp)
+    const message = record.message
+    if (!Number.isFinite(at)) continue
+
+    if (message.role === 'assistant') {
+      modelCalls += 1
+      if (previousMs !== undefined) modelMs += Math.max(0, at - previousMs)
+      if (typeof message.model === 'string') models.add(message.model)
+      for (const key of ['input', 'output', 'cacheRead', 'cacheWrite']) {
+        if (typeof message.usage?.[key] === 'number') usage[key] += message.usage[key]
+      }
+      const batch = readToolCalls(message)
+      // 批内混了 Task 时，本地工具的结束时刻会被最慢的 Task 拖长（整批共用写入时刻）。
+      const batchHasTask = batch.some((call) => call.name === TASK_TOOL_NAME)
+      for (const call of batch) {
+        const isTask = call.name === TASK_TOOL_NAME
+        pending.set(call.id, {
+          startMs: at,
+          isTask,
+          durationTrusted: isTask || !batchHasTask,
+          label: isTask
+            ? String(call.arguments?.subagent_type ?? 'unknown').replace(NAMESPACE_PREFIX, '')
+            : String(call.name ?? 'unknown'),
+        })
+      }
+    }
+
+    if (message.role === 'toolResult') {
+      const started = pending.get(message.toolCallId)
+      if (started) {
+        pending.delete(message.toolCallId)
+        spans.push({ ...started, endMs: at, isError: message.isError === true })
+      }
+    }
+
+    previousMs = at
+  }
+
+  const startedAtMs = messages.length ? Date.parse(messages[0].timestamp) : undefined
+  const finishedAtMs = messages.length ? Date.parse(messages[messages.length - 1].timestamp) : undefined
+  const toIntervals = (list) => list.map((span) => ({ start: span.startMs, end: span.endMs }))
+  const subagentSpans = spans.filter((span) => span.isTask)
+  const localSpans = spans.filter((span) => !span.isTask && span.durationTrusted)
+  const localSpansShadowed = spans.filter((span) => !span.isTask && !span.durationTrusted)
+
+  const byAgent = new Map()
+  for (const span of subagentSpans) {
+    const entry = byAgent.get(span.label) ?? { agentId: span.label, calls: 0, totalMs: 0, errors: 0 }
+    entry.calls += 1
+    entry.totalMs += span.endMs - span.startMs
+    if (span.isError) entry.errors += 1
+    byAgent.set(span.label, entry)
+  }
+
+  return {
+    sessionId: records.find((record) => record?.type === 'session')?.id,
+    startedAtMs,
+    finishedAtMs,
+    wallMs: startedAtMs !== undefined && finishedAtMs !== undefined ? finishedAtMs - startedAtMs : 0,
+    models: [...models],
+    modelCalls,
+    modelMs,
+    usage,
+    subagentWallMs: mergeIntervalsMs(toIntervals(subagentSpans)),
+    subagentSumMs: subagentSpans.reduce((sum, span) => sum + (span.endMs - span.startMs), 0),
+    localToolWallMs: mergeIntervalsMs(toIntervals(localSpans)),
+    localToolCalls: localSpans.length,
+    /** 与 Task 同批、耗时被拖长而不可信的本地工具（只计数，不计时）。 */
+    localToolShadowed: localSpansShadowed.length,
+    unfinished: pending.size,
+    subagents: subagentSpans.map((span, index) => ({
+      order: index + 1,
+      agentId: span.label,
+      ms: span.endMs - span.startMs,
+      isError: span.isError,
+    })),
+    byAgent: [...byAgent.values()].sort((a, b) => b.totalMs - a.totalMs),
+  }
+}
+
+const seconds = (ms) => `${(ms / 1000).toFixed(0)}s`
+const share = (ms, total) => (total > 0 ? `${((ms / total) * 100).toFixed(1)}%` : '—')
+
+export function formatReport(summary) {
+  const lines = []
+  const total = summary.wallMs
+  lines.push(`会话 ${summary.sessionId ?? '(未知)'}`)
+  lines.push(`总墙钟 ${seconds(total)}（${(total / 60000).toFixed(1)} 分钟）  模型 ${summary.models.join(', ') || '—'}`)
+  lines.push('')
+  lines.push('归因（子 agent 与本地工具按区间并集算挂钟，并发不重复计）：')
+  lines.push(`  子 agent 派发    ${seconds(summary.subagentWallMs).padStart(6)}  ${share(summary.subagentWallMs, total).padStart(6)}`)
+  lines.push(`  主会话模型调用   ${seconds(summary.modelMs).padStart(6)}  ${share(summary.modelMs, total).padStart(6)}  （${summary.modelCalls} 次，含派发等待）`)
+  const shadowed = summary.localToolShadowed > 0 ? `，另有 ${summary.localToolShadowed} 次与派发同批、耗时不可分辨` : ''
+  lines.push(`  本地工具 / MCP   ${seconds(summary.localToolWallMs).padStart(6)}  ${share(summary.localToolWallMs, total).padStart(6)}  （${summary.localToolCalls} 次${shadowed}）`)
+  lines.push('')
+  lines.push('子 agent 明细（按派发顺序）：')
+  for (const span of summary.subagents) {
+    lines.push(`  ${String(span.order).padStart(2)}. ${span.agentId.padEnd(20)} ${seconds(span.ms).padStart(6)}${span.isError ? '  ⚠️ 失败' : ''}`)
+  }
+  lines.push('')
+  lines.push('按 agent 汇总（totalMs 是逐次相加，并发时会大于挂钟）：')
+  for (const entry of summary.byAgent) {
+    lines.push(`  ${entry.agentId.padEnd(20)} ${String(entry.calls).padStart(2)} 次  ${seconds(entry.totalMs).padStart(6)}${entry.errors ? `  ⚠️ ${entry.errors} 次失败` : ''}`)
+  }
+  lines.push('')
+  const { input, output, cacheRead, cacheWrite } = summary.usage
+  lines.push(`token：入 ${input} / 出 ${output} / 缓存读 ${cacheRead} / 缓存写 ${cacheWrite}`)
+  if (summary.unfinished > 0) {
+    lines.push(`⚠️ 有 ${summary.unfinished} 个工具调用没等到结果（run 被中止或会话被截断），其耗时未计入。`)
+  }
+  return lines.join('\n')
+}
+
+export function listSessionFiles(dir) {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.jsonl'))
+    .map((name) => {
+      const path = join(dir, name)
+      return { path, name, mtimeMs: statSync(path).mtimeMs }
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+}
+
+function main(argv) {
+  const args = argv.slice(2)
+  const dir = piSessionsDir()
+  const explicit = args.find((arg) => !arg.startsWith('--'))
+
+  if (args.includes('--list')) {
+    const files = listSessionFiles(dir)
+    if (files.length === 0) {
+      console.log(`没有找到会话记录：${dir}`)
+      return
+    }
+    for (const file of files) console.log(`${new Date(file.mtimeMs).toISOString()}  ${file.name}`)
+    return
+  }
+
+  const target = explicit ?? listSessionFiles(dir)[0]?.path
+  if (!target || !existsSync(target)) {
+    console.error(`没有找到会话记录。目录：${dir}`)
+    console.error('先在 App 里跑一次写作，或用 --list 查看可选会话。')
+    process.exitCode = 1
+    return
+  }
+
+  const summary = summarizeSession(parseSessionLines(readFileSync(target, 'utf8')))
+  if (summary.modelCalls === 0) {
+    console.log(`这份会话没有模型调用记录：${target}`)
+    return
+  }
+  console.log(formatReport(summary))
+}
+
+// 裸 `file://${argv[1]}` 拼接在路径含空格或软链时会静默失效，照 audit-*.mjs 用 pathToFileURL。
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv)
+}

--- a/scripts/ops-write-timing.test.mjs
+++ b/scripts/ops-write-timing.test.mjs
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test'
+
+import { mergeIntervalsMs, parseSessionLines, piSessionsDir, summarizeSession } from './ops-write-timing.mjs'
+
+/** 会话记录的真实形状：顶层 timestamp + message，assistant 的 toolCall 带 id/name/arguments。 */
+function assistantMessage(timestamp, toolCalls = [], extra = {}) {
+  return {
+    type: 'message',
+    timestamp,
+    message: {
+      role: 'assistant',
+      model: 'deepseek-v4-pro',
+      usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+      content: toolCalls.map((call) => ({ type: 'toolCall', ...call })),
+      ...extra,
+    },
+  }
+}
+
+function toolResult(timestamp, toolCallId, extra = {}) {
+  return { type: 'message', timestamp, message: { role: 'toolResult', toolCallId, ...extra } }
+}
+
+function task(id, agentId) {
+  return { id, name: 'Task', arguments: { subagent_type: agentId } }
+}
+
+describe('mergeIntervalsMs', () => {
+  test('重叠区间只算一次——并发派发不能逐个相加', () => {
+    const overlapping = Array.from({ length: 4 }, () => ({ start: 0, end: 81_000 }))
+    expect(mergeIntervalsMs(overlapping)).toBe(81_000)
+  })
+
+  test('不相接的区间相加，相接的合成一段', () => {
+    expect(mergeIntervalsMs([{ start: 0, end: 10 }, { start: 20, end: 30 }])).toBe(20)
+    expect(mergeIntervalsMs([{ start: 0, end: 10 }, { start: 5, end: 30 }])).toBe(30)
+  })
+
+  test('零长与倒置区间忽略', () => {
+    expect(mergeIntervalsMs([{ start: 5, end: 5 }, { start: 10, end: 1 }])).toBe(0)
+  })
+})
+
+describe('parseSessionLines', () => {
+  test('跳过写坏的半行而不是整份放弃（会话可能被中断截断）', () => {
+    const records = parseSessionLines('{"type":"session","id":"s1"}\n{坏行\n\n{"type":"message"}\n')
+    expect(records).toEqual([{ type: 'session', id: 's1' }, { type: 'message' }])
+  })
+})
+
+describe('summarizeSession', () => {
+  test('子 agent 按 subagent_type 归因，并发派发按并集算挂钟', () => {
+    const summary = summarizeSession([
+      { type: 'session', id: 'sess-1' },
+      assistantMessage('2026-08-19T12:00:00.000Z', [task('t1', 'narracat:memory-keeper'), task('t2', 'memory-keeper')]),
+      toolResult('2026-08-19T12:01:21.000Z', 't1'),
+      toolResult('2026-08-19T12:01:21.000Z', 't2'),
+    ])
+
+    expect(summary.sessionId).toBe('sess-1')
+    // 两路并发各 81s：挂钟仍是 81s，逐次相加才是 162s
+    expect(summary.subagentWallMs).toBe(81_000)
+    expect(summary.subagentSumMs).toBe(162_000)
+    // narracat: 前缀两种写法都归到同一个 agent
+    expect(summary.byAgent).toEqual([{ agentId: 'memory-keeper', calls: 2, totalMs: 162_000, errors: 0 }])
+  })
+
+  test('与 Task 同批的本地工具不计时——整批共用写入时刻，会被最慢的派发拖长', () => {
+    const summary = summarizeSession([
+      // 模型在派发 Task 的同一条消息里调 TaskUpdate：真机上这让 TaskUpdate 背上了 273s
+      assistantMessage('2026-08-19T12:00:00.000Z', [task('t1', 'chapter-writer'), { id: 'u1', name: 'TaskUpdate' }]),
+      toolResult('2026-08-19T12:04:33.000Z', 't1'),
+      toolResult('2026-08-19T12:04:33.000Z', 'u1'),
+    ])
+
+    expect(summary.subagentWallMs).toBe(273_000)
+    expect(summary.localToolWallMs).toBe(0)
+    expect(summary.localToolCalls).toBe(0)
+    expect(summary.localToolShadowed).toBe(1)
+  })
+
+  test('纯本地工具批次照常计时', () => {
+    const summary = summarizeSession([
+      assistantMessage('2026-08-19T12:00:00.000Z', [{ id: 'r1', name: 'read' }]),
+      toolResult('2026-08-19T12:00:00.500Z', 'r1'),
+    ])
+
+    expect(summary.localToolWallMs).toBe(500)
+    expect(summary.localToolCalls).toBe(1)
+    expect(summary.localToolShadowed).toBe(0)
+  })
+
+  test('模型调用耗时取与上一条消息的间隔，usage 与 model 累计', () => {
+    const summary = summarizeSession([
+      { type: 'message', timestamp: '2026-08-19T12:00:00.000Z', message: { role: 'user', content: [] } },
+      assistantMessage('2026-08-19T12:00:12.000Z'),
+      assistantMessage('2026-08-19T12:00:20.000Z'),
+    ])
+
+    expect(summary.modelCalls).toBe(2)
+    expect(summary.modelMs).toBe(20_000)
+    expect(summary.models).toEqual(['deepseek-v4-pro'])
+    expect(summary.usage).toEqual({ input: 20, output: 10, cacheRead: 0, cacheWrite: 0 })
+  })
+
+  test('没等到结果的工具调用只计数、不计时（run 被中止或会话截断）', () => {
+    const summary = summarizeSession([
+      assistantMessage('2026-08-19T12:00:00.000Z', [task('t1', 'chapter-writer')]),
+    ])
+
+    expect(summary.unfinished).toBe(1)
+    expect(summary.subagentWallMs).toBe(0)
+  })
+
+  test('失败的派发被标出来', () => {
+    const summary = summarizeSession([
+      assistantMessage('2026-08-19T12:00:00.000Z', [task('t1', 'chapter-writer')]),
+      toolResult('2026-08-19T12:00:10.000Z', 't1', { isError: true }),
+    ])
+
+    expect(summary.subagents[0]).toEqual({ order: 1, agentId: 'chapter-writer', ms: 10_000, isError: true })
+    expect(summary.byAgent[0].errors).toBe(1)
+  })
+
+  test('空会话不炸', () => {
+    const summary = summarizeSession([])
+    expect(summary.modelCalls).toBe(0)
+    expect(summary.wallMs).toBe(0)
+  })
+})
+
+describe('piSessionsDir', () => {
+  const home = '/home/u'
+
+  test('三个平台各走各的 userData 惯例', () => {
+    expect(piSessionsDir('darwin', {}, home)).toBe('/home/u/Library/Application Support/NarraCat/pi-agent/sessions')
+    expect(piSessionsDir('win32', { APPDATA: 'C:\\Users\\u\\AppData\\Roaming' }, home)).toContain('NarraCat')
+    expect(piSessionsDir('linux', {}, home)).toBe('/home/u/.config/NarraCat/pi-agent/sessions')
+  })
+
+  test('Windows 缺 APPDATA 时回落到默认 Roaming 路径，不返回 undefined 拼接', () => {
+    expect(piSessionsDir('win32', {}, home)).toBe('/home/u/AppData/Roaming/NarraCat/pi-agent/sessions')
+  })
+})


### PR DESCRIPTION
Refs #28（替代已关闭的 PR #32）

## 为什么是脚本

PR #32 造了一份生产埋点仪表（300+ 行 + 用户磁盘上的落盘产物）来回答「这一章的时间花在哪」。但 pi 的会话记录 `pi-agent/sessions/*.jsonl` **每条 message 本就带 `timestamp` + `model` + `usage`**，Task 的 `subagent_type` 也在调用参数里——issue #29 的诊断正是这么做出来的。所以这个问题零生产代码就能答，#32 已关闭（分支保留）。

```
bun --no-cache run ops:write-timing            # 最近一次会话
bun --no-cache run ops:write-timing -- --list  # 列出可选会话
node scripts/ops-write-timing.mjs <file.jsonl> # 指定会话
```

真机第 17 章那次 run 的输出：

```
总墙钟 1735s（28.9 分钟）  模型 deepseek-v4-flash

归因（子 agent 与本地工具按区间并集算挂钟，并发不重复计）：
  子 agent 派发     1549s   89.3%
  主会话模型调用     184s   10.6%  （32 次，含派发等待）
  本地工具 / MCP       2s    0.1%  （43 次，另有 4 次与派发同批、耗时不可分辨）

子 agent 明细（按派发顺序）：
   1. chapter-writer         273s      6. continuity-editor      103s
   2. chapter-writer         291s      7-10. memory-keeper     81s ×4（并发）
   3. chapter-writer         315s
   4. chapter-writer         250s
   5. chapter-writer         236s
```

## 口径上撞出来的一个真陷阱（写在这里，免得下次再踩）

**同一条 assistant 消息里发出的工具是一批，整批的 toolResult 共用一个写入时刻**，于是批内每个工具的「耗时」都等于批次挂钟。模型经常在派发 `Task` 的同时调 `TaskUpdate` 更新任务卡——照单全收的话，4 个 `TaskUpdate` 会各自背上 273s，把「本地工具 / MCP」算成 **709s（20.5%）**，而实测真值是 **4.8s（0.1%）**。

第一版实现就是这么错的，对着真机数据才发现。现在混批里的本地工具只计数、不计时，并在报告里显式标注「耗时不可分辨」——**宁可少报，也不给一个看起来合理的错数字**。

另外并发派发按**区间并集**算挂钟：4 路 memory-keeper 各 81s 是 81s，不是 324s。

## 验证

```
bun --no-cache run typecheck          → 通过
bun --no-cache run check:architecture → 0 violation(s)
bun --no-cache test ./scripts         → 192 pass / 0 fail，Ran 192 tests across 25 files
```

**变异测试**（验证测试有牙，不是装饰）：
- 去掉混批保护（还原那个 709s 的错） → **1 红**
- 区间并集改成逐个相加 → **3 红**

跨平台：`piSessionsDir` 按平台走 userData 惯例（含 Windows 缺 `APPDATA` 时的回落），有测试覆盖——Windows 适配（#25）落地后可直接用。

只读脚本：不写、不删任何文件。

## 这份数据带来的结论

已写进 #28：刀 A 天花板 ≈10.6%、刀 B ≈4.7%、刀 C <2%，而 **chapter-writer 跑了 5 遍、其中 2 遍是白跑重试（527s，30.4%）**——真正的主刀是 #29，不是模型分层。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
