### PR TITLE
fix(library,workbench): 损坏项目给作者出路而不是 IPC 黑话 (#38)

### DIFF
--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -22,7 +22,11 @@
 
 **两条防静默失配的守卫**：判据文案收成 `shared/lib/ipc-error.ts` 常量三处共用（原先主进程里重复写了两份），各写各的字符串会在改动一侧时静默失配、损坏态退回老样子且无测试会红；渲染端用 `window.electron?.revealProjectFolder?.()` 调 IPC，**preload 漏登记会完全静默**（可选链吞掉，typecheck 也拦不住，因为 ipc.d.ts 声明是齐的），故补 preload 三处登记守卫。验证：typecheck / 全量 **3055 pass 0 fail**（对 main 基线 +12 tests +3 files）/ check:design / check:architecture / build 全绿。
 
-**待办**：真机 dogfood（与 #37 一起）。原报告里「刚录入一个角色之后」那条链仍未复现——等 ③ 的日志上线后，下次再撞就能一眼看出是哪一步把非项目根的路径当 projectPath 传了下去。
+**dogfood 校正了 issue 的一个前提（2026-08-20 验收通过）**：issue 说「书架放行 invalid 项目」，实际更精确——`scanRootChildren` 只放行 `isNarraCatProject` 为真的目录，所以 `novelRootDir` 下**缺文件**的坏目录压根不会进书架。invalid 卡片有两个来源，行为不同：①**缺 config/state**（`isNarraCatProject` 假）→ 被 root 扫描过滤 → 只可能来自 `recentNovelPaths` → 移除有效；②**文件在但读不出**（yaml 损坏，`loadSummarySafely` catch 分支同样吐 `status:'invalid'`）→ `isNarraCatProject` 真 → **会被 root 扫描列出** → 在 root 下时移除确实无效。四种组合逐个核过，`canRemoveFromLibrary` 的判据都对——**第②类正是 `canRemove=false` 分支存在的理由**，不能因为「invalid 项目总能移除」的直觉把它删掉。
+
+**造 dogfood 数据的教训**：第一次把测试用的坏项目建在 `novelRootDir` 下，结果它被上面那条过滤规则挡住、根本不显示，白让产品主人找了一轮。**造完测试数据必须先离线跑一遍消费方**（这里是 `scanNovelProjects`）证明它真会出现，再叫人去看——否则就是把未经验证的东西当成已完成交付。
+
+**dogfood 结果**：五步验收全过（卡片人话文案 / 点击不跳工作台而弹浮层 / 「打开所在文件夹」/ 「从书架移除」后卡片消失且文件夹仍在 / 原始文件名不外露）。原报告里「刚录入一个角色之后」那条链仍未复现——等 ③ 的日志上线后，下次再撞就能一眼看出是哪一步把非项目根的路径当 projectPath 传了下去。
 
 **2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
 

--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -4,13 +4,23 @@
 
 ## Current Branch
 
-`main`（= `c999265`，**已 push**）。社区第二批三个 PR（#18/#19/#20）合并，对应 issue #14/#16/#17 全部关闭、#15 拆分归位后 close。引擎 **4.0.172**。仓库已合一，「公开镜像仓 + 定向同步」的说法自 2026-08-16 起作废——本仓即唯一开发仓。
+`main`（= `4699fb2`，**已 push**）。社区第三批：PR #13（#5 刀 1，custom 渠道 OpenAI 协议）合并。此前社区第二批三个 PR（#18/#19/#20）合并，对应 issue #14/#16/#17 全部关闭、#15 拆分归位后 close。引擎 **4.0.172**（本次未动引擎）。仓库已合一，「公开镜像仓 + 定向同步」的说法自 2026-08-16 起作废——本仓即唯一开发仓。
 
 ## Current Phase
 
 主线 `main`。产品北极星 = ADR-0030「账房归我们 / 花归用户 / 尺归读者」；产品方向 2026-07-11 定案两大模块「用户编辑 + 可配置底座」。**正文编辑器主战役已收官**（PR #443 合并 main，ADR-0031，引擎 4.0.91，产品主人真机验收通过）；写作质量「脱胎换骨」主线阶段性收刀（arc 速度靶 PR #441 / 获得引擎四刀 PR #442 均已合并）。ADR 已扩至 **0035**。
 
 产品路线以下方 **Next（产品路线图 · 2026-07-12 统筹版）** 为准：四条泳道 = A 花的所有权（用户编辑）/ B 花的表达权（可配置底座）/ C 尺（评价与验证）/ D 账房（记忆与资产底座）。战略层以 `docs/COMPASS.md` 为准，执行入口 `/next-issue`。
+
+**2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
+
+**两轮 review。第一轮抓到的阻断项是这条记录的重点**：切协议按钮**实质点不动，还会把磁盘上已落盘的 wire 静默改回去**。根因在 `src/lib/settings-config.ts` 的草稿保护——`toDisplay` 把 providers 整个换回本地草稿（原为防「用户正在打字的 baseUrl 被落盘结果吃掉」），而 `onModelWireChange` 从不更新草稿里的 wire，这层保护就变成了回滚；紧接着 `mergeProviderDraft` 在「测试连接」时把整个 provider 对象从草稿写回 persisted，把磁盘上正确的 openai 也覆盖掉。**本质是把离散的即时落盘字段（wire，语义同「设为主力」）塞进了为打字输入设计的保护圈**。采纳修法 2（字段级保护：只回护 `baseUrl`），一次修掉两处。**贡献者的根因交代比修复本身值钱**：这刀是从他 fork 的完整实现里提取的，原版有 `displayProviders:'saved'` 防这类回滚，提取时被当成动态渠道的附属品剔掉了——**从大实现里切片时被剥离的保护件，是回归的高发区**，以后审同类提取式 PR 要专门过一遍。
+
+**维护者复审不采信贡献者的测试报告，全部独立复跑**：`typecheck` / `check:design` / `check:architecture` 全绿；全量 **3000 pass / 0 fail across 296 files**；**合并最新 main 后复跑 3008 pass / 0 fail across 297 files**（零冲突）；阻断项两步**另写一份复现脚本**（不复用贡献者用例）验证 3 pass。**额外验的两项是复审真正的增量**：①**存量用户升级路径**——`wire` 成了必填字段，legacy 兼容一旦写错，所有老用户升级后验证态会被清空、被迫重新测试连接；拿本机真实 `config.json`（无 wire 字段、两条已验证 deepseek 条目）跑新 `normalizeAppConfig`，**快照零清空、主力槽仍 verified**。②**指纹加 wire 的迁移成本**——一度担心会让存量用户旧对话一次性失配，查下来不成立：`sdkSessionsByThread` 是纯内存 Map（`run-manager.ts:194`），跨重启本就不 resume，升级必然重启，零成本。
+
+**刀 2 未做的用户可见后果必须在刀 1 交代**（这是审核时提的第二条必改）：四条直连 `@anthropic-ai/sdk` 的路径在 openai wire 下全挂——`character-chat-runner`（取**主力槽**，故只要 custom 设成主力，角色聊天就中招）/ `character-chat-profiler` / `packs/pack-compile` / `packs/card-rewrite`。**最坑的是误导性**：`testProviderConnection` 走 `createPiModel`、openai wire 已接通，用户会看到**测试连接绿灯**，转头去唠个嗑撞一个 Anthropic SDK 抛的 404 天书——绿灯之后功能挂掉，比一开始就报错更伤。选了成本近零的解法：维护者定稿的渠道配置提示文案里，把前缀缓存费用警示与功能覆盖缺口一起写清，UI 测试断言「只覆盖写作主链」关键词防将来改文案把告知改丢。
+
+**已知项与待办**：`maxTokens: 32_000` 沿用 anthropic wire 的调优值，openai wire 下部分兼容网关/小模型可能直接 400，留待真实反馈后考虑按 wire 分设；baseUrl 不带 `/v1` 时 openai 分支不自动补，静默 404 回落内置目录（placeholder 与 description 均有提示，可接受）。**两项维护者未验并已如实标注**：openai wire 真连（无 OpenAI 兼容端点，依赖贡献者的 E2E 证据——opencode.ai 网关、模型清单 + 主链完整往返，是可复现描述而非「我机器上好了」）；协议按钮与须知文案在 Electron 里的真机排版观感（结构测试与 `check:design` 均绿，留 dogfood 时自查）。**顺带立 #24**：`check:design` 在 Windows 上恒红（`brand-illustrations.ts violates brand asset guard`），贡献者验证在 main 裸跑同样红、与本 PR 无关；怀疑守卫的字符串子串断言撞上 CRLF 行尾（本仓无 `.gitattributes`），**一个在某平台恒红的守卫比没有守卫更糟**——会训练出「这条红的可以跳过」的习惯，且把 Windows 贡献者挡在「无法自证改动干净」的位置上。
 
 **2026-08-18（社区第二批：外部报告三条修复全部合并，PR #18/#19/#20）**：报告人 @Akimixu-19897 一天内提三条（#14/#15/#16），逐条读代码定位后**结论与报告不完全一致**，是本轮最值得记的部分。
 

--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -12,6 +12,18 @@
 
 产品路线以下方 **Next（产品路线图 · 2026-07-12 统筹版）** 为准：四条泳道 = A 花的所有权（用户编辑）/ B 花的表达权（可配置底座）/ C 尺（评价与验证）/ D 账房（记忆与资产底座）。战略层以 `docs/COMPASS.md` 为准，执行入口 `/next-issue`。
 
+**2026-08-20（#38：损坏项目给作者出路而不是 IPC 黑话，分支 `fix/38-invalid-project-guidance` = `2e46507`，未合并）**：作者录入角色后撞到红条 `Error invoking remote method 'novel:refresh-status': Error: 缺少 .narracat/config.yaml 或 .narracat/state.yaml`。排查结论是**文件并没丢**（复现机四个项目文件全在，也排除了写入竞态——`state-sync.ts` 全程原地覆盖、不存在句柄短暂消失的窗口），真正的问题是三条不需要复现就能修的确定性缺陷。
+
+**① 入口没拦**：书架明知这本书坏了、卡上都标了红，`<Link>` 仍覆盖整卡照常可点，进去必撞 `aggregateNovelStatusSnapshot` 第一行。改成点击弹说明浮层。**主动作定为「打开所在文件夹」而不是删除**——invalid 很可能是误判（文件夹被移动/重命名、外置盘没插、config.yaml 被误删而正文还在），这种时候引导作者删东西是灾难。
+
+**②「从书架移除」只在真能生效时才给**：书架 = `novelRootDir` 直接子目录 + 配置里的最近路径，两者合并。root 下的项目摘掉最近路径**下次扫描照样回来**，给一个点了不生效的按钮比不给更糟；这类项目改为把删除入口指回卡片「更多」。移除本身复用既有 `deleteNovelProject`——查下来它对 invalid 项目本就只摘书架条目、不 trash 任何文件，语义正合适，无需新造 IPC。
+
+**③ 黑话与可观测性**：新增 `stripIpcErrorPrefix` 剥掉 `Error invoking remote method '…'` 外壳（这段实现细节还把唯一有用的信息挤到了后面）；项目文件不完整时给人话 +「返回书架」，不再给一个重试一万次都是同一个错的按钮；主进程抛错前补 `projectPath` 与两个文件各自的存在性到日志——**只有一句静态文案、不带路径，正是本次无法从现场倒推的直接原因**，面向作者的文案保持不变。
+
+**两条防静默失配的守卫**：判据文案收成 `shared/lib/ipc-error.ts` 常量三处共用（原先主进程里重复写了两份），各写各的字符串会在改动一侧时静默失配、损坏态退回老样子且无测试会红；渲染端用 `window.electron?.revealProjectFolder?.()` 调 IPC，**preload 漏登记会完全静默**（可选链吞掉，typecheck 也拦不住，因为 ipc.d.ts 声明是齐的），故补 preload 三处登记守卫。验证：typecheck / 全量 **3055 pass 0 fail**（对 main 基线 +12 tests +3 files）/ check:design / check:architecture / build 全绿。
+
+**待办**：真机 dogfood（与 #37 一起）。原报告里「刚录入一个角色之后」那条链仍未复现——等 ③ 的日志上线后，下次再撞就能一眼看出是哪一步把非项目根的路径当 projectPath 传了下去。
+
 **2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
 
 **两轮 review。第一轮抓到的阻断项是这条记录的重点**：切协议按钮**实质点不动，还会把磁盘上已落盘的 wire 静默改回去**。根因在 `src/lib/settings-config.ts` 的草稿保护——`toDisplay` 把 providers 整个换回本地草稿（原为防「用户正在打字的 baseUrl 被落盘结果吃掉」），而 `onModelWireChange` 从不更新草稿里的 wire，这层保护就变成了回滚；紧接着 `mergeProviderDraft` 在「测试连接」时把整个 provider 对象从草稿写回 persisted，把磁盘上正确的 openai 也覆盖掉。**本质是把离散的即时落盘字段（wire，语义同「设为主力」）塞进了为打字输入设计的保护圈**。采纳修法 2（字段级保护：只回护 `baseUrl`），一次修掉两处。**贡献者的根因交代比修复本身值钱**：这刀是从他 fork 的完整实现里提取的，原版有 `displayProviders:'saved'` 防这类回滚，提取时被当成动态渠道的附属品剔掉了——**从大实现里切片时被剥离的保护件，是回归的高发区**，以后审同类提取式 PR 要专门过一遍。

--- a/electron/main/ipc/novel.ts
+++ b/electron/main/ipc/novel.ts
@@ -476,6 +476,14 @@ export function registerNovelIpcHandlers(): void {
     return runProjectMutation(request.projectPath, () => updateNovelProjectMetadata(request))
   })
 
+  // 损坏项目的自救入口（#38）：invalid 多半是文件被移动/重命名或磁盘没连接，
+  // 让作者自己打开文件夹看一眼，比引导他删东西安全得多。
+  ipcMain.handle('novel:reveal-folder', async (_event, input: unknown) => {
+    const projectPath = typeof input === 'string' ? input.trim() : ''
+    if (!projectPath) throw new Error('缺少项目路径。')
+    shell.showItemInFolder(projectPath)
+  })
+
   ipcMain.handle('novel:delete-project', async (_event, input: unknown) => {
     const deleteInput = readDeleteNovelProjectInput(input)
     return runProjectMutation(deleteInput.projectPath, async () => {

--- a/electron/main/novel/novel-project.ts
+++ b/electron/main/novel/novel-project.ts
@@ -1,3 +1,4 @@
+import { NOVEL_PROJECT_INCOMPLETE_MESSAGE } from '@shared/lib/ipc-error'
 import type { Dirent } from 'node:fs'
 import { readFile, readdir, stat, writeFile } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
@@ -32,7 +33,7 @@ import type {
   UpdateNovelProjectMetadataInput,
 } from '@shared/types/novel'
 
-const missingProjectProblem = '缺少 .narracat/config.yaml 或 .narracat/state.yaml'
+const missingProjectProblem = NOVEL_PROJECT_INCOMPLETE_MESSAGE
 const corruptedStructureProblem = '全书结构数据损坏：章卷映射缺失或不完整，请让 Agent 重新同步全书结构。'
 const reservedBibleDirectoryNames = new Set([
   'characters',

--- a/electron/main/novel/novel-status.test.ts
+++ b/electron/main/novel/novel-status.test.ts
@@ -146,3 +146,27 @@ describe('novel status aggregation', () => {
     expect(snapshot.references).toEqual({ sourceCount: 0, guidanceGenerated: false })
   })
 })
+
+describe('incomplete project diagnostics (#38)', () => {
+  test('logs the project path and which files are missing before throwing', async () => {
+    // 作者只会看到一句「缺少 …」，不带路径。本次线上排查就卡在这里：无法从现场倒推
+    // 到底是哪个项目、哪条路径出的问题。面向作者的文案不变，路径只进主进程日志。
+    const root = await makeProject('status-diagnostics', 'setup')
+    await rm(join(root, '.narracat', 'state.yaml'), { force: true })
+
+    const logs: string[] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => {
+      logs.push(args.map((value) => String(value)).join(' '))
+    }
+    try {
+      await expect(aggregateNovelStatusSnapshot(root)).rejects.toThrow()
+    } finally {
+      console.error = originalError
+    }
+
+    const text = logs.join('\n')
+    expect(text).toContain(root)
+    expect(text).toContain('state.yaml')
+  })
+})

--- a/electron/main/novel/novel-status.ts
+++ b/electron/main/novel/novel-status.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { NOVEL_PROJECT_INCOMPLETE_MESSAGE } from '@shared/lib/ipc-error'
+import { readFile, stat, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { isNarraCatProject } from './novel-project'
@@ -10,7 +11,7 @@ import type {
   NovelStatusSnapshot,
 } from '@shared/types/novel'
 
-const missingProjectProblem = '缺少 .narracat/config.yaml 或 .narracat/state.yaml'
+const missingProjectProblem = NOVEL_PROJECT_INCOMPLETE_MESSAGE
 const defaultGenre = '未分类'
 
 async function readYamlFile(path: string): Promise<Record<string, unknown>> {
@@ -150,13 +151,33 @@ export interface NovelStatusAggregationOptions {
   enrich?: (input: { projectPath: string; currentChapter: number | null }) => Promise<NovelStatusEnrichment>
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  return Boolean(await stat(path).catch(() => null))
+}
+
 export async function aggregateNovelStatusSnapshot(
   projectPath: string,
   options: NovelStatusAggregationOptions = {},
 ): Promise<NovelStatusSnapshot> {
   const trimmed = projectPath.trim()
   if (!trimmed) throw new Error('缺少项目路径。')
-  if (!(await isNarraCatProject(trimmed))) throw new Error(missingProjectProblem)
+  if (!(await isNarraCatProject(trimmed))) {
+    // 面向作者的文案保持不变（不把本机路径推到 UI 上），但主进程日志必须留下现场：
+    // 没有 projectPath 就无法从一句静态文案倒推是哪个项目、缺的是哪个文件（#38）。
+    const [hasConfig, hasState] = await Promise.all([
+      fileExists(join(trimmed, narracatConfigPath())),
+      fileExists(join(trimmed, narracatStatePath())),
+    ])
+    console.error(
+      '[novel-status] 项目文件不完整：',
+      JSON.stringify({
+        projectPath: trimmed,
+        'config.yaml': hasConfig ? 'ok' : 'missing',
+        'state.yaml': hasState ? 'ok' : 'missing',
+      }),
+    )
+    throw new Error(missingProjectProblem)
+  }
 
   const [config, state] = await Promise.all([
     readYamlFile(join(trimmed, narracatConfigPath())),

--- a/electron/preload/index.cts
+++ b/electron/preload/index.cts
@@ -2,6 +2,7 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 const api = {
   ping: (): Promise<string> => ipcRenderer.invoke('ping'),
+  revealProjectFolder: (projectPath: string) => ipcRenderer.invoke('novel:reveal-folder', projectPath),
   checkReleaseGuard: () => ipcRenderer.invoke('release-guard:check'),
   getUpdaterState: () => ipcRenderer.invoke('updater:get-state'),
   checkForUpdates: () => ipcRenderer.invoke('updater:check'),

--- a/electron/preload/preload-contract.test.ts
+++ b/electron/preload/preload-contract.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * preload 登记守卫（#38）。
+ *
+ * 渲染端调用 `window.electron?.xxx?.()` 时，preload 漏登记不会报错——可选链让它
+ * **什么都不发生且完全静默**，typecheck 也拦不住（类型声明在 ipc.d.ts 里是齐的）。
+ * 新增 IPC 必须三处同时到位：main handler / preload / 类型声明。
+ */
+describe('preload IPC registration', () => {
+  const preload = readFileSync(fileURLToPath(new URL('./index.cts', import.meta.url)), 'utf-8')
+  const mainHandlers = readFileSync(
+    fileURLToPath(new URL('../main/ipc/novel.ts', import.meta.url)),
+    'utf-8',
+  )
+
+  test('exposes revealProjectFolder and backs it with a main-process handler', () => {
+    expect(preload).toContain('revealProjectFolder')
+    expect(preload).toContain("'novel:reveal-folder'")
+    expect(mainHandlers).toContain("ipcMain.handle('novel:reveal-folder'")
+  })
+})

--- a/shared/lib/ipc-error.test.ts
+++ b/shared/lib/ipc-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  NOVEL_PROJECT_INCOMPLETE_MESSAGE,
+  isProjectIncompleteError,
+  stripIpcErrorPrefix,
+} from './ipc-error'
+
+describe('stripIpcErrorPrefix', () => {
+  test('removes the Electron IPC wrapper so the author sees the real message', () => {
+    expect(
+      stripIpcErrorPrefix(
+        "Error invoking remote method 'novel:refresh-status': Error: 缺少 .narracat/config.yaml 或 .narracat/state.yaml",
+      ),
+    ).toBe('缺少 .narracat/config.yaml 或 .narracat/state.yaml')
+  })
+})
+
+describe('isProjectIncompleteError', () => {
+  test('recognizes an incomplete project even through the IPC wrapper', () => {
+    // 判据必须两侧共用同一份文案常量：各写各的字符串，改一处就会静默失配，
+    // 损坏项目又会退回「红条 + 重试」的老样子，而且没有测试会红。
+    expect(
+      isProjectIncompleteError(
+        `Error invoking remote method 'novel:refresh-status': Error: ${NOVEL_PROJECT_INCOMPLETE_MESSAGE}`,
+      ),
+    ).toBe(true)
+  })
+
+  test('does not mistake a transient failure for a broken project', () => {
+    expect(isProjectIncompleteError('读取超时，请稍后重试')).toBe(false)
+  })
+})

--- a/shared/lib/ipc-error.ts
+++ b/shared/lib/ipc-error.ts
@@ -1,0 +1,23 @@
+/**
+ * IPC 错误的产品化处理（#38）。
+ *
+ * Electron 会把主进程抛出的 Error 包成
+ * `Error invoking remote method 'novel:refresh-status': Error: <原文>` 再交给渲染端。
+ * 这层外壳是纯实现细节，直接渲染给作者既看不懂，还会把唯一有用的信息挤到后面。
+ */
+
+const IPC_WRAPPER = /^Error invoking remote method '[^']*':\s*(?:Error:\s*)?/
+
+export function stripIpcErrorPrefix(message: string): string {
+  return message.replace(IPC_WRAPPER, '').trim()
+}
+
+/**
+ * 「项目文件不完整」的判据文案，主进程抛出、渲染端识别，双方共用这一份。
+ * 各写各的字符串会在改动一侧时静默失配——损坏项目退回「红条 + 重试」的老样子，且无测试会红。
+ */
+export const NOVEL_PROJECT_INCOMPLETE_MESSAGE = '缺少 .narracat/config.yaml 或 .narracat/state.yaml'
+
+export function isProjectIncompleteError(message: string): boolean {
+  return stripIpcErrorPrefix(message).startsWith(NOVEL_PROJECT_INCOMPLETE_MESSAGE)
+}

--- a/shared/lib/library-project.test.ts
+++ b/shared/lib/library-project.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { canRemoveFromLibrary } from './library-project'
+
+describe('canRemoveFromLibrary', () => {
+  test('an outside project can be removed because the shelf only remembers its path', () => {
+    expect(canRemoveFromLibrary('/Users/a/Desktop/借来的书', '/Users/a/Novels')).toBe(true)
+  })
+
+  test('a project inside the novel root cannot be removed — the next scan brings it back', () => {
+    // 书架 = novelRootDir 的子目录 + 最近路径。root 下的项目摘掉最近路径也没用，
+    // 下次扫描照样出现。给一个点了不生效的按钮比不给更糟。
+    expect(canRemoveFromLibrary('/Users/a/Novels/novel-x', '/Users/a/Novels')).toBe(false)
+  })
+})

--- a/shared/lib/library-project.ts
+++ b/shared/lib/library-project.ts
@@ -1,0 +1,16 @@
+/**
+ * 书架条目的可操作性判断（#38）。
+ *
+ * 书架列表 = `novelRootDir` 的直接子目录 + 配置里的最近路径，两者合并。
+ * 因此「从书架移除」只对后者成立：root 下的项目摘掉最近路径也没用，下次扫描照样出现。
+ * 给作者一个点了不生效的按钮，比不给这个按钮更糟。
+ */
+
+function segments(path: string): string[] {
+  return path.trim().replace(/[/\\]+$/, '').split(/[/\\]+/)
+}
+
+export function canRemoveFromLibrary(projectPath: string, novelRootDir: string): boolean {
+  const parent = segments(projectPath).slice(0, -1).join('/')
+  return parent !== segments(novelRootDir).join('/')
+}

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -364,6 +364,8 @@ export type PublishPackDraftResult =
 
 export interface ElectronApi {
   ping: () => Promise<string>
+  /** 在系统文件管理器中定位项目文件夹（损坏项目的自救入口，#38）。 */
+  revealProjectFolder: (projectPath: string) => Promise<void>
   checkReleaseGuard: () => Promise<ReleaseGateVerdict>
   getUpdaterState: () => Promise<UpdaterState>
   checkForUpdates: () => Promise<void>

--- a/src/components/workbench/WorkbenchStatusPanel.test.tsx
+++ b/src/components/workbench/WorkbenchStatusPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import {
   CurrentArcBlock,
@@ -44,7 +45,8 @@ function render({
   nextStep?: StatusNextStep
 }): string {
   return renderToStaticMarkup(
-    <TooltipProvider>
+    <MemoryRouter>
+      <TooltipProvider>
       <WorkbenchStatusPanelView
         phase={phase}
         snapshot={snapshot}
@@ -53,7 +55,8 @@ function render({
         nextStep={nextStep}
         onRefresh={() => {}}
       />
-    </TooltipProvider>,
+      </TooltipProvider>
+    </MemoryRouter>,
   )
 }
 
@@ -192,6 +195,22 @@ describe('WorkbenchStatusPanelView', () => {
 
     expect(html).toContain('data-workbench-status-failure="true"')
     expect(html).toContain('还没有状态快照')
+  })
+
+
+  test('broken project shows plain-language guidance and a way back instead of retry', () => {
+    // 对损坏项目重试一万次都是同一个错。作者需要的是「这本书的文件不完整」+ 一条出路，
+    // 而不是一个永远点不出结果的重试按钮，更不是 IPC 实现细节。
+    const html = render({
+      phase: 'failed',
+      snapshot: null,
+      error: '缺少 .narracat/config.yaml 或 .narracat/state.yaml',
+    })
+
+    expect(html).toContain('data-workbench-status-failure="true"')
+    expect(html).toContain('data-workbench-status-back-to-library="true"')
+    expect(html).not.toContain('data-workbench-status-retry="true"')
+    expect(html).not.toContain('.narracat/config.yaml')
   })
 
   test('enriched snapshot shows the default 当前剧情 tab plus triggers for the other groups', () => {

--- a/src/components/workbench/WorkbenchStatusPanel.tsx
+++ b/src/components/workbench/WorkbenchStatusPanel.tsx
@@ -1,3 +1,5 @@
+import { isProjectIncompleteError } from '@shared/lib/ipc-error'
+import { Link } from 'react-router'
 import { Fragment, useEffect } from 'react'
 import { Check, CircleAlert, Gauge, Loader2, RefreshCw } from 'lucide-react'
 import { BrandIllustration, type BrandIllustrationPurpose } from '@/components/brand'
@@ -443,6 +445,31 @@ function WorkbenchStatusFailure({
   onRetry: () => void
   retrying: boolean
 }) {
+  // 项目文件不完整时重试一万次都是同一个错，给出路而不是给重试按钮；
+  // 原始错误只进主进程日志，不推到作者面前（#38）。
+  if (error && isProjectIncompleteError(error)) {
+    return (
+      <div className={cn(DESTRUCTIVE_INLINE_CLASS, 'mb-4 flex items-start gap-2')} data-workbench-status-failure="true">
+        <CircleAlert className="mt-0.5 size-4 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium">这本书的项目文件不完整</div>
+          <div className="mt-0.5 break-words text-xs leading-snug opacity-90">
+            暂时算不出写作进度。常见原因是文件夹被移动或重命名，也可能是它所在的磁盘没有连接。
+          </div>
+        </div>
+        <Button
+          asChild
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          data-workbench-status-back-to-library="true"
+        >
+          <Link to="/">返回书架</Link>
+        </Button>
+      </div>
+    )
+  }
+
   return (
     <div className={cn(DESTRUCTIVE_INLINE_CLASS, 'mb-4 flex items-start gap-2')} data-workbench-status-failure="true">
       <CircleAlert className="mt-0.5 size-4 shrink-0" />

--- a/src/lib/workbench-status-store.test.ts
+++ b/src/lib/workbench-status-store.test.ts
@@ -129,6 +129,27 @@ describe('useWorkbenchStatusStore', () => {
     expect(useWorkbenchStatusStore.getState().snapshot).toEqual(previous)
   })
 
+
+  test('strips the Electron IPC wrapper from the stored error message (#38)', async () => {
+    // 作者看到的是 store 里这个字符串。带着 `Error invoking remote method 'novel:refresh-status'`
+    // 直接渲染，等于把实现细节糊在脸上，还把唯一有用的信息挤到后面。
+    useWorkbenchStatusStore.setState({ projectPath: '/novels/stars', phase: 'loaded' })
+    mockElectron({
+      refreshNovelStatus: () =>
+        Promise.reject(
+          new Error(
+            "Error invoking remote method 'novel:refresh-status': Error: 缺少 .narracat/config.yaml 或 .narracat/state.yaml",
+          ),
+        ),
+    })
+
+    await useWorkbenchStatusStore.getState().refresh('/novels/stars')
+
+    expect(useWorkbenchStatusStore.getState().error).toBe(
+      '缺少 .narracat/config.yaml 或 .narracat/state.yaml',
+    )
+  })
+
   test('enter hydrates the persisted snapshot then background-refreshes when one exists', async () => {
     const persisted = snapshotFixture()
     const fresh = snapshotFixture({ generatedAt: '2026-06-17T00:00:00.000Z' })

--- a/src/lib/workbench-status-store.ts
+++ b/src/lib/workbench-status-store.ts
@@ -1,3 +1,4 @@
+import { stripIpcErrorPrefix } from '@shared/lib/ipc-error'
 import { create } from 'zustand'
 import { readNovelStatus, refreshNovelStatus } from '@/lib/ipc'
 import type { NovelStatusSnapshot } from '@shared/types/novel'
@@ -27,7 +28,8 @@ interface WorkbenchStatusStore {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  // 剥掉 Electron IPC 外壳再交给 UI：作者看到的就是这个字符串（#38）。
+  return stripIpcErrorPrefix(error instanceof Error ? error.message : String(error))
 }
 
 const initialState = {

--- a/src/routes/library.test.tsx
+++ b/src/routes/library.test.tsx
@@ -10,6 +10,7 @@ import {
   LibraryFilterBar,
   LibraryFilteredEmptyState,
   LibraryHomeHero,
+  LibraryInvalidProjectPanel,
   LibraryProjectDeletePanel,
   LIBRARY_PROJECT_METADATA_DIALOG_CONTENT_CLASS,
   LibraryNavBrand,
@@ -229,6 +230,73 @@ describe('LibraryRoute presentation', () => {
     expect(filterLibraryProjects(projects, { status: 'all', genre: '未分类' }).map((project) => project.id)).toEqual([
       'legacy',
     ])
+  })
+
+
+  test('an invalid project card no longer links into a workbench that must fail (#38)', () => {
+    // 书架明知这本书坏了、卡上都标了红，仍旧让作者点进去，然后用一句开发黑话糊他脸上。
+    // 入口必须先拦住：进到一个什么都读不出来的工作台对作者零价值。
+    const invalid = { ...baseProject, status: 'invalid' as const, problem: '缺少 .narracat/config.yaml 或 .narracat/state.yaml' }
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <LibraryProjectCard project={invalid} />
+      </MemoryRouter>,
+    )
+
+    expect(html).not.toContain('/workbench?project=')
+    expect(html).toContain('data-library-invalid-trigger="true"')
+    // 原始文件名不糊到作者脸上。
+    expect(html).not.toContain('.narracat/config.yaml')
+  })
+
+
+  test('the broken-project notice leads with opening the folder, not with deleting', () => {
+    // invalid 多半是误判——文件夹被移动、外置盘没插、config.yaml 被误删而正文还在。
+    // 主动作必须是「去看一眼」，不能引导作者先删东西。
+    const invalid = { ...baseProject, status: 'invalid' as const }
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Dialog open>
+        <LibraryInvalidProjectPanel
+          canRemove
+          project={invalid}
+          removing={false}
+          onCancel={() => {}}
+          onRemove={() => {}}
+          onReveal={() => {}}
+        />
+        </Dialog>
+      </MemoryRouter>,
+    )
+
+    expect(html).toContain('data-library-invalid-reveal="true"')
+    expect(html).toContain('打开所在文件夹')
+    expect(html).toContain('data-library-invalid-remove="true"')
+    expect(html).not.toContain('.narracat/config.yaml')
+  })
+
+  test('hides removal when the project sits inside the novel root, where removing cannot work', () => {
+    // root 下的项目摘掉最近路径也没用，下次扫描照样出现。这时改为把删除入口指回「更多」，
+    // 而不是给一个点了不生效的按钮。
+    const invalid = { ...baseProject, status: 'invalid' as const }
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Dialog open>
+        <LibraryInvalidProjectPanel
+          canRemove={false}
+          project={invalid}
+          removing={false}
+          onCancel={() => {}}
+          onRemove={() => {}}
+          onReveal={() => {}}
+        />
+        </Dialog>
+      </MemoryRouter>,
+    )
+
+    expect(html).not.toContain('data-library-invalid-remove="true"')
+    expect(html).toContain('更多')
+    expect(html).toContain('data-library-invalid-reveal="true"')
   })
 
   test('renders project cards in the desktop book-cover layout without redundant open copy', () => {
@@ -491,7 +559,10 @@ describe('LibraryRoute presentation', () => {
       </MemoryRouter>,
     )
 
-    expect(html).toContain('缺少 config.yaml')
+    // #38：invalid 仍然可见且仍排在最后，但卡上不再露 `缺少 config.yaml` 这类文件名，
+    // 只留一句人话；缺什么、能怎么办放进点击后的说明浮层。
+    expect(html).not.toContain('缺少 config.yaml')
+    expect(html).toContain('项目文件不完整')
     expect(html.match(/loading="eager"/g) ?? []).toHaveLength(3)
     expect(html).not.toContain('loading="lazy"')
     expect(html.indexOf('断点')).toBeLessThan(html.indexOf('可写'))

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type FormEventHandler, type ImgHTMLAttributes } from 'react'
 import { Link } from 'react-router'
+import { canRemoveFromLibrary } from '@shared/lib/library-project'
 import { toast } from 'sonner'
 import {
   Archive,
@@ -987,6 +988,135 @@ export function LibraryProjectManagementMenu({ project }: { project: NovelProjec
   )
 }
 
+
+export const LIBRARY_INVALID_PROJECT_DIALOG_CONTENT_CLASS = 'sm:max-w-[440px]'
+
+/**
+ * 损坏项目说明浮层（#38）。
+ *
+ * invalid 很可能是误判——文件夹被移动/重命名、外置盘没插、config.yaml 被误删而正文还在。
+ * 所以主动作是「打开所在文件夹」让作者自己看一眼，而不是引导他先删东西。
+ */
+export function LibraryInvalidProjectPanel({
+  canRemove,
+  onCancel,
+  onRemove,
+  onReveal,
+  project,
+  removing,
+}: {
+  canRemove: boolean
+  onCancel: () => void
+  onRemove: () => void
+  onReveal: () => void
+  project: NovelProjectSummary
+  removing: boolean
+}) {
+  return (
+    <div data-library-invalid-project-panel="true" className="grid gap-5">
+      <DialogHeader className="pr-8 text-left">
+        <DialogTitle className="text-lg leading-tight">这本书暂时打不开</DialogTitle>
+        <DialogDescription>
+          “{project.title}”的项目文件不完整，NarraCat 读不出它的进度和正文。常见原因是文件夹被移动或重命名，也可能是它所在的磁盘没有连接。
+        </DialogDescription>
+      </DialogHeader>
+
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        建议先打开文件夹看一眼：文件还在的话，放回原处就能恢复。
+        {canRemove
+          ? '确认不需要了，可以只把它从书架上移除——不会删掉任何文件。'
+          : '这本书就放在你的小说文件夹里，确认不要了请用卡片右上角「更多」里的删除。'}
+      </p>
+
+      <DialogFooter className="gap-2 sm:justify-between">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          知道了
+        </Button>
+        <div className="flex gap-2">
+          {canRemove ? (
+            <Button
+              type="button"
+              variant="outline"
+              data-library-invalid-remove="true"
+              disabled={removing}
+              onClick={onRemove}
+            >
+              {removing ? '移除中…' : '从书架移除'}
+            </Button>
+          ) : null}
+          <Button type="button" data-library-invalid-reveal="true" onClick={onReveal}>
+            打开所在文件夹
+          </Button>
+        </div>
+      </DialogFooter>
+    </div>
+  )
+}
+
+export function LibraryInvalidProjectDialog({
+  open,
+  onOpenChange,
+  project,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  project: NovelProjectSummary
+}) {
+  const [novelRootDir, setNovelRootDir] = useState<string | null>(null)
+  const [removing, setRemoving] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void window.electron
+      ?.getConfig?.()
+      .then((payload) => {
+        if (!cancelled) setNovelRootDir(payload?.config?.novelRootDir ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setNovelRootDir(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  // 读不到 novelRootDir 时按「不能移除」处理：宁可少给一个按钮，也不给点了不生效的。
+  const canRemove = novelRootDir ? canRemoveFromLibrary(project.path, novelRootDir) : false
+
+  async function remove() {
+    setRemoving(true)
+    try {
+      // 对 invalid 项目，删除流程本就只摘书架条目、不动任何文件（novel-delete.ts）。
+      await deleteLibraryProject({
+        projectPath: project.path,
+        title: project.title,
+        confirmationTitle: project.title,
+      })
+      onOpenChange(false)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setRemoving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={LIBRARY_INVALID_PROJECT_DIALOG_CONTENT_CLASS}>
+        <LibraryInvalidProjectPanel
+          canRemove={canRemove}
+          project={project}
+          removing={removing}
+          onCancel={() => onOpenChange(false)}
+          onRemove={() => void remove()}
+          onReveal={() => void window.electron?.revealProjectFolder?.(project.path)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export function LibraryProjectCard({
   coverLoading = 'lazy',
   project,
@@ -995,7 +1125,11 @@ export function LibraryProjectCard({
   project: NovelProjectSummary
 }) {
   const cover = getLibraryCoverPreset(project.coverPreset)
-  const problem = project.problem ?? (project.status === 'invalid' ? '项目文件需要检查' : null)
+  const isInvalid = project.status === 'invalid'
+  const [noticeOpen, setNoticeOpen] = useState(false)
+  // 损坏项目不把 `.narracat/config.yaml` 这类文件名糊到作者脸上，卡上只留一句人话，
+  // 详情与出路放进点击后的说明浮层（#38）。
+  const problem = isInvalid ? '项目文件不完整，点开看看能怎么办' : (project.problem ?? null)
   const displayGenre = normalizeLibraryGenre(project.genre)
   const chapterProgress = formatCardProgress(project.chapterProgress)
   const wordCount = formatCardWordCount(project.wordCountLabel)
@@ -1011,11 +1145,27 @@ export function LibraryProjectCard({
         project.status === 'invalid' && 'bg-destructive/5 hover:bg-destructive/10'
       )}
     >
-      <Link
-        to={`/workbench?project=${encodeURIComponent(project.path)}`}
-        aria-label={`打开 ${project.title} 工作台`}
-        className="absolute inset-0 z-0 rounded-[16px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
+      {isInvalid ? (
+        // 进到一个什么都读不出来的工作台对作者零价值，入口先拦住。
+        <button
+          type="button"
+          data-library-invalid-trigger="true"
+          aria-label={`${project.title} 项目文件不完整，查看怎么办`}
+          onClick={() => setNoticeOpen(true)}
+          className="absolute inset-0 z-0 rounded-[16px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      ) : (
+        <Link
+          to={`/workbench?project=${encodeURIComponent(project.path)}`}
+          aria-label={`打开 ${project.title} 工作台`}
+          className="absolute inset-0 z-0 rounded-[16px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      )}
+
+      {isInvalid ? (
+        <LibraryInvalidProjectDialog open={noticeOpen} onOpenChange={setNoticeOpen} project={project} />
+      ) : null}
+
 
       <div
         data-library-book-cover="true"


### PR DESCRIPTION
Closes #38

## 现象与排查

作者录入角色后，工作台状态面板弹红条：

```
状态更新失败
Error invoking remote method 'novel:refresh-status': Error: 缺少 .narracat/config.yaml 或 .narracat/state.yaml
```

**文件并没丢。** 复现机四个项目的 config/state 全部存在且可读；也排除了写入竞态——`state-sync.ts` 全程 `writeFile` 原地覆盖（不是 unlink→create），不存在文件句柄短暂消失的窗口。

真正的问题是三条不需要复现就能确证的缺陷。

## ① 入口没拦：书架标了红，仍旧让作者点进必炸的工作台

`<Link>` 覆盖整卡，invalid 卡片照常可点，进去必撞 `aggregateNovelStatusSnapshot` 第一行。

改为点击弹说明浮层。**主动作是「打开所在文件夹」而不是删除**——invalid 很可能是误判（文件夹被移动/重命名、外置盘没插、config.yaml 被误删而正文还在），这种时候引导作者删东西是灾难。

## ②「从书架移除」只在真能生效时才给

书架列表 = `novelRootDir` 直接子目录 **+** 配置里的最近路径。root 下的项目摘掉最近路径**下次扫描照样回来**，给一个点了不生效的按钮比不给更糟；这类项目改为把删除入口指回卡片「更多」。

移除本身复用既有 `deleteNovelProject`——它对 invalid 项目本就只摘书架条目、不 trash 任何文件，语义正合适，无需新造 IPC。

## ③ 黑话与可观测性

- 新增 `stripIpcErrorPrefix` 剥掉 `Error invoking remote method '…'` 外壳（这段实现细节还把唯一有用的信息挤到了后面）
- 项目文件不完整时给人话 +「返回书架」，不再给一个重试一万次都是同一个错的按钮
- 主进程抛错前补 `projectPath` 与两个文件各自的存在性到日志——**只有一句静态文案、不带路径，正是本次无法从现场倒推的直接原因**；面向作者的文案保持不变，路径不推到 UI 上

## 两条防静默失配的守卫

- 判据文案收成 `shared/lib/ipc-error.ts` 常量三处共用（原先主进程里重复写了两份）。各写各的字符串会在改动一侧时静默失配，损坏态退回老样子且无测试会红
- 渲染端用 `window.electron?.revealProjectFolder?.()` 调 IPC，**preload 漏登记会完全静默**（可选链吞掉，typecheck 也拦不住——ipc.d.ts 声明是齐的），故补 preload 三处登记守卫

## dogfood 校正了 issue 的一个前提

issue 说「书架放行 invalid 项目」，实际更精确：`scanRootChildren` 只放行 `isNarraCatProject` 为真的目录，所以 root 下**缺文件**的坏目录压根不会进书架。invalid 有两个来源，行为不同：

| 来源 | `isNarraCatProject` | 会被 root 扫描列出 | 移除有效 |
|---|---|---|---|
| 缺 config/state | 假 | 否 | 是（只能来自最近路径） |
| 文件在但读不出（yaml 损坏） | 真 | **是** | root 下时**否** |

第二类正是 `canRemove=false` 分支存在的理由——四种组合逐个核过，判据都对。

## 验证

- `typecheck` / `check:design` / `check:architecture` / `build` 全绿
- 全量测试 **3055 pass / 0 fail**（对 main 基线 +12 tests +3 files，核对过文件数不是静默跳过）
- **真机 dogfood 五步全过**：卡片人话文案 / 点击不跳工作台而弹浮层 /「打开所在文件夹」/「从书架移除」后卡片消失且文件夹仍在 / 原始文件名不外露

## 未解决

原报告「刚录入一个角色之后」那条链仍未复现。等 ③ 的日志上线，下次再撞就能一眼看出是哪一步把非项目根的路径当 projectPath 传了下去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A
