### PR TITLE
fix(agent): durable 事件路径取证 + 换 pi 遗留契约清理 (#37 刀①)

### DIFF
--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -4,13 +4,23 @@
 
 ## Current Branch
 
-`main`（= `c999265`，**已 push**）。社区第二批三个 PR（#18/#19/#20）合并，对应 issue #14/#16/#17 全部关闭、#15 拆分归位后 close。引擎 **4.0.172**。仓库已合一，「公开镜像仓 + 定向同步」的说法自 2026-08-16 起作废——本仓即唯一开发仓。
+`main`（= `4699fb2`，**已 push**）。社区第三批：PR #13（#5 刀 1，custom 渠道 OpenAI 协议）合并。此前社区第二批三个 PR（#18/#19/#20）合并，对应 issue #14/#16/#17 全部关闭、#15 拆分归位后 close。引擎 **4.0.172**（本次未动引擎）。仓库已合一，「公开镜像仓 + 定向同步」的说法自 2026-08-16 起作废——本仓即唯一开发仓。
 
 ## Current Phase
 
 主线 `main`。产品北极星 = ADR-0030「账房归我们 / 花归用户 / 尺归读者」；产品方向 2026-07-11 定案两大模块「用户编辑 + 可配置底座」。**正文编辑器主战役已收官**（PR #443 合并 main，ADR-0031，引擎 4.0.91，产品主人真机验收通过）；写作质量「脱胎换骨」主线阶段性收刀（arc 速度靶 PR #441 / 获得引擎四刀 PR #442 均已合并）。ADR 已扩至 **0035**。
 
 产品路线以下方 **Next（产品路线图 · 2026-07-12 统筹版）** 为准：四条泳道 = A 花的所有权（用户编辑）/ B 花的表达权（可配置底座）/ C 尺（评价与验证）/ D 账房（记忆与资产底座）。战略层以 `docs/COMPASS.md` 为准，执行入口 `/next-issue`。
+
+**2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
+
+**两轮 review。第一轮抓到的阻断项是这条记录的重点**：切协议按钮**实质点不动，还会把磁盘上已落盘的 wire 静默改回去**。根因在 `src/lib/settings-config.ts` 的草稿保护——`toDisplay` 把 providers 整个换回本地草稿（原为防「用户正在打字的 baseUrl 被落盘结果吃掉」），而 `onModelWireChange` 从不更新草稿里的 wire，这层保护就变成了回滚；紧接着 `mergeProviderDraft` 在「测试连接」时把整个 provider 对象从草稿写回 persisted，把磁盘上正确的 openai 也覆盖掉。**本质是把离散的即时落盘字段（wire，语义同「设为主力」）塞进了为打字输入设计的保护圈**。采纳修法 2（字段级保护：只回护 `baseUrl`），一次修掉两处。**贡献者的根因交代比修复本身值钱**：这刀是从他 fork 的完整实现里提取的，原版有 `displayProviders:'saved'` 防这类回滚，提取时被当成动态渠道的附属品剔掉了——**从大实现里切片时被剥离的保护件，是回归的高发区**，以后审同类提取式 PR 要专门过一遍。
+
+**维护者复审不采信贡献者的测试报告，全部独立复跑**：`typecheck` / `check:design` / `check:architecture` 全绿；全量 **3000 pass / 0 fail across 296 files**；**合并最新 main 后复跑 3008 pass / 0 fail across 297 files**（零冲突）；阻断项两步**另写一份复现脚本**（不复用贡献者用例）验证 3 pass。**额外验的两项是复审真正的增量**：①**存量用户升级路径**——`wire` 成了必填字段，legacy 兼容一旦写错，所有老用户升级后验证态会被清空、被迫重新测试连接；拿本机真实 `config.json`（无 wire 字段、两条已验证 deepseek 条目）跑新 `normalizeAppConfig`，**快照零清空、主力槽仍 verified**。②**指纹加 wire 的迁移成本**——一度担心会让存量用户旧对话一次性失配，查下来不成立：`sdkSessionsByThread` 是纯内存 Map（`run-manager.ts:194`），跨重启本就不 resume，升级必然重启，零成本。
+
+**刀 2 未做的用户可见后果必须在刀 1 交代**（这是审核时提的第二条必改）：四条直连 `@anthropic-ai/sdk` 的路径在 openai wire 下全挂——`character-chat-runner`（取**主力槽**，故只要 custom 设成主力，角色聊天就中招）/ `character-chat-profiler` / `packs/pack-compile` / `packs/card-rewrite`。**最坑的是误导性**：`testProviderConnection` 走 `createPiModel`、openai wire 已接通，用户会看到**测试连接绿灯**，转头去唠个嗑撞一个 Anthropic SDK 抛的 404 天书——绿灯之后功能挂掉，比一开始就报错更伤。选了成本近零的解法：维护者定稿的渠道配置提示文案里，把前缀缓存费用警示与功能覆盖缺口一起写清，UI 测试断言「只覆盖写作主链」关键词防将来改文案把告知改丢。
+
+**已知项与待办**：`maxTokens: 32_000` 沿用 anthropic wire 的调优值，openai wire 下部分兼容网关/小模型可能直接 400，留待真实反馈后考虑按 wire 分设；baseUrl 不带 `/v1` 时 openai 分支不自动补，静默 404 回落内置目录（placeholder 与 description 均有提示，可接受）。**两项维护者未验并已如实标注**：openai wire 真连（无 OpenAI 兼容端点，依赖贡献者的 E2E 证据——opencode.ai 网关、模型清单 + 主链完整往返，是可复现描述而非「我机器上好了」）；协议按钮与须知文案在 Electron 里的真机排版观感（结构测试与 `check:design` 均绿，留 dogfood 时自查）。**顺带立 #24**：`check:design` 在 Windows 上恒红（`brand-illustrations.ts violates brand asset guard`），贡献者验证在 main 裸跑同样红、与本 PR 无关；怀疑守卫的字符串子串断言撞上 CRLF 行尾（本仓无 `.gitattributes`），**一个在某平台恒红的守卫比没有守卫更糟**——会训练出「这条红的可以跳过」的习惯，且把 Windows 贡献者挡在「无法自证改动干净」的位置上。
 
 **2026-08-18（社区第二批：外部报告三条修复全部合并，PR #18/#19/#20）**：报告人 @Akimixu-19897 一天内提三条（#14/#15/#16），逐条读代码定位后**结论与报告不完全一致**，是本轮最值得记的部分。
 

--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -20,7 +20,17 @@
 
 **测试覆盖的边界**：兄弟目录前缀误伤（`/novel-x` 不得吃掉 `/novel-x-backup`，最初实现真踩了，落盘会变成 `<项目>-backup`）、Windows 两侧分隔符不一致（配置里 `/`、Node 错误串里 `\`，按字面匹配整条漏掉 = Windows 上取证等于没做）、项目外路径仍被抹、存量事件缺 `target` 字段仍可读。验证：typecheck / 全量 **3053 pass 0 fail**（对 main 基线 3043/301 为 **+10 tests +2 files**，核对过文件数不是静默跳过）/ check:design / check:architecture / build 全绿；启动烟测正常，dev 下引擎根解析为真实存在目录并验证相对化生效。
 
-**待办**：真机 dogfood 跑一章拿真实路径分布，才能进 #37 的 ②（过程流区分「跳过」与「失败」）与 ③（25% 打空的系统性根因）。③ 明确**不能凭猜改 prompt**。
+**真机 dogfood 打脸（2026-08-20）：跑完一章，target 字段一个都没有，而全部单测照样绿。** 根因是字段名搞错——最初照搬 `tool-phrase.ts` 的 `['file_path','filePath']`，那是 claude-sdk 时代的契约（工具名还是大写 `Read`）；换 pi 后工具名变小写、参数名变 `path`，`extractToolTargetPath` 于是永远返回 undefined。取证走 pi 的 `sessions/*.jsonl`（工具调用的完整入参本来就落在那里）：`read {path,offset}` / `write {path,content}` / `find {path,pattern}` / `grep {pattern,path,context}`，四个工具一律 `path`，无一使用 `file_path`。
+
+**最刺眼的一点**：`pi-tool-guard.ts` 第 45 行注释早就写着「路径字段受圈禁的 pi 内置工具（**字段全叫 path**）」，同文件的 `SDK_TO_PI_TOOL_NAME` 就是权威映射表（含 `Glob → find` 这个改名）。**先读那个文件，这个 bug 一个都不会有。**「复用同仓已有常量」看起来是对的工程直觉，实际是从一份过期契约里抄答案；而测试与实现共用同一个错误假设（用例全用 `{file_path}` 构造），所以全绿也挡不住。修复同时把 sink 测试的 input 改成 `{path}`——原来的形态在真实系统里根本不存在，测试等于在验证虚构场景。
+
+**同源副产品（已一并修）**：`tool-phrase.ts` 的 `Read`/`Write`/`Grep`/`Glob` 四个 case 在 pi 下全是死代码，工具卡文案静默退化——作者看到的不是「读取 config.yaml」而是 default 分支兜底吐的 **`read config.yaml`**（英文工具标识直接糊脸）。旧的大写 case 保留（fall-through），因为存量会话事件里存的是 SDK 名，重看旧对话仍要正确渲染；另补 `ls` 与 `AskUserQuestion`。守卫测试第一版只挡「调用 <name>」，**漏掉了「<name> <值>」这种形态，红一次才发现**——退化不止一种长相。
+
+**最终真机验证通过**：`find → <项目>`、`read → <项目>/manuscript/vol-01/ch-001.md`、`read → <项目>/outline/vol-01/ch-001.md`、`find → <项目>/.narracat/manuscript-drafts`；`bash → 无 target`（正确，它用 command 不用 path）。相对化同批验证：`ENOENT ... access '<项目>/.narracat/staging/ch-019.md'`。
+
+**给 ③ 的第一条线索**：本次跑章 read 失败 5 次 = 3 次 EISDIR（错误串不带路径）+ 2 次 ENOENT 指向 `<项目>/.narracat/staging/ch-0XX.md`，**agent 在读还没生成的 staging 文件**。注意本批 read 失败率 10.4%（43/5）与历史 25.6%（145/50）不可直接对比——本次改动没有触碰 read 行为，差异不能归因于它。
+
+**待办**：#37 的 ②（过程流区分「跳过」与「失败」）与 ③（系统性打空的根因）。③ 现在有了带路径的取证数据，但仍**不能凭猜改 prompt**——需要更多样本确认 staging 那条线索是不是主因。
 
 **2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
 

--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -12,6 +12,16 @@
 
 产品路线以下方 **Next（产品路线图 · 2026-07-12 统筹版）** 为准：四条泳道 = A 花的所有权（用户编辑）/ B 花的表达权（可配置底座）/ C 尺（评价与验证）/ D 账房（记忆与资产底座）。战略层以 `docs/COMPASS.md` 为准，执行入口 `/next-issue`。
 
+**2026-08-20（#37 刀①：durable 事件路径取证，分支 `fix/37-durable-path-forensics` = `554705d`，未合并）**：Agent 过程流频繁「已跳过 调用 read」，取证发现 read 失败率 **25.6%（50/195）**，但错误里的路径被我们自己的脱敏（`agent-durable-events.ts` 的 `ABSOLUTE_PATH`）整段抹成 `[本机路径]`——**根因不可查这件事本身是第一层问题**。改法：脱敏**之前**先把已知根相对化成 `<项目>/…` / `<引擎>/…`，根以上不落盘、根以外照旧整段抹。
+
+**issue 原方案只做脱敏，实测会留 1/3 盲区**：50 次失败里 33 次 ENOENT 的错误串自带路径，另外 **17 次 EISDIR 的错误串根本不含路径**（`EISDIR: illegal operation on a directory, read`，到此为止），唯一带路径的是 `tool.started` 的 `input`，而 sink 的 `tools` Map 只存 `{messageId,toolName,title}`、input 被丢弃。故落盘事件新增可选 `target`：在 started 时取出路径、相对化后存进 live 投影，收尾事件再写出。**只改脱敏对 EISDIR 那一类无效**，会再来一轮。
+
+**已知根经装配层注入**（`ipc/agent.ts` → coordinator → sink），与 run-manager / pi adapter 共用同一份 `resolveNarraCatAgentCorePath({appRoot, resourcesPath})`（均不传 `envPath`），避免两处算出不同引擎根。**根为空时功能不报错、不失败，只是落盘里照旧 `[本机路径]` 而单测全绿**——这类静默失效只能在装配处拦，故加了装配层源码断言。
+
+**测试覆盖的边界**：兄弟目录前缀误伤（`/novel-x` 不得吃掉 `/novel-x-backup`，最初实现真踩了，落盘会变成 `<项目>-backup`）、Windows 两侧分隔符不一致（配置里 `/`、Node 错误串里 `\`，按字面匹配整条漏掉 = Windows 上取证等于没做）、项目外路径仍被抹、存量事件缺 `target` 字段仍可读。验证：typecheck / 全量 **3053 pass 0 fail**（对 main 基线 3043/301 为 **+10 tests +2 files**，核对过文件数不是静默跳过）/ check:design / check:architecture / build 全绿；启动烟测正常，dev 下引擎根解析为真实存在目录并验证相对化生效。
+
+**待办**：真机 dogfood 跑一章拿真实路径分布，才能进 #37 的 ②（过程流区分「跳过」与「失败」）与 ③（25% 打空的系统性根因）。③ 明确**不能凭猜改 prompt**。
+
 **2026-08-18（社区第三批：custom 渠道支持 OpenAI 协议，PR #13 = #5 刀 1，`4699fb2`）**：@zfengChen 的提案 #5 拆三刀后的第一刀落地。custom 渠道新增 `wire` 字段（`anthropic` 默认 / `openai`），主链走 pi-ai 原生 `openai-completions`（零新依赖），模型清单双头拉取（`Bearer {base}/models` vs `x-api-key {base}/v1/models`），wire 贯通配置归一化 / 验证快照 / 会话指纹。**默认行为零变化**——`normalizeWire` 把 openai 锁死在 custom 渠道，内置四家含手改配置文件一律回落 anthropic，错配拦在入口而非事后补救。
 
 **两轮 review。第一轮抓到的阻断项是这条记录的重点**：切协议按钮**实质点不动，还会把磁盘上已落盘的 wire 静默改回去**。根因在 `src/lib/settings-config.ts` 的草稿保护——`toDisplay` 把 providers 整个换回本地草稿（原为防「用户正在打字的 baseUrl 被落盘结果吃掉」），而 `onModelWireChange` 从不更新草稿里的 wire，这层保护就变成了回滚；紧接着 `mergeProviderDraft` 在「测试连接」时把整个 provider 对象从草稿写回 persisted，把磁盘上正确的 openai 也覆盖掉。**本质是把离散的即时落盘字段（wire，语义同「设为主力」）塞进了为打字输入设计的保护圈**。采纳修法 2（字段级保护：只回护 `baseUrl`），一次修掉两处。**贡献者的根因交代比修复本身值钱**：这刀是从他 fork 的完整实现里提取的，原版有 `displayProviders:'saved'` 防这类回滚，提取时被当成动态渠道的附属品剔掉了——**从大实现里切片时被剥离的保护件，是回归的高发区**，以后审同类提取式 PR 要专门过一遍。

--- a/electron/main/agent/events/agent-event-sink.test.ts
+++ b/electron/main/agent/events/agent-event-sink.test.ts
@@ -595,3 +595,137 @@ describe('agent event sink', () => {
     })
   })
 })
+
+describe('durable tool forensics (#37)', () => {
+  test('records the project-relative target path of a failed tool call', async () => {
+    // EISDIR 类错误串本身不含路径，只有 tool.started 的 input 里有。落盘不记 target 就
+    // 永远查不出 agent 到底读了哪个目录——这正是 read 失败率 25.6% 却无从定位的原因。
+    const root = await createRoot()
+    const store = createAgentConversationStore({
+      rootDir: root,
+      now: () => occurredAt,
+      createSegmentId: () => segmentId,
+    })
+    const sink = createAgentEventSink({ store, broadcast: () => {} })
+    const projectPath = '/Users/somebody/Novels/novel-x'
+
+    await sink.publish({
+      type: 'run.started',
+      runId: 'run-forensics',
+      threadId,
+      command: 'freeform',
+      prompt: '写第 20 章',
+      projectPath,
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.started',
+      runId: 'run-forensics',
+      messageId: 'assistant-run-forensics',
+      toolCallId: 'tool-forensics',
+      toolName: 'Read',
+      title: '调用 Read',
+      input: { file_path: `${projectPath}/bible/characters` },
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.failed',
+      runId: 'run-forensics',
+      toolCallId: 'tool-forensics',
+      error: 'EISDIR: illegal operation on a directory, read',
+      createdAt: occurredAt,
+    })
+
+    const durable = await allJsonText(root)
+    expect(durable).toContain('<项目>/bible/characters')
+    expect(durable).not.toContain('/Users/somebody')
+  })
+
+  test('rewrites in-project paths inside the error string but still scrubs anything outside the root', async () => {
+    // ENOENT 类错误串自带路径（33/50 次属此类）。相对化只能作用在项目根以内——根以外的
+    // 路径必须继续整段抹掉，否则作者截图求助就会泄露用户名与本机目录结构。
+    const root = await createRoot()
+    const store = createAgentConversationStore({
+      rootDir: root,
+      now: () => occurredAt,
+      createSegmentId: () => segmentId,
+    })
+    const sink = createAgentEventSink({ store, broadcast: () => {} })
+    const projectPath = '/Users/somebody/Novels/novel-x'
+
+    await sink.publish({
+      type: 'run.started',
+      runId: 'run-enoent',
+      threadId,
+      command: 'freeform',
+      prompt: '写第 20 章',
+      projectPath,
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.started',
+      runId: 'run-enoent',
+      messageId: 'assistant-run-enoent',
+      toolCallId: 'tool-enoent',
+      toolName: 'Read',
+      title: '调用 Read',
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.failed',
+      runId: 'run-enoent',
+      toolCallId: 'tool-enoent',
+      error: `ENOENT: no such file or directory, access '${projectPath}/chapters/020.md' (also tried /Users/somebody/Desktop/草稿.md)`,
+      createdAt: occurredAt,
+    })
+
+    const durable = await allJsonText(root)
+    expect(durable).toContain('<项目>/chapters/020.md')
+    expect(durable).toContain('[本机路径]')
+    expect(durable).not.toContain('/Users/somebody')
+  })
+
+  test('rewrites Agent Core paths as <引擎> so engine reads stay traceable too', async () => {
+    // agent 读的不只是小说项目，还有引擎的 skill/command 文件。开发机上引擎目录同样在
+    // /Users/… 下，不给它一个根就会被整段抹掉，引擎侧的读取失败照样查不了。
+    const root = await createRoot()
+    const store = createAgentConversationStore({
+      rootDir: root,
+      now: () => occurredAt,
+      createSegmentId: () => segmentId,
+    })
+    const agentCorePath = '/Users/somebody/app/agent-core/narracat'
+    const sink = createAgentEventSink({ store, broadcast: () => {}, agentCorePath })
+
+    await sink.publish({
+      type: 'run.started',
+      runId: 'run-engine',
+      threadId,
+      command: 'freeform',
+      prompt: '写第 20 章',
+      projectPath: '/Users/somebody/Novels/novel-x',
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.started',
+      runId: 'run-engine',
+      messageId: 'assistant-run-engine',
+      toolCallId: 'tool-engine',
+      toolName: 'Read',
+      title: '调用 Read',
+      input: { file_path: `${agentCorePath}/skills/write.md` },
+      createdAt: occurredAt,
+    })
+    await sink.publish({
+      type: 'tool.failed',
+      runId: 'run-engine',
+      toolCallId: 'tool-engine',
+      error: 'ENOENT: no such file or directory',
+      createdAt: occurredAt,
+    })
+
+    const durable = await allJsonText(root)
+    expect(durable).toContain('<引擎>/skills/write.md')
+    expect(durable).not.toContain('/Users/somebody')
+  })
+})

--- a/electron/main/agent/events/agent-event-sink.test.ts
+++ b/electron/main/agent/events/agent-event-sink.test.ts
@@ -132,7 +132,7 @@ describe('agent event sink', () => {
       toolCallId: 'tool-1',
       toolName: 'Read',
       title: '读取 /Users/writer/secret-novel/chapter.md',
-      input: { file_path: '/Users/writer/secret-novel/chapter.md', apiKey: 'sk-secret' },
+      input: { path: '/Users/writer/secret-novel/chapter.md', apiKey: 'sk-secret' },
       createdAt: occurredAt,
     })
     await sink.publish({
@@ -625,7 +625,8 @@ describe('durable tool forensics (#37)', () => {
       toolCallId: 'tool-forensics',
       toolName: 'Read',
       title: '调用 Read',
-      input: { file_path: `${projectPath}/bible/characters` },
+      // pi runtime 的真实参数名是 `path`（真机会话取证），测试必须用真实形态
+      input: { path: `${projectPath}/bible/characters` },
       createdAt: occurredAt,
     })
     await sink.publish({
@@ -713,7 +714,7 @@ describe('durable tool forensics (#37)', () => {
       toolCallId: 'tool-engine',
       toolName: 'Read',
       title: '调用 Read',
-      input: { file_path: `${agentCorePath}/skills/write.md` },
+      input: { path: `${agentCorePath}/skills/write.md` },
       createdAt: occurredAt,
     })
     await sink.publish({

--- a/electron/main/agent/events/agent-event-sink.ts
+++ b/electron/main/agent/events/agent-event-sink.ts
@@ -19,6 +19,11 @@ import {
   sanitizeDurableSummary,
   sanitizeDurableText,
 } from '@shared/lib/agent-durable-events'
+import {
+  extractToolTargetPath,
+  relativizeKnownRoots,
+  type ScrubRoot,
+} from '@shared/lib/agent-path-scrub'
 import { applyTaskToolCall } from './task-plan-from-tools.ts'
 
 interface SegmentLiveState {
@@ -31,7 +36,7 @@ interface LiveRunProjection {
   threadId: string
   assistantText: string
   taskPlan: AgentTaskPlanItem[]
-  tools: Map<string, { messageId: string; toolName: string; title: string }>
+  tools: Map<string, { messageId: string; toolName: string; title: string; target?: string }>
   status: 'accepted' | 'running' | 'waiting-user' | 'cancelling' | 'durability-failed'
   lastEventAt: string
   stalledAt?: string
@@ -68,6 +73,11 @@ export interface AgentEventSinkOptions {
   onSideEffectError?: (error: unknown, event: AgentEventEnvelopeV1) => void
   now?: () => string
   ringSize?: number
+  /**
+   * Agent Core 根路径。用于把引擎侧的读写路径相对化成 `<引擎>/…`（#37 取证）——
+   * 开发机上引擎目录同样在用户目录下，不给根就会被脱敏整段抹掉。
+   */
+  agentCorePath?: string
 }
 
 function visiblePrompt(event: Extract<AgentEvent, { type: 'run.started' }>): string {
@@ -199,12 +209,27 @@ export function createAgentEventSink(options: AgentEventSinkOptions): AgentEvent
     return envelope
   }
 
+  /**
+   * 取证时允许保留相对路径的已知根（#37）。根以上的部分（用户名、本机目录结构）不落盘，
+   * 根以下的部分保留——既不泄露隐私，又能看出 agent 读的是哪一类文件。
+   */
+  function scrubRootsFor(run: LiveRunProjection): ScrubRoot[] {
+    const roots: ScrubRoot[] = []
+    if (run.projectPath) roots.push({ label: '项目', path: run.projectPath })
+    if (options.agentCorePath) roots.push({ label: '引擎', path: options.agentCorePath })
+    return roots
+  }
+
   function durableToolEvent(
     event: Extract<AgentEvent, { type: 'tool.completed' | 'tool.failed' }>,
     run: LiveRunProjection,
   ): AgentDurableEventV1 | null {
     const tool = run.tools.get(event.toolCallId)
     if (!tool) return null
+    const target = tool.target === undefined ? {} : { target: tool.target }
+    // 错误串里的路径先相对化再脱敏：否则 `access '/Users/…'` 会被整段抹成 `[本机路径]`，
+    // 连我们也查不出 agent 读的是哪个文件（#37）。
+    const roots = scrubRootsFor(run)
     if (event.type === 'tool.completed') {
       return {
         type: 'run.tool-summarized',
@@ -214,7 +239,8 @@ export function createAgentEventSink(options: AgentEventSinkOptions): AgentEvent
         toolName: tool.toolName,
         title: sanitizeDurableText(tool.title, '工具执行完成', 500),
         status: 'complete',
-        summary: sanitizeDurableSummary(event.summary, '工具执行完成'),
+        summary: sanitizeDurableSummary(relativizeKnownRoots(event.summary ?? '', roots), '工具执行完成'),
+        ...target,
         createdAt: event.createdAt,
       }
     }
@@ -226,7 +252,8 @@ export function createAgentEventSink(options: AgentEventSinkOptions): AgentEvent
       toolName: tool.toolName,
       title: sanitizeDurableText(tool.title, '工具执行失败', 500),
       status: 'failed',
-      error: sanitizeDurableSummary(event.error, '工具执行失败'),
+      error: sanitizeDurableSummary(relativizeKnownRoots(event.error, roots), '工具执行失败'),
+      ...target,
       createdAt: event.createdAt,
     }
   }
@@ -359,7 +386,15 @@ export function createAgentEventSink(options: AgentEventSinkOptions): AgentEvent
           // assistantText 只保留最后一段（工具/问答全部结束后的总结），否则问答完成或用户手动
           // 终止时全程过程文本会平铺成一个巨型气泡。子会话事件带 parentToolCallId 不算主会话边界。
           if (!event.parentToolCallId) run.assistantText = ''
+          // 目标路径只在 tool.started 的 input 里，收尾事件（tool.completed/failed）拿不到，
+          // 所以在这里就取出并相对化存起来，供落盘取证使用（#37）。
+          const rawTarget = extractToolTargetPath(event.input)
+          const target =
+            rawTarget === undefined
+              ? undefined
+              : sanitizeDurableText(relativizeKnownRoots(rawTarget, scrubRootsFor(run)), '', 500)
           run.tools.set(event.toolCallId, {
+            ...(target ? { target } : {}),
             messageId: event.messageId,
             toolName: event.toolName,
             title: event.title,

--- a/electron/main/agent/runs/agent-runtime-coordinator.ts
+++ b/electron/main/agent/runs/agent-runtime-coordinator.ts
@@ -46,6 +46,8 @@ export interface AgentRuntimeCoordinatorDeps {
   resolveProjectIdentity: (projectPath: string) => Promise<AgentProjectIdentity>
   beforeBroadcast?: (event: AgentEventEnvelopeV1) => void | Promise<void>
   onSideEffectError?: (error: unknown, event: AgentEventEnvelopeV1) => void
+  /** Agent Core 根路径，透传给 sink 做路径取证的已知根（#37）。 */
+  agentCorePath?: string
 }
 
 export interface AgentRuntimeCoordinator {
@@ -158,6 +160,7 @@ export function createAgentRuntimeCoordinator(deps: AgentRuntimeCoordinatorDeps)
   const sink = createAgentEventSink({
     store: deps.store,
     broadcast,
+    ...(deps.agentCorePath ? { agentCorePath: deps.agentCorePath } : {}),
     beforeBroadcast: async (envelope) => {
       try {
         await deps.beforeBroadcast?.(envelope)

--- a/electron/main/ipc/agent-wiring.test.ts
+++ b/electron/main/ipc/agent-wiring.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * 装配层接线守卫（#37）。
+ *
+ * 路径取证依赖 sink 拿到「已知根」，根为空时功能不报错、不失败，只是默默什么都不做——
+ * 落盘里照旧是 `[本机路径]`，而所有单测仍然全绿。这类静默失效只能在装配处拦。
+ */
+describe('agent runtime IPC wiring', () => {
+  const source = readFileSync(fileURLToPath(new URL('./agent.ts', import.meta.url)), 'utf-8')
+
+  test('passes the resolved Agent Core path into the runtime coordinator', () => {
+    expect(source).toContain('resolveNarraCatAgentCorePath')
+    expect(source).toMatch(/agentCorePath[,:]/)
+  })
+})

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -17,6 +17,7 @@ import {
 import { createAgentSessionCompatibilityFingerprint } from '../agent/runs/session-fingerprint.ts'
 import { createAgentMainSideEffects } from '../agent/events/agent-main-side-effects.ts'
 import { NARRACAT_AGENT_CORE_VERSION_LOCK } from '../engine/agent-core-contract.ts'
+import { resolveNarraCatAgentCorePath } from '../engine/engine.ts'
 import type {
   AgentEventsAfterResultV1,
   AgentHistorySegmentSummaryV1,
@@ -89,6 +90,12 @@ export function getAgentRuntimeCoordinator(): AgentRuntimeCoordinator {
         }),
       onSideEffectError: (error) => console.error(error),
       beforeBroadcast: mainSideEffects,
+      // 路径取证的已知根之一（#37）：引擎目录在开发机上同样落在用户目录下，
+      // 不传根就会被脱敏整段抹成 `[本机路径]`，引擎侧的读取失败照样查不了。
+      agentCorePath: resolveNarraCatAgentCorePath({
+        appRoot: app.getAppPath(),
+        resourcesPath: process.resourcesPath,
+      }),
     })
   }
   return _agentRuntimeCoordinator

--- a/shared/lib/agent-durable-events.test.ts
+++ b/shared/lib/agent-durable-events.test.ts
@@ -22,3 +22,35 @@ describe('durable Agent conversation boundaries', () => {
     expect(divided.messages.map((message) => message.role)).toEqual(['divider'])
   })
 })
+
+describe('durable tool events stay readable across versions', () => {
+  test('reduces a stored tool event that predates the target field (#37)', () => {
+    // target 是 #37 新增的可选字段。用户机器上已有大量不含该字段的落盘事件，
+    // 读取端一旦按必填处理，历史会话就会整段读不出来。
+    const accepted = reduceAgentDurableEvent(createEmptyDurableAgentThread('novel:legacy'), {
+      type: 'run.accepted',
+      runId: 'run-legacy',
+      command: 'freeform',
+      visiblePrompt: '写第 20 章',
+      createdAt: '2026-07-24T12:00:00.000Z',
+    })
+    const reduced = reduceAgentDurableEvent(accepted, {
+      type: 'run.tool-summarized',
+      runId: 'run-legacy',
+      messageId: 'assistant-run-legacy',
+      toolCallId: 'tool-legacy',
+      toolName: 'Read',
+      title: '调用 Read',
+      status: 'failed',
+      error: 'EISDIR: illegal operation on a directory, read',
+      createdAt: '2026-07-24T12:00:00.000Z',
+    })
+
+    const toolParts = reduced.messages
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === 'tool-call')
+    expect(toolParts).toEqual([
+      expect.objectContaining({ type: 'tool-call', toolCallId: 'tool-legacy', status: 'failed' }),
+    ])
+  })
+})

--- a/shared/lib/agent-path-scrub.test.ts
+++ b/shared/lib/agent-path-scrub.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { extractToolTargetPath, relativizeKnownRoots } from './agent-path-scrub'
+
+describe('relativizeKnownRoots', () => {
+  test('rewrites a path under the project root as <项目>/…', () => {
+    const result = relativizeKnownRoots(
+      "ENOENT: no such file or directory, access '/Users/a/Novels/novel-x/bible/characters/林小满.md'",
+      [{ label: '项目', path: '/Users/a/Novels/novel-x' }],
+    )
+
+    expect(result).toContain('<项目>/bible/characters/林小满.md')
+    expect(result).not.toContain('/Users/a')
+  })
+
+  test('does not treat a sibling directory sharing the root name as inside the root', () => {
+    // /novel-x 与 /novel-x-backup 是两本不同的书。按字符串前缀切会把后者改写成
+    // `<项目>-backup`，读起来像项目内路径，实际是另一个目录——取证会指向错的地方。
+    const result = relativizeKnownRoots('/Users/a/Novels/novel-x-backup/bible/世界观.md', [
+      { label: '项目', path: '/Users/a/Novels/novel-x' },
+    ])
+
+    expect(result).toBe('/Users/a/Novels/novel-x-backup/bible/世界观.md')
+  })
+
+  test('matches a Windows root regardless of which separator each side uses', () => {
+    // Windows 上两侧分隔符常不一致：projectPath 可能来自配置（正斜杠），而 Node 的错误
+    // 信息给的是反斜杠。按字面匹配会整条漏掉，取证在 Windows 上等于没做。
+    const result = relativizeKnownRoots(
+      "EISDIR: illegal operation on a directory, read 'C:\\Users\\a\\Novels\\novel-x\\bible\\characters'",
+      [{ label: '项目', path: 'C:/Users/a/Novels/novel-x' }],
+    )
+
+    expect(result).toContain('<项目>')
+    expect(result).not.toContain('C:\\Users\\a')
+  })
+})
+
+describe('extractToolTargetPath', () => {
+  test('reads the file path from a Read call', () => {
+    expect(extractToolTargetPath({ file_path: '/a/b/chapters/001.md' })).toBe(
+      '/a/b/chapters/001.md',
+    )
+  })
+
+  test('returns undefined for a tool call that carries no path', () => {
+    // 无路径的工具（MCP 查询等）不该凭空造出一个 target 字段。
+    expect(extractToolTargetPath({ query: '林小满是谁' })).toBeUndefined()
+  })
+})

--- a/shared/lib/agent-path-scrub.test.ts
+++ b/shared/lib/agent-path-scrub.test.ts
@@ -42,6 +42,16 @@ describe('extractToolTargetPath', () => {
     )
   })
 
+
+  test('reads the pi runtime path argument (#37 dogfood: real tools use `path`)', () => {
+    // 真机取证：pi 的 read/write/find/grep 一律用 `path`。
+    // 最初照搬了 tool-phrase.ts 的 ['file_path','filePath']——那是 claude-sdk 时代的
+    // 契约（工具名还是大写 Read），换 pi 后早已不成立，导致 target 在真实 run 里恒为空。
+    expect(extractToolTargetPath({ path: '/a/b/.narracat/staging/ch-021.md' })).toBe(
+      '/a/b/.narracat/staging/ch-021.md',
+    )
+  })
+
   test('returns undefined for a tool call that carries no path', () => {
     // 无路径的工具（MCP 查询等）不该凭空造出一个 target 字段。
     expect(extractToolTargetPath({ query: '林小满是谁' })).toBeUndefined()

--- a/shared/lib/agent-path-scrub.ts
+++ b/shared/lib/agent-path-scrub.ts
@@ -1,0 +1,57 @@
+/**
+ * Agent 事件里的路径取证（#37 刀①）。
+ *
+ * durable 事件的脱敏会把所有绝对路径整段抹成 `[本机路径]`，初衷是作者截图求助时不泄露
+ * 用户名与本机目录结构。代价是连我们也拿不到 agent 究竟读了哪个文件，read 失败率 25.6%
+ * 却无从定位。本模块在脱敏**之前**先把已知根下的路径改写成 `<项目>/…` / `<引擎>/…`，
+ * 既不泄露根以上的部分，又能一眼看出读的是哪一类文件；根之外的路径继续交给脱敏整段抹掉。
+ */
+
+export interface ScrubRoot {
+  /** 占位标签，渲染为 `<label>`。 */
+  label: string
+  /** 根的绝对路径。 */
+  path: string
+}
+
+/**
+ * 工具 input 里表示「操作目标文件」的字段名，按优先级排列。
+ * 与 `src/components/workbench/agent/tool-phrase.ts` 的路径读取共用同一份，避免两处漂移。
+ */
+export const TOOL_PATH_INPUT_KEYS = ['file_path', 'filePath'] as const
+
+/**
+ * 从工具调用入参里取出操作目标路径。取不到就返回 undefined——宁可没有 target 字段，
+ * 也不要把别的字段当路径落进取证数据里。
+ */
+export function extractToolTargetPath(input: Record<string, unknown> | undefined): string | undefined {
+  if (!input) return undefined
+  for (const key of TOOL_PATH_INPUT_KEYS) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function relativizeKnownRoots(text: string, roots: ScrubRoot[]): string {
+  let result = text
+  for (const root of roots) {
+    // 去掉尾部分隔符后再匹配，并要求根后面是分隔符或边界：否则 /novel-x 会吃掉
+    // 兄弟目录 /novel-x-backup，把另一本书的路径伪装成项目内路径。
+    const normalized = root.path.replace(/[/\\]+$/, '')
+    if (!normalized) continue
+    // 两侧分隔符可能不一致（Windows 上配置里是 `/`、Node 错误信息里是 `\`），
+    // 所以按段拆开、用 [/\\]+ 重连，而不是按字面匹配。
+    const segments = normalized.split(/[/\\]+/).map(escapeRegExp)
+    const pattern = new RegExp(
+      `${segments.join('[/\\\\]+')}(?=[/\\\\]|$|['"\`\\s,;:)\\]}])`,
+      'g',
+    )
+    result = result.replace(pattern, `<${root.label}>`)
+  }
+  return result
+}

--- a/shared/lib/agent-path-scrub.ts
+++ b/shared/lib/agent-path-scrub.ts
@@ -17,8 +17,15 @@ export interface ScrubRoot {
 /**
  * 工具 input 里表示「操作目标文件」的字段名，按优先级排列。
  * 与 `src/components/workbench/agent/tool-phrase.ts` 的路径读取共用同一份，避免两处漂移。
+ *
+ * `path` 是当前 pi runtime 的真实契约——真机会话取证：read / write / find / grep
+ * 一律用 `path`，无一使用 `file_path`。后两个是 claude-sdk 时代（工具名还是大写 `Read`）
+ * 的遗留字段，留作兼容存量数据，新链路不会命中。
+ *
+ * 教训：最初只照搬了 tool-phrase.ts 的 ['file_path','filePath']，结果 target 在真实
+ * run 里恒为空，而全部单测照样绿——字段名这类跨系统契约必须拿真实数据核对，不能靠读同仓代码推断。
  */
-export const TOOL_PATH_INPUT_KEYS = ['file_path', 'filePath'] as const
+export const TOOL_PATH_INPUT_KEYS = ['path', 'file_path', 'filePath'] as const
 
 /**
  * 从工具调用入参里取出操作目标路径。取不到就返回 undefined——宁可没有 target 字段，

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -209,6 +209,11 @@ export type AgentDurableEventV1 =
       status: 'complete' | 'failed'
       summary?: string
       error?: string
+      /**
+       * 工具操作的目标路径，已相对化为 `<项目>/…` / `<引擎>/…`（#37 取证）。
+       * 无路径的工具（MCP 查询等）缺省；存量事件没有此字段，读取端按可选处理。
+       */
+      target?: string
       createdAt: string
     }
   | {

--- a/src/components/workbench/agent/tool-phrase.test.ts
+++ b/src/components/workbench/agent/tool-phrase.test.ts
@@ -126,3 +126,38 @@ describe('getToolPhrase · NovelMemory MCP 人读动作名', () => {
     expect(mapped).toEqual(declared)
   })
 })
+
+describe('pi runtime tool names (#37 dogfood)', () => {
+  // 真机会话取证：pi 用小写内置名（Read→read、Write→write、Grep→grep），且 Glob 已改名为
+  // find。换 pi 时 tool-phrase 的 case 没跟着改，这些分支成了死代码，工具卡文案静默退化成
+  // 「调用 read」这类兜底黑话——违反「产品面不出现开发黑话」的既有约定。
+  const REAL_TOOL_CALLS: Array<[string, Record<string, unknown>]> = [
+    ['read', { path: '/novels/x/.narracat/config.yaml' }],
+    ['write', { path: '/novels/x/chapters/ch-021.md', content: 'a\nb' }],
+    ['find', { pattern: '*.md', path: '/novels/x/bible' }],
+    ['grep', { pattern: '林小满', path: '/novels/x' }],
+    ['edit', { path: '/novels/x/chapters/ch-021.md' }],
+    ['bash', { command: 'ls -la' }],
+    ['AskUserQuestion', { question: '要用哪个方向？' }],
+  ]
+
+  test('never leaks the raw english tool name to the author', () => {
+    // 退化形态不止「调用 read」：default 分支拿到 path 时会吐「read config.yaml」，
+    // 同样是把工具标识糊到作者脸上。断言按「label 不以工具名开头」来写，两种都能抓。
+    for (const [name, input] of REAL_TOOL_CALLS) {
+      const { label } = getToolPhrase(name, input)
+      expect(label.startsWith(name)).toBe(false)
+      expect(label.startsWith(`调用 ${name}`)).toBe(false)
+    }
+  })
+
+  test('reads the pi path argument for file tools', () => {
+    expect(getToolPhrase('read', { path: '/novels/x/.narracat/config.yaml' }).label).toBe(
+      '读取 config.yaml',
+    )
+    expect(getToolPhrase('write', { path: '/novels/x/chapters/ch-021.md', content: 'a\nb' }).label).toContain(
+      'ch-021.md',
+    )
+    expect(getToolPhrase('find', { pattern: '*.md' }).label).toBe('搜索文件 *.md')
+  })
+})

--- a/src/components/workbench/agent/tool-phrase.ts
+++ b/src/components/workbench/agent/tool-phrase.ts
@@ -1,5 +1,11 @@
 import { TOOL_PATH_INPUT_KEYS } from '@shared/lib/agent-path-scrub'
 
+/**
+ * 工具名有两代：当前 pi runtime 用小写内置名（read/write/edit/bash/grep/find/ls，
+ * 权威映射见 electron/main/agent/runtime/adapters/pi/pi-tool-guard.ts 的
+ * SDK_TO_PI_TOOL_NAME——注意 Glob 已改名为 find），claude-sdk 时代的大写名仍保留，
+ * 因为用户机器上的历史会话事件里存的是旧名，重看旧对话时要能正确渲染。
+ */
 export interface ToolPhrase {
   label: string
   loadingLabel: string
@@ -179,7 +185,8 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
   const input = asRecord(rawInput)
 
   switch (toolName) {
-    case 'Read': {
+    case 'Read':
+    case 'read': {
       const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       if (!path) return phrase('读取文件')
 
@@ -192,7 +199,8 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
       return phrase(`读取 ${filename(path)}`)
     }
 
-    case 'Edit': {
+    case 'Edit':
+    case 'edit': {
       const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       const name = path ? filename(path) : '文件'
       const diff = diffStats(input)
@@ -204,7 +212,8 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
       return phrase(`编辑 ${parts.join(' ')}`)
     }
 
-    case 'Write': {
+    case 'Write':
+    case 'write': {
       const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       const name = path ? filename(path) : '文件'
       const content = input.content
@@ -214,23 +223,35 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
       return phrase(`写入 ${name}`)
     }
 
-    case 'Bash': {
+    case 'Bash':
+    case 'bash': {
       const command = firstString(input, ['command'])
       return phrase(command ? `执行 ${compactInlineText(command, 80)}` : '执行命令')
     }
 
-    case 'Grep': {
+    case 'Grep':
+    case 'grep': {
       const pattern = firstString(input, ['pattern'])
       if (!pattern) return phrase('搜索内容')
       const scope = firstString(input, ['glob', 'path'])
       return phrase(scope ? `搜索内容 /${pattern}/ in ${scope}` : `搜索内容 /${pattern}/`)
     }
 
-    case 'Glob': {
+    case 'Glob':
+    case 'find': {
       const pattern = firstString(input, ['pattern'])
       if (!pattern) return phrase('搜索文件')
       const path = firstString(input, ['path'])
       return phrase(path ? `搜索文件 ${pattern} in ${path}` : `搜索文件 ${pattern}`)
+    }
+
+    case 'ls': {
+      const path = firstString(input, ['path'])
+      return phrase(path ? `查看目录 ${filename(path)}` : '查看目录')
+    }
+
+    case 'AskUserQuestion': {
+      return phrase('向你提问')
     }
 
     case 'WebFetch': {

--- a/src/components/workbench/agent/tool-phrase.ts
+++ b/src/components/workbench/agent/tool-phrase.ts
@@ -1,3 +1,5 @@
+import { TOOL_PATH_INPUT_KEYS } from '@shared/lib/agent-path-scrub'
+
 export interface ToolPhrase {
   label: string
   loadingLabel: string
@@ -178,7 +180,7 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
 
   switch (toolName) {
     case 'Read': {
-      const path = firstString(input, ['file_path', 'filePath'])
+      const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       if (!path) return phrase('读取文件')
 
       const offset = typeof input.offset === 'number' ? input.offset : undefined
@@ -191,7 +193,7 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
     }
 
     case 'Edit': {
-      const path = firstString(input, ['file_path', 'filePath'])
+      const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       const name = path ? filename(path) : '文件'
       const diff = diffStats(input)
       if (!diff) return phrase(`编辑 ${name}`)
@@ -203,7 +205,7 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
     }
 
     case 'Write': {
-      const path = firstString(input, ['file_path', 'filePath'])
+      const path = firstString(input, [...TOOL_PATH_INPUT_KEYS])
       const name = path ? filename(path) : '文件'
       const content = input.content
       if (typeof content === 'string' && content.length > 0) {


### PR DESCRIPTION
Closes #37 的第①刀（可观测性）。②③ 仍开着。

## 为什么第①刀是前置条件

`shared/lib/agent-durable-events.ts` 的脱敏把所有绝对路径整段抹成 `[本机路径]`。初衷（作者截图求助不泄露用户名与目录结构）是对的，代价是**连我们也拿不到 agent 究竟读了哪个文件**——read 失败率 25.6%（50/195）却无从定位，issue 的 ②③ 全卡在这里。

改法：脱敏**之前**先把已知根相对化成 `<项目>/…` / `<引擎>/…`，根以上不落盘、根以外照旧整段抹。

## issue 原方案只做脱敏会留 1/3 盲区

50 次失败里 33 次 ENOENT 的错误串自带路径，另外 **17 次 EISDIR 的错误串根本不含路径**（`EISDIR: illegal operation on a directory, read`，到此为止）。唯一带路径的是 `tool.started` 的 input，而 sink 的 `tools` Map 只存 `{messageId,toolName,title}`、input 被丢弃。

所以落盘事件新增可选 `target`：在 started 时取出路径、相对化后存进 live 投影，收尾事件再写出。只存路径不存文件内容（`write` 的正文不落盘）。

已知根经装配层注入（`ipc/agent.ts` → coordinator → sink），与 run-manager / pi adapter 共用同一份 `resolveNarraCatAgentCorePath({appRoot, resourcesPath})`。**根为空时功能不报错、不失败，只是落盘里照旧 `[本机路径]` 而单测全绿**——这类静默失效只能在装配处拦，故加了装配层源码断言。

## 真机 dogfood 打脸：target 一个都没有

跑完一整章，`target` 字段全部缺失，而全部单测照样绿。

**根因是字段名搞错了。** 最初照搬 `tool-phrase.ts` 的 `['file_path','filePath']`——那是 claude-sdk 时代的契约（工具名还是大写 `Read`）；换 pi 后工具名变小写、参数名变 `path`，`extractToolTargetPath` 于是永远返回 undefined。

取证走 pi 的 `sessions/*.jsonl`（工具调用的完整入参本来就落在那里）：

```
read  {path: 23, offset: 1}
write {path, content}
find  {path, pattern}
grep  {pattern, path, context}
```

四个工具一律 `path`，无一使用 `file_path`。

**最刺眼的一点**：`pi-tool-guard.ts` 第 45 行注释早就写着「路径字段受圈禁的 pi 内置工具（**字段全叫 path**）」，同文件的 `SDK_TO_PI_TOOL_NAME` 就是权威映射表。先读那个文件，这个 bug 一个都不会有。「复用同仓已有常量」看起来是对的工程直觉，实际是从一份过期契约里抄答案；而测试与实现共用同一个错误假设（用例全用 `{file_path}` 构造），所以全绿也挡不住。

修复同时把 sink 测试的 input 改成 `{path}`——原来的形态在真实系统里根本不存在，测试等于在验证虚构场景。

## 同源副产品：工具卡文案早已退化（一并修）

`tool-phrase.ts` 的 `Read`/`Write`/`Grep`/`Glob` 四个 case 在 pi 下全是死代码（注意 `Glob` 已改名为 `find`，不只是大小写）。作者看到的不是「读取 config.yaml」，而是 default 分支兜底吐的 **`read config.yaml`**——英文工具标识直接糊在脸上，违反产品面不出现开发黑话的既有约定。`AskUserQuestion` 同样没有分支。

旧的大写 case 一并保留（fall-through）：用户机器上的历史会话事件里存的是 SDK 名，重看旧对话时仍要正确渲染。另补 `ls` 与 `AskUserQuestion`。

守卫测试按「label 不以工具名开头」写，而不是只挡「调用 `<name>`」——退化有两种形态，第一版只挡后者，**漏掉了本次这种，红一次才发现**。

## 真机验证通过

```
find  complete  target='<项目>'
read  complete  target='<项目>/manuscript/vol-01/ch-001.md'
read  complete  target='<项目>/outline/vol-01/ch-001.md'
find  complete  target='<项目>/.narracat/manuscript-drafts'
bash  complete  target=None        ← 正确，bash 用 command 不用 path
```

相对化同批验证：`ENOENT ... access '<项目>/.narracat/staging/ch-019.md'`

## 测试覆盖的边界

兄弟目录前缀误伤（`/novel-x` 不得吃掉 `/novel-x-backup`——最初实现真踩了，落盘会变成 `<项目>-backup`，取证指向错的地方）、Windows 两侧分隔符不一致（配置里 `/`、Node 错误串里 `\`，按字面匹配整条漏掉 = Windows 上取证等于没做）、项目外路径仍被抹、存量事件缺 `target` 字段仍可读。

## 验证

`typecheck` / `check:design` / `check:architecture` / `build` 全绿；全量测试 **3068 pass / 0 fail**。

## 给 ③ 的第一条线索（不在本 PR 范围）

本次跑章 read 失败 5 次 = 3 次 EISDIR（错误串不带路径）+ 2 次 ENOENT 指向 `<项目>/.narracat/staging/ch-0XX.md`，**agent 在读还没生成的 staging 文件**。

一个诚实的限定：本批 read 失败率 10.4%（43/5）与历史 25.6%（145/50）**不可直接对比**——本 PR 没有触碰 read 行为，差异不能归因于它，样本也不足以定性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A
