### PR TITLE
fix(workbench): 工具报错如实标「失败」，不再说成「已跳过」(#37 刀②)

### DIFF
--- a/electron/main/agent/runtime/adapters/pi/pi-event-mapper.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-event-mapper.ts
@@ -33,10 +33,10 @@ export const PI_SESSION_MESSAGE_TYPE = 'narracat_pi_session'
  * 键名带 narracat 前缀避免与任何第三方工具的 details 撞名（本映射对全部工具生效）。
  *
  * UI 上的实际口径（别过度承诺）：tool.failed 复用工具级失败的既有通用呈现——执行过程流里逐项徽章
- * 是「已跳过」+ 失败原因（展开可见），而不是「完成」；折叠态汇总行仍读作「执行过程已完成 · N 项
- * （自动调整 M 次）」。汇总行那句是「工具级错误属自愈型瞬时事件」的既有产品决策
- * （见 AgentProcessStream.tsx），子会话异常终止（烧掉数分钟与整章 token 的实质失败）是否该在
- * 汇总行破例，留给产品单独决定，本刀不动（#29）。渲染端断言见
+ * 是「失败」+ 失败原因（展开可见），而不是「完成」；折叠态汇总行读作「执行过程已完成 · N 项
+ * （M 次失败）」，如实计次但不升级成 run 级红色告警（#37 刀②改的就是这句措辞，原文「自动调整
+ * M 次」把报错说成了 agent 的主动优化，见 AgentProcessStream.tsx）。仍未做的是把失败原因提到
+ * 折叠态——那要动汇总行信息密度，不在本刀范围。渲染端断言见
  * src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx。
  */
 export type PiSubagentAbnormalStop = 'length' | 'error'

--- a/electron/main/agent/runtime/adapters/pi/pi-subagent.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-subagent.ts
@@ -237,7 +237,7 @@ export function createTaskTool({
         }
         // details 是给 UI 的侧信道（见 PiSubagentAbnormalStopDetails，那里记着 UI 上的确切口径）：
         // 模型收到的是带 ⚠️ 前缀的成功结果（保住已产出部分与质量门反馈），任务卡则据此收口成
-        // tool.failed——逐项呈现从「完成」变「已跳过」+ 失败原因，不再一声不吭地放行。
+        // tool.failed——逐项呈现从「完成」变「失败」+ 失败原因，不再一声不吭地放行。
         const details: PiSubagentAbnormalStopDetails | undefined = abnormalStop
           ? { narracatSubagentAbnormalStop: abnormalStop }
           : undefined

--- a/src/components/workbench/agent/AgentProcessStream.test.tsx
+++ b/src/components/workbench/agent/AgentProcessStream.test.tsx
@@ -90,7 +90,7 @@ describe('AgentProcessStream', () => {
     expect(html).not.toContain('outputTokens')
   })
 
-  test('renders tool errors as neutral skipped items instead of a red failed rollup', () => {
+  test('renders tool errors as honest failures without escalating to a red run-level rollup', () => {
     const parts: AgentProcessPart[] = [
       {
         id: 'reasoning-1',
@@ -122,13 +122,15 @@ describe('AgentProcessStream', () => {
 
     const html = renderToStaticMarkup(<AgentProcessStream parts={parts} defaultOpen />)
 
-    // 工具级错误是自愈型瞬时事件：汇总行不标红失败，逐项徽章用中性「已跳过」
-    expect(html).toContain('执行过程已完成 · 2 项（自动调整 1 次）')
+    // 工具报错就说失败：状态机里没有「主动跳过」这一档，把 failed 说成「已跳过」是把
+    // 失败美化成主动省略（#37 刀②）。但仍不升级成 run 级红色告警——红色留给终态失败。
+    expect(html).toContain('执行过程已完成 · 2 项（1 次失败）')
     expect(html).not.toContain('执行过程失败')
-    expect(html).not.toContain('失败')
-    expect(html).toContain('已跳过')
+    expect(html).not.toContain('已跳过')
+    expect(html).not.toContain('自动调整')
+    expect(html).toContain('>失败<')
     expect(html).not.toContain('text-destructive')
-    // 错误详情仍可查看，只是不再用警报色
+    // 错误详情仍可查看，只是不用警报色
     expect(html).toContain('已完成思考')
     expect(html).toContain('读取 config.yaml')
     expect(html).toContain('Permission denied: config.yaml')

--- a/src/components/workbench/agent/AgentProcessStream.tsx
+++ b/src/components/workbench/agent/AgentProcessStream.tsx
@@ -53,13 +53,14 @@ function summarizeProcessStream(parts: AgentProcessPart[]): ProcessSummary {
     }
   }
 
-  // 工具级失败是 LLM 自愈型瞬时噪声（换工具/重试后继续），不把整组执行过程标红——
-  // 红色保留给 run 级终态失败（由独立的 error part 渲染）。这里只如实标注跳过次数。
-  const skippedCount = parts.filter((part) => part.status === 'failed').length
+  // 工具级失败多数能自愈（换工具/重试后继续），所以不把整组执行过程标红——红色保留给 run 级
+  // 终态失败（由独立的 error part 渲染）。但计次要如实说「失败」：原措辞「自动调整 N 次」把
+  // 报错读成了 agent 的主动优化，作者据此以为一切正常，实际那 N 次可能正是成稿缺料的原因（#37）。
+  const failedCount = parts.filter((part) => part.status === 'failed').length
   return {
     title:
-      skippedCount > 0
-        ? `执行过程已完成 · ${completedCount} 项（自动调整 ${skippedCount} 次）`
+      failedCount > 0
+        ? `执行过程已完成 · ${completedCount} 项（${failedCount} 次失败）`
         : `执行过程已完成 · ${completedCount} 项`,
     status: 'complete',
   }
@@ -69,8 +70,8 @@ function ProcessDetail({ parts }: { parts: AgentProcessPart[] }) {
   return (
     <ol className="space-y-1">
       {parts.map((part) => {
-        const skipped = part.status === 'failed'
-        const detail = getSkippedDetail(part)
+        const failed = part.status === 'failed'
+        const detail = getFailureDetail(part)
 
         return (
           <li key={part.id} className="min-w-0">
@@ -78,7 +79,7 @@ function ProcessDetail({ parts }: { parts: AgentProcessPart[] }) {
               <span
                 className={cn(
                   'mt-0.5 shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] leading-none',
-                  skipped ? 'bg-warning/10 text-warning' : 'bg-active text-hint-foreground'
+                  failed ? 'bg-warning/10 text-warning' : 'bg-active text-hint-foreground'
                 )}
               >
                 {getStatusLabel(part.status)}
@@ -115,7 +116,7 @@ function getRunningSummary(part: AgentProcessPart): string {
   return `正在${part.title}...`
 }
 
-function getSkippedDetail(part: AgentProcessPart): string | undefined {
+function getFailureDetail(part: AgentProcessPart): string | undefined {
   if (part.type === 'tool-call' && part.status === 'failed') return compactProcessText(part.error ?? '')
   return undefined
 }
@@ -131,8 +132,10 @@ function getProcessTitle(part: AgentProcessPart): string {
 
 function getStatusLabel(status: AgentPartStatus): string {
   if (status === 'running') return '进行中'
-  // 工具级错误在执行过程中是可自愈的瞬时事件，标「已跳过」而非「失败」。
-  if (status === 'failed') return '已跳过'
+  // 报错就说失败。AgentPartStatus 里没有「主动跳过」这一档——agent 判断无需执行的工具压根不会
+  // 产生事件，所以 failed 唯一的含义就是失败，标成「已跳过」是把失败说成主动省略（#37 刀②）。
+  // 中性色（warning，非 destructive）已足够表达「可自愈、不必惊慌」，不需要靠措辞去柔化。
+  if (status === 'failed') return '失败'
   return '完成'
 }
 

--- a/src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx
+++ b/src/components/workbench/agent/AgentSubagentAbnormalStop.test.tsx
@@ -65,8 +65,9 @@ describe('子会话异常终止的任务卡渲染（#29 刀 2）', () => {
       reduceTaskDispatch({ content: [{ type: 'text', text: RESULT_TEXT }], details: ABNORMAL_STOP_DETAILS }),
     )
 
-    // 逐项徽章：已跳过（工具级失败的既有中性呈现），绝不能是「完成」
-    expect(html).toContain('>已跳过<')
+    // 逐项徽章：失败（中性呈现，不用警报色），绝不能是「完成」，也不能说成「已跳过」
+    expect(html).toContain('>失败<')
+    expect(html).not.toContain('>已跳过<')
     expect(html).not.toContain('>完成<')
     expect(html).toContain('章节写手Agent 写第 3 章')
     // 失败原因对用户可见，且能看出是 length（截断）而非 error
@@ -79,21 +80,21 @@ describe('子会话异常终止的任务卡渲染（#29 刀 2）', () => {
     )
 
     expect(html).toContain('>完成<')
-    expect(html).not.toContain('>已跳过<')
+    expect(html).not.toContain('>失败<')
     expect(html).not.toContain(ABNORMAL_STOP_REASON)
   })
 
-  test('现状留档：折叠态汇总行仍读作「已完成」，失败原因要展开才看得到', () => {
-    // 这条不是目标态，是如实记录刀 2 到此为止的边界：执行过程流的汇总行沿用「工具级错误是自愈型
-    // 瞬时事件」的既有产品口径（AgentProcessStream:56），把异常终止一并算进「自动调整 N 次」。
-    // 子会话异常终止（烧掉几分钟与整章 token 的实质失败）是否该在汇总行破例，留给产品决定（#29）。
+  test('折叠态汇总行如实计次「1 次失败」，具体原因仍要展开才看得到', () => {
+    // 汇总行沿用「工具级失败不升级成 run 级红色告警」的既有口径，但计次措辞已由「自动调整 N 次」
+    // 改为「N 次失败」（#37 刀②）——异常终止算进这一格是对的，它本就是失败，不是自动调整。
+    // 仍未做的是把失败原因提到折叠态：那要动汇总行信息密度，超出本刀范围。
     const message = reduceTaskDispatch({
       content: [{ type: 'text', text: RESULT_TEXT }],
       details: ABNORMAL_STOP_DETAILS,
     })
     const html = renderToStaticMarkup(<AgentMessageItem message={message} />)
 
-    expect(html).toContain('执行过程已完成 · 0 项（自动调整 1 次）')
+    expect(html).toContain('执行过程已完成 · 0 项（1 次失败）')
     expect(html).not.toContain(ABNORMAL_STOP_REASON)
   })
 })

--- a/src/components/workbench/agent/AgentToolCallRow.tsx
+++ b/src/components/workbench/agent/AgentToolCallRow.tsx
@@ -23,7 +23,7 @@ export function AgentToolCallRow({ part }: { part: ToolCallPart }) {
 export function getToolDisplayTitle(part: ToolCallPart): string {
   const phrase = getToolPhrase(part.toolName, part.input)
   if (part.status === 'running') return phrase.loadingLabel
-  if (part.status === 'failed') return `${phrase.label} · 已跳过`
+  if (part.status === 'failed') return `${phrase.label} · 失败`
   return part.summary ?? phrase.label
 }
 


### PR DESCRIPTION
作者反馈的第一句是「经常会有跳过的问题，不清楚原因」——措辞把失败说成了主动省略，语义正好反了。

## 为什么「已跳过」不是一个可选措辞

`AgentPartStatus` 只有 `running | complete | failed` 三档，**系统里不存在「主动跳过」**：agent 判断无需执行的工具压根不会产生事件。所以 `failed` 唯一的含义就是失败。

| 位置 | 之前 | 现在 |
|---|---|---|
| 逐项徽章 | `已跳过` | `失败` |
| 折叠汇总行 | `执行过程已完成 · 2 项（自动调整 1 次）` | `执行过程已完成 · 2 项（1 次失败）` |
| 工具行标题 | `读取 config.yaml · 已跳过` | `读取 config.yaml · 失败` |

「自动调整 N 次」这个措辞把报错读成了 agent 的主动优化，作者据此以为一切正常，而那 N 次可能正是成稿缺料的原因。

## 保留的既有决策

**不升级成 run 级红色告警**：徽章仍是 warning 色（非 destructive），整组执行过程仍标「已完成」——红色留给终态失败。issue 里要的就是这个分寸：不吓人，但不能让作者以为跳过 = 正常。

## 顺带了结一条留档测试

`AgentSubagentAbnormalStop.test.tsx` 里有条自称「这不是目标态」的测试：子会话异常终止（烧掉几分钟与整章 token 的实质失败）此前被算进「自动调整」，留给产品决定是否破例。现在如实计入失败，那条留档的疑虑一并消掉。

## 验证

`bun test src/components/workbench/agent/` 119 pass；typecheck / check:design / check:architecture 全过；全量 bun test 无新增失败。

Refs #37（刀②；刀③ 的根因另见 #43 相关分支）
