### PR TITLE
fix(agent): find 工具改用 tinyglobby，不再依赖 fd 二进制

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "tailwind-merge": "^3.5.0",
         "three": "^0.185.1",
         "three-spritetext": "^1.10.0",
+        "tinyglobby": "^0.2.17",
         "typebox": "1.3.8",
         "yaml": "^2.8.4",
         "zustand": "^5.0.12",
@@ -1678,7 +1679,7 @@
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
@@ -1922,6 +1923,8 @@
 
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "node-gyp/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "node-gyp/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1963,6 +1966,8 @@
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2103,6 +2108,8 @@
     "app-builder-lib/@electron/rebuild/node-gyp/nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "app-builder-lib/@electron/rebuild/node-gyp/proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
+
+    "app-builder-lib/@electron/rebuild/node-gyp/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "app-builder-lib/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 

--- a/electron/main/agent/runtime/adapters/pi/index.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/index.test.ts
@@ -140,7 +140,9 @@ describe('切片③ 权限门禁接线', () => {
     const adapter = createPiAdapter()
     const options = (await adapter.createRunOptions(makeRunConfig())) as PiRunOptions
     expect(options.tools).toEqual(['read', 'grep', 'find', 'bash'])
-    expect(options.customTools).toHaveLength(0)
+    // 只有 find（不依赖 fd 的替代实现，工具面含 find 时自动注入）——此处要钉的是
+    // 「不注册其它自定义工具」，故精确列举而非只判空。
+    expect(options.customTools.map((tool) => tool.name)).toEqual(['find'])
   })
 
   test('allowedTools 含 AskUserQuestion 时注册自定义工具且 tools 列表含其名', async () => {
@@ -207,7 +209,9 @@ describe('切片③ 权限门禁接线', () => {
     } as never)) as PiRunOptions
     expect(options.tools).toEqual(['read', 'write', 'find'])
     expect(options.cwd).toBe('/tmp/sandbox-ws')
-    expect(options.customTools).toHaveLength(0)
+    // 只有 find（不依赖 fd 的替代实现，工具面含 find 时自动注入）——此处要钉的是
+    // 「不注册其它自定义工具」，故精确列举而非只判空。
+    expect(options.customTools.map((tool) => tool.name)).toEqual(['find'])
     expect(options.extensions).toHaveLength(2)
   })
 
@@ -326,7 +330,9 @@ describe('切片⑤ 子 agent 派发与任务卡接线', () => {
       ...makeRunConfig({ loadNarraCatRuntime: true }),
       sandbox: { tools: ['Read', 'Write', 'Glob'], workspaceDir: '/tmp/sandbox-ws' },
     } as never)) as PiRunOptions
-    expect(options.customTools).toHaveLength(0)
+    // 只有 find（不依赖 fd 的替代实现，工具面含 find 时自动注入）——此处要钉的是
+    // 「不注册其它自定义工具」，故精确列举而非只判空。
+    expect(options.customTools.map((tool) => tool.name)).toEqual(['find'])
     expect(options.tools).toEqual(['read', 'write', 'find'])
   })
 
@@ -387,7 +393,9 @@ describe('切片⑥ NovelMemory 工具接线', () => {
       ...makeRunConfig({ loadNarraCatRuntime: true }),
       sandbox: { tools: ['Read', 'Write', 'Glob'], workspaceDir: '/tmp/sandbox-ws' },
     } as never)) as PiRunOptions
-    expect(options.customTools).toHaveLength(0)
+    // 只有 find（不依赖 fd 的替代实现，工具面含 find 时自动注入）——此处要钉的是
+    // 「不注册其它自定义工具」，故精确列举而非只判空。
+    expect(options.customTools.map((tool) => tool.name)).toEqual(['find'])
   })
 
   test('子会话按自己声明的面过滤：只含 novel_query，不含父面也开了的 novel_commit_chapter', async () => {
@@ -441,5 +449,53 @@ describe('切片⑥ NovelMemory 工具接线', () => {
     // model 别名映射（模型池化）：frontmatter model:'haiku' → 同 provider 已验证轻量槽；父 run 用主力槽
     expect(childOptions.model.id).toBe('model-haiku')
     expect(options.model.id).toBe('model-sonnet')
+  })
+})
+
+describe('find 工具可移植化（不依赖 fd 二进制）', () => {
+  // pi 内置 find 走 fd：查系统 PATH，找不到就下载。macOS 从 Finder 启动的 App 继承 launchd
+  // 窄 PATH（不含 Homebrew），作者机器上也不会装 fd，GitHub 下载对国内用户基本不可达——
+  // 真机打包版实测 find 一半调用直接报「fd is not available」。同名 customTool 覆盖内置。
+  test('工具面含 find 时注入同名替代实现', async () => {
+    const adapter = createPiAdapter()
+    const options = (await adapter.createRunOptions(makeRunConfig())) as PiRunOptions
+    expect(options.tools).toContain('find')
+    expect(options.customTools.map((tool) => tool.name)).toContain('find')
+  })
+
+  test('工具面不含 find 时不注入——不给会话凭空多一个工具面', async () => {
+    const adapter = createPiAdapter()
+    const options = (await adapter.createRunOptions(makeRunConfig({ allowedTools: ['Read', 'Write'] }))) as PiRunOptions
+    expect(options.tools).not.toContain('find')
+    expect(options.customTools.map((tool) => tool.name)).not.toContain('find')
+  })
+
+  test('子会话同样拿到替代实现——写手/审校跑在子会话里，漏了这条它们的 find 照样是坏的', async () => {
+    capturedChildSessionCalls = []
+    const adapter = createPiAdapter({ memoryBridge: fakeMemoryBridge })
+    const options = (await adapter.createRunOptions(
+      makeRunConfig({
+        loadNarraCatRuntime: true,
+        allowedTools: ['Read', 'Glob', 'Agent'],
+        agents: {
+          'chapter-writer': { description: '写手', prompt: '写手系统词', tools: ['Read', 'Glob'] },
+        },
+      }),
+    )) as PiRunOptions
+    const task = options.customTools.find((tool) => tool.name === 'Task')!
+    await task.execute('tc-1', { subagent_type: 'chapter-writer', prompt: '写第一章' } as never, undefined, undefined, {} as never)
+
+    const childOptions = capturedChildSessionCalls[0]!.options as PiRunOptions
+    expect(childOptions.tools).toContain('find')
+    expect(childOptions.customTools.map((tool) => tool.name)).toContain('find')
+  })
+
+  test('沙盒会话（学习/向导）同样注入——它们一样跑在打包版里', async () => {
+    const adapter = createPiAdapter()
+    const options = (await adapter.createSandboxedRunOptions({
+      ...makeRunConfig(),
+      sandbox: { tools: ['Read', 'Glob'], workspaceDir: '/tmp/sandbox-ws' },
+    } as never)) as PiRunOptions
+    expect(options.customTools.map((tool) => tool.name)).toContain('find')
   })
 })

--- a/electron/main/agent/runtime/adapters/pi/index.ts
+++ b/electron/main/agent/runtime/adapters/pi/index.ts
@@ -18,6 +18,7 @@
  */
 import { join } from 'node:path'
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
+import { createPortableFindTool } from './pi-fs-tools.ts'
 import { resolveNarraCatEngine } from '../../../../engine/engine.ts'
 import { resolveEngineAgentDefinitions } from '../../../../engine/engine-agent-registry.ts'
 import type { EngineAgentDefinition } from '../../../../engine/engine-agent-registry.ts'
@@ -98,6 +99,10 @@ async function buildPiRunOptions(
   const customTools: ToolDefinition[] = includeAskUserQuestion
     ? [createAskUserQuestionTool({ canUseTool: canUseTool!, signal: args.abortController.signal })]
     : []
+  // pi 内置 find 走 fd 二进制（查 PATH → 查不到就去 GitHub 下载），两条路在打包版上都不通：
+  // Finder 启动的 App 继承 launchd 窄 PATH，作者机器也不会装 fd。同名 customTool 覆盖内置那个。
+  // 只在工具面本来就有 find 时注入——不给没这个面的会话凭空多一个工具。
+  if (face.tools.includes('find')) customTools.push(createPortableFindTool(cwd))
   // 引擎钩子（字数提示/任务书系统词硬门）只在 loadNarraCatRuntime 时挂：学习/向导等沙盒会话
   // 本就不跑引擎契约，与 SDK 侧同条件不装载 plugin 对齐（brief 见 Task 5 任务书）。
   const agentDir = join(args.userDataPath ?? args.appRoot, 'pi-agent')
@@ -143,6 +148,10 @@ async function buildPiRunOptions(
     const childMemoryTools = memoryContext
       ? createMemoryTools({ definitions: memoryContext.definitions, allowedNames: childFace.memoryTools, channel: memoryContext.channel })
       : []
+    // 与父会话同一条纪律：写手/审校都跑在子会话里，漏了这条它们的 find 照样是坏的。
+    const childCustomTools = childFace.tools.includes('find')
+      ? [...childMemoryTools, createPortableFindTool(cwd)]
+      : childMemoryTools
     // model 别名映射（生产接线门前项②）：frontmatter 三别名走模型池槽位，其余继承 run 模型。
     const childModel = createPiModel(args.config, resolvePiModelAlias(args.config, definition.model))
     return {
@@ -151,14 +160,14 @@ async function buildPiRunOptions(
       apiKey: args.apiKey,
       cwd,
       agentDir,
-      tools: [...childFace.tools, ...childMemoryTools.map((tool) => tool.name)],
+      tools: [...new Set([...childFace.tools, ...childCustomTools.map((tool) => tool.name)])],
       maxTurns: SUBAGENT_MAX_TURNS,
       systemPrompt: definition.prompt,
       abortController: childAbort,
       // 各子会话新起一个实例：救回逻辑的 eager 快照是扩展闭包内的 run 级状态，共用实例会让
       // 并发子会话互相串参数。
       extensions: [createPiEagerToolArgsRestorer(), childGuard, createPiEngineHooksExtension({ cwd })],
-      customTools: childMemoryTools,
+      customTools: childCustomTools,
     }
   }
 
@@ -197,7 +206,9 @@ async function buildPiRunOptions(
     agentDir,
     // pi 的 isAllowedTool 会把不在 tools 白名单里的 custom tool 过滤掉（切片③已踩），故自定义工具
     // 名必须同步登记进白名单。
-    tools: [...face.tools, ...customTools.map((tool) => tool.name)],
+    // 去重：portable find 与内置同名，两边都列会让工具面出现重复项（pi 侧无害，但工具面是
+    // 对外可观测的契约，保持它等于「这个会话真正能用的工具集合」）。
+    tools: [...new Set([...face.tools, ...customTools.map((tool) => tool.name)])],
     maxTurns: args.maxTurns ?? DEFAULT_PI_MAX_TURNS,
     systemPrompt: typeof args.systemPrompt === 'string' ? args.systemPrompt : undefined,
     systemPromptAppendix: agentsGuide ?? undefined,

--- a/electron/main/agent/runtime/adapters/pi/pi-fs-tools.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-fs-tools.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createPortableFindTool } from './pi-fs-tools.ts'
+
+/**
+ * pi 内置 find 依赖 fd 二进制：先查系统 PATH，找不到就去 GitHub Releases 下载。
+ * 两条路在生产上都不通——macOS 从 Finder 启动的 App 继承 launchd 的窄 PATH（不含
+ * /opt/homebrew/bin），而目标用户（网文作者）机器上本来就没有 fd，GitHub 下载对
+ * 国内用户更是基本不可达。真机打包版实测 find 一半调用直接报
+ * 「fd is not available and could not be downloaded」。
+ *
+ * 本模块用 Node 内置 fs.glob 提供 FindOperations，复用 pi 自己的
+ * createFindToolDefinition，只换底层实现——schema / 描述 / 输出格式全部不动，零漂移。
+ */
+
+let root: string
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'narracat-find-'))
+  mkdirSync(join(root, 'manuscript', 'vol-01'), { recursive: true })
+  mkdirSync(join(root, 'bible', 'characters'), { recursive: true })
+  mkdirSync(join(root, '.narracat', 'staging'), { recursive: true })
+  mkdirSync(join(root, 'node_modules', 'junk'), { recursive: true })
+  writeFileSync(join(root, 'manuscript', 'vol-01', 'ch-001.md'), '第一章')
+  writeFileSync(join(root, 'manuscript', 'vol-01', 'ch-002.md'), '第二章')
+  writeFileSync(join(root, 'bible', 'characters', 'su-jian.md'), '苏见')
+  writeFileSync(join(root, '.narracat', 'staging', 'ch-021.md'), '任务书')
+  writeFileSync(join(root, 'node_modules', 'junk', 'noise.md'), '不该出现')
+})
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+async function runFind(pattern: string, path?: string): Promise<string> {
+  const tool = createPortableFindTool(root)
+  const result = await tool.execute(
+    'call-1',
+    { pattern, ...(path === undefined ? {} : { path }) } as never,
+    undefined,
+    undefined,
+    undefined,
+  )
+  const first = result.content[0]
+  return first && first.type === 'text' ? first.text : ''
+}
+
+describe('createPortableFindTool（不依赖 fd 的 find）', () => {
+  test('工具名与内置 find 一致——同名才能覆盖掉依赖 fd 的那个', () => {
+    expect(createPortableFindTool(root).name).toBe('find')
+  })
+
+  test('递归匹配章节文件', async () => {
+    const text = await runFind('**/ch-*.md')
+    expect(text).toContain('manuscript/vol-01/ch-001.md')
+    expect(text).toContain('manuscript/vol-01/ch-002.md')
+  })
+
+  test('返回相对搜索根的路径，不泄露本机绝对路径', async () => {
+    const text = await runFind('**/ch-*.md')
+    expect(text).not.toContain(root)
+    expect(text).not.toContain(tmpdir())
+    for (const line of text.split('\n').filter(Boolean)) {
+      expect(line.startsWith('/')).toBe(false)
+    }
+  })
+
+  test('能搜到隐藏目录里的任务书（.narracat 是引擎的工作区，不能被当成隐藏文件跳过）', async () => {
+    const text = await runFind('**/staging/*.md')
+    expect(text).toContain('.narracat/staging/ch-021.md')
+  })
+
+  test('限定子目录搜索时，路径相对该子目录', async () => {
+    const text = await runFind('*.md', 'bible/characters')
+    expect(text).toContain('su-jian.md')
+    expect(text).not.toContain('bible/characters/su-jian.md')
+  })
+
+  test('排除 node_modules', async () => {
+    const text = await runFind('**/*.md')
+    expect(text).not.toContain('noise.md')
+  })
+
+  test('无匹配时给出明确结果，不是报错', async () => {
+    const text = await runFind('**/*.does-not-exist')
+    expect(text).toContain('No files found')
+  })
+
+  test('搜索路径不存在时报错，而不是静默返回空', async () => {
+    await expect(runFind('*.md', 'no/such/dir')).rejects.toThrow()
+  })
+})

--- a/electron/main/agent/runtime/adapters/pi/pi-fs-tools.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-fs-tools.ts
@@ -1,0 +1,56 @@
+/**
+ * 不依赖外部二进制的文件检索工具（替换 pi 内置 find）。
+ *
+ * pi 的 find 走 fd：先查系统 PATH，找不到就去 GitHub Releases 下载。两条路在生产上都不通——
+ * macOS 从 Finder 启动的 App 继承 launchd 的窄 PATH（`/usr/bin:/bin:/usr/sbin:/sbin`，不含
+ * Homebrew），而目标用户（网文作者）机器上本来就不会装 fd 这类开发者工具，GitHub 下载对国内
+ * 用户更是基本不可达。真机打包版实测：find 有一半调用直接报「fd is not available and could
+ * not be downloaded」。dev 从终端启动继承了完整 PATH，所以这个缺陷一直没暴露。
+ *
+ * 做法是复用 pi 自己的 `createFindToolDefinition`，只把底层 FindOperations 换成 tinyglobby——
+ * 工具名、schema、描述、输出格式与截断语义全部原样继承，零漂移。同名工具经 customTools 注入
+ * 即可覆盖内置那个。
+ *
+ * 为什么不用 Node 内置 `fs.glob`：①它没有 `dot` 选项，`**` 不跨隐藏目录，而 `.narracat/staging/`
+ * 正是任务书所在，搜不到任务书 agent 就会去猜文件名；②实测 Electron 的 Node 24 与 bun 对同一
+ * pattern 结果不同（`**\/.narracat/**\/*.md` 在 Node 下命中、bun 下不命中），测试跑在 bun、
+ * 生产跑在 Node，那样的测试根本代表不了生产。tinyglobby 在两个运行时结果逐字一致。
+ *
+ * 一处已知差异：fd 会读 `.gitignore`，本实现不读。pi 在 customOps 分支硬编码了
+ * `ignore: ['**\/node_modules/**', '**\/.git/**']`，对小说项目足够——小说目录里没有需要靠
+ * .gitignore 屏蔽的产物。
+ *
+ * grep 没有对应做法：它的 GrepOperations 只能替换 isDirectory/readFile，搜索本身无条件调用
+ * ripgrep，绕不开。
+ */
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import { glob } from 'tinyglobby'
+import { createFindToolDefinition } from '@mariozechner/pi-coding-agent'
+import type { FindOperations, ToolDefinition } from '@mariozechner/pi-coding-agent'
+
+async function pathExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.access(absolutePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const globOperations: FindOperations = {
+  exists: pathExists,
+  async glob(pattern, cwd, options) {
+    // dot:true 是关键——`.narracat/` 是引擎工作区（任务书、暂存区都在里面），按「隐藏文件」
+    // 跳过就等于让 agent 看不见自己的任务书。
+    const matches = await glob(pattern, { cwd, dot: true, ignore: options.ignore })
+    // 必须回绝对路径：pi 的 relativize 只认「以搜索根开头」的绝对路径，拿到相对路径会
+    // 走 path.relative(searchPath, 相对路径)，那是按进程 cwd 解析的，算出来是错的。
+    return matches.slice(0, options.limit).map((entry) => join(cwd, entry))
+  },
+}
+
+/** 与内置 find 同名同形，只是不需要 fd。 */
+export function createPortableFindTool(cwd: string): ToolDefinition {
+  return createFindToolDefinition(cwd, { operations: globOperations }) as ToolDefinition
+}

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "tailwind-merge": "^3.5.0",
     "three": "^0.185.1",
     "three-spritetext": "^1.10.0",
+    "tinyglobby": "^0.2.17",
     "typebox": "1.3.8",
     "yaml": "^2.8.4",
     "zustand": "^5.0.12"


### PR DESCRIPTION
真机打包版实测：`find` 有一半调用直接报「fd is not available and could not be downloaded」。

## 为什么生产上必然坏

pi 内置 find 走 `fd` 二进制：先查系统 PATH，找不到就去 GitHub Releases 下载。两条路在生产上都不通——

- **macOS 从 Finder 启动的 App 继承 launchd 窄 PATH**（`/usr/bin:/bin:/usr/sbin:/sbin`），看不到 `/opt/homebrew/bin`，所以开发者机器上装了 fd 也没用
- 目标用户（网文作者）机器上本就不会装 fd 这类开发者工具
- GitHub Releases 下载对国内用户基本不可达

dev 从终端启动继承了完整 PATH，这个缺陷因此一直没暴露——典型的「dev 绿、生产红」。

影响不止于 find 本身：App 注入的 `CHAPTER_ARTIFACT_PATH_GUARD` 明确要求 agent「必须先用 Glob 检查…使用实际存在的路径」，Glob 就是 pi 的 find。它坏了，agent 探路失败后只能直接猜路径 read，于是 ENOENT / EISDIR。

## 做法

复用 pi 自己的 `createFindToolDefinition`，只把底层 `FindOperations` 换成 tinyglobby（56K）——工具名、schema、描述、输出格式与截断语义全部原样继承，**零漂移**。同名 customTool 覆盖内置实现（pi 的 `_refreshToolRegistry` 里 customTools 后于内置写入 registry）。

**两条装配路径都注入**：主/沙盒会话共用的 `buildPiRunOptions`，以及子会话的 `buildChildRunOptions`。写手与审校都跑在子会话里，漏了后者它们的 find 照样是坏的。只在工具面本来就有 find 时注入，不给没这个面的会话凭空多一个工具。

## 为什么不用 Node 内置 fs.glob

试过，两个问题都致命：

1. **没有 `dot` 选项**，`**` 不跨隐藏目录，而 `.narracat/staging/` 正是任务书所在——搜不到任务书 agent 就会去猜文件名
2. **实测 Electron 的 Node 24 与 bun 对同一 pattern 结果不同**（`**/.narracat/**/*.md` 在 Node 下命中、bun 下不命中）。测试跑在 bun、生产跑在 Node，那种测试根本代表不了生产

tinyglobby 在两个运行时结果逐字一致。

## 未解决：grep 仍依赖 ripgrep

`GrepOperations` 只能替换 `isDirectory`/`readFile`，搜索本身无条件 `ensureTool("rg")`，绕不开。需要单独一刀——倾向自研同名工具而非打包二进制（跨平台一致、无签名问题、Windows 线一次带上）。

## 验证

新增 8 条 find 行为断言（含隐藏目录、子目录相对化、路径不存在时报错）+ 4 条装配断言（主/子/沙盒会话都注入、工具面无 find 时不注入）；typecheck / check:architecture 通过；全量 bun test 无新增失败。

四处既有 `expect(options.customTools).toHaveLength(0)` 改为精确列举 `toEqual(['find'])`——那些断言的原意是「不注册其它自定义工具」，精确列举既保留原意，将来意外多出工具也照样能发现。
