### PR TITLE
fix(agent): 输出上限 32000 → 64000，止住冷改被截断后降级重试

### DIFF
--- a/electron/main/agent/runtime/adapters/pi/pi-model.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-model.test.ts
@@ -44,7 +44,11 @@ describe('createPiModel', () => {
     // 断言**实发值**而不是 Model 上的存值：上游 pi-ai 会先除以 3（issue #35），
     // 原来这里只盯存值 32000，于是「意图 32000、实发 10666」悄悄跑了很久都没人发现。
     expect(effectivePiMaxTokens(model.maxTokens)).toBe(TARGET_MAX_OUTPUT_TOKENS)
-    expect(TARGET_MAX_OUTPUT_TOKENS).toBe(32_000)
+    // 64000 不是拍脑袋：真机第 22 章（3912 字）走一次冷改，thinking 开着时单次 output 实测
+    // 21561 tokens（其中 87% 是 thinking），32000 只剩三分之一余量——生产上冷改还要带任务书、
+    // 正文路径与四遍指令，比裸测重得多，撞顶是必然。provider 侧 deepseek-v4-flash 上限 384K，
+    // 不是瓶颈；瓶颈一直是我们自己配的这个数。
+    expect(TARGET_MAX_OUTPUT_TOKENS).toBe(64_000)
   })
 
   test('实发 max_tokens 补偿上游除以 3（issue #35 的唯一护栏）', () => {

--- a/electron/main/agent/runtime/adapters/pi/pi-model.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-model.ts
@@ -13,10 +13,19 @@ import { resolveLightModel, resolvePrimaryModel } from '@shared/lib/model-slots'
 /** 窗口值与 SDK 侧 CLAUDE_CODE_MAX_CONTEXT_TOKENS 对齐。 */
 const ONE_M_CONTEXT_WINDOW = 1_000_000
 const DEFAULT_CONTEXT_WINDOW = 200_000
-/** 对齐 SDK 路径的实际输出上限（sdk-runner 未设输出 env，走 Claude CLI 默认 32000）——A/B 单变量
- * 纪律：8192 会截断章节写作长输出，是 SDK 路径没有的新变量；超限仍触发 stopReason='length'，
- * 由事件映射 fail-loud（生产接线门前项①）。 */
-export const TARGET_MAX_OUTPUT_TOKENS = 32_000
+/** 实际输出上限。原为 32000（对齐 SDK 路径的 Claude CLI 默认值），真机撞顶后按实测抬到 64000。
+ *
+ * 为什么 32000 不够：DeepSeek V4 默认开着 thinking，而 thinking 计入 output_tokens。真机第 22 章
+ * （3912 字）走一次冷改实测 output 21561 tokens，其中 **87% 是 thinking**——32000 只剩三分之一
+ * 余量，生产上冷改还要带任务书、正文路径与四遍指令，撞顶是必然。撞顶的后果不只是慢：主会话
+ * 会一路降级重试（先禁止贴正文、再砍遍数、最后拆成定点补丁），把「冷改必须整章重缝」这条已被
+ * 盲读验证过的质量纪律给跨了。
+ *
+ * provider 不是瓶颈：deepseek-v4-flash 输出上限 384K，一直是我们自己配的这个数在卡。
+ *
+ * 注意这里只加余量，没有关 thinking——关掉能省那 87%，但它是创作质量变量，要走真稿盲评，
+ * 不在本刀范围。超限仍触发 stopReason='length'，由事件映射 fail-loud。 */
+export const TARGET_MAX_OUTPUT_TOKENS = 64_000
 
 /**
  * 上游补偿系数（issue #35）：`@mariozechner/pi-ai@0.73.1` 的 `buildParams`


### PR DESCRIPTION
真机第 22 章 output 烧到 **279,304 tokens**（第 20 章是 16,897，**16.5 倍**）。还原派发序列后发现 chapter-writer 被派了 **11 次**（设计值 2 次：热写 + 冷改）。

## 撞顶的不是模型能力，是我们自己配的数

打真实 API 实测（第 22 章 3912 字，走一次冷改）：

| | output_tokens | thinking 字符 | 正文字符 |
|---|---:|---:|---:|
| 当前行为（thinking 开） | **21,561** | 26,818 | 3,917 |
| 关闭 thinking | 2,775 | 0 | 3,925 |

thinking 占 output 的 **87%**，而它计入 `output_tokens`。单次冷改裸测就用掉 21,561，32000 只剩三分之一余量——生产上冷改还要带任务书、正文路径与四遍指令，比裸测重得多，撞顶是必然。

thinking 一直开着的原因：`pi-model.ts` 写死 `reasoning: false` → pi-ai 的 `buildParams` 里 `if (model.reasoning)` 为假 → 请求根本不带 thinking 参数 → DeepSeek V4 用它自己的默认（开）。DeepSeek 文档另注明 `budget_tokens` 被忽略，即 thinking 长度不可限制。

**provider 不是瓶颈**：`deepseek-v4-flash` 输出上限 384K。

## 为什么这不只是「慢」

冷改被截断后，主会话会一路降级重试。实测序列：

```
03:57 冷改
04:01 冷改重试 —「注意输出要精炼：不要贴整章正文」
04:06 冷改再重试 —「本轮只做两遍」
04:10~04:12 拆成 4 次定点修改（删某句／破折号／万能副词／短段鼓点）
```

这跨了「**冷改必须整章重缝、不得降级成定点补丁/句子级润色**」这条已被盲读实验验证过的质量纪律——砍它是拿已验证的质量换速度。所以第 22 章的成稿质量可能已经实质受损，不只是烧时间。

## 本刀只加余量，不关 thinking

关掉能省那 87%（也省生成时间），但它是**创作质量变量**。已按引擎纪律做过真稿盲评：

- **冷改**：两臂相似度 98.7%，thinking 无价值
- **热写**：产品主人盲读**偏好 thinking 开**的那份

所以不能全局关。分档方案（热写开、冷改关）记在 #42。

## 验证

`pi-model.test.ts` 15 pass（含「实发 max_tokens 补偿上游除三」那条护栏——上游哪天不再除 3，它会红，那就是按拆除说明书改回去的信号）；全量 bun test 3524 pass / 469 fail，与 main 基线一致（这刀只改数值和断言，不新增测试）。

修复后热写实测 `stop=end_turn`，16,520 用量 / 64,000 上限，余量充足。

Refs #42
