### PR TITLE
fix(release): 版本线 0.1 → 0.2，止住新仓版本号低于线上导致存量用户收不到更新

### DIFF
--- a/docs/adr/0006-client-build-version-is-derived-at-build-time.md
+++ b/docs/adr/0006-client-build-version-is-derived-at-build-time.md
@@ -10,8 +10,20 @@ The previous OPS rule required `package.json.version` to equal `0.1.<git commit 
 
 ## Decision
 
-The user-facing client build version remains `0.1.<release commit count>`, but it is derived by the build / release path from the current release commit instead of being hand-maintained in `package.json.version`. `package.json.version` is treated as the package manifest or product-line base version, while About, RC artifact naming, and release verification use the derived client build version.
+The user-facing client build version is `<line prefix>.<release commit count>`, but it is derived by the build / release path from the current release commit instead of being hand-maintained in `package.json.version`. `package.json.version` is treated as the package manifest or product-line base version, while About, RC artifact naming, and release verification use the derived client build version.
 
 ## Consequences
 
 OPS checks should verify that the version resolver exists and produces the current commit-derived client build version, not that `package.json.version` equals the current commit count. This avoids version drift across normal commits, merge commits, rebases, and release-prep fixes.
+
+## Amendment 2026-08-25: version line raised `0.1` → `0.2`
+
+The prefix lives in a single place, `CLIENT_BUILD_VERSION_PREFIX` in `scripts/client-build-version.mjs`. It was raised from `0.1` to `0.2` on 2026-08-25. The derivation mechanism above is unchanged; only the line moved.
+
+**Why.** This repository was re-created with a clean history on 2026-08-04, so its commit count restarts at 0. The last shipped release, `v0.1.1930`, carries a commit count from the *previous* repository. Both counts landed on the same `0.1.x` line, so a release cut here would be `0.1.63` — which semver ranks *below* the `0.1.1930` already installed on users' machines. `electron-updater` only updates when the feed version is higher, so such a release would reach nobody.
+
+The open-source prep note judged that "the first version number will get smaller, which is expected — monotonic within the repo is enough". That holds for internal builds; **it missed existing users' auto-update path**. This amendment closes that gap.
+
+**Why raise the minor instead of adding an offset to the count.** Under semver every `0.2.x` outranks every `0.1.x`, so the problem is settled once and does not require knowing how far the old line counted. An offset would mean carrying that magic number forever.
+
+**Guard.** `scripts/client-build-version.test.mjs` asserts that the produced version outranks `0.1.1930` even at a commit count of 1, and that the invariant would fail if the prefix were moved back to `0.1`. Validators must use the exported `CLIENT_BUILD_VERSION_RE` rather than hardcoding the prefix in a regex.

--- a/docs/agents/release-checklist.md
+++ b/docs/agents/release-checklist.md
@@ -9,7 +9,7 @@
 - Target: macOS arm64
 - Artifact: DMG plus unpacked `.app`
 - Artifact naming: `NarraCat-${version}-mac-arm64`
-- Client build version: `0.1.<release commit count>` from `scripts/client-build-version.mjs`
+- Client build version: `0.2.<release commit count>` from `scripts/client-build-version.mjs` (line prefix = `CLIENT_BUILD_VERSION_PREFIX`; raised `0.1` → `0.2` on 2026-08-25, see ADR-0006 amendment — a `0.1.x` cut would rank below the shipped `v0.1.1930` and reach nobody)
 
 ## Automatic Gate
 

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -37,7 +37,7 @@ bun --no-cache run ops:status
 
 ## Client Version
 
-- 客户端构建版本使用 `0.1.<release commit 提交数>`。
+- 客户端构建版本使用 `0.2.<release commit 提交数>`（版本线前缀是 `CLIENT_BUILD_VERSION_PREFIX`，2026-08-25 由 `0.1` 抬到 `0.2`，见 ADR-0006 修订——本仓干净历史重建后提交数从 0 重数，而线上 `v0.1.1930` 的数字来自旧主仓，仍走 `0.1.x` 的话新版在 semver 下反而更小，存量用户收不到更新）。
 - 提交数由构建 / 发布脚本在打包时从当前 release commit 派生，例如 `git rev-list --count HEAD`。
 - `package.json` 的 `version` 是源码清单 / 产品线基础版本，不承载提交数派生的客户端构建版本。
 - About 版本展示、RC artifact 命名和发布验收记录必须使用同一套客户端构建版本解析逻辑。

--- a/scripts/client-build-version.mjs
+++ b/scripts/client-build-version.mjs
@@ -6,7 +6,26 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '..')
 
-export const CLIENT_BUILD_VERSION_PREFIX = '0.1'
+/**
+ * 客户端版本线前缀。**这是对外契约的一部分，改它等于改所有存量用户的更新判定。**
+ *
+ * 2026-08-25 由 `0.1` 抬到 `0.2`：本仓（公开仓）2026-08-04 以干净历史重建，提交数从 0
+ * 重新计数，而线上最后一个正式版 `v0.1.1930` 的数字来自旧主仓的提交数。两套计数撞在同一条
+ * `0.1.x` 线上，新仓发出来的 `0.1.63` 在 semver 下**小于**线上的 `0.1.1930`——electron-updater
+ * 只在 feed 版本更高时才更新，存量用户一个都收不到，等于发了个寂寞。
+ *
+ * 开源准备期（ADR-0006 落地时）判断过「首发版本号变小属预期，同仓内单调递增即可」——
+ * 那句话对内部构建成立，**漏掉的是存量用户的自动更新**，这次补上。
+ *
+ * 抬 minor 而不是给计数加偏移量：semver 下 `0.2.x` 恒大于任何 `0.1.x`，一次性了结，
+ * 不必猜旧线到底数到了多少；偏移量方案则要一直背着那个魔数。
+ */
+export const CLIENT_BUILD_VERSION_PREFIX = '0.2'
+
+/** 版本号格式正则（SSOT——校验方一律用它，不要各自手写 `^0\.1\.` 这类硬编码） */
+export const CLIENT_BUILD_VERSION_RE = new RegExp(
+  `^${CLIENT_BUILD_VERSION_PREFIX.replace(/\./g, '\\.')}\\.\\d+$`,
+)
 
 export function formatClientBuildVersion(commitCount) {
   const count = Number(commitCount)

--- a/scripts/client-build-version.test.mjs
+++ b/scripts/client-build-version.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   CLIENT_BUILD_VERSION_PREFIX,
+  CLIENT_BUILD_VERSION_RE,
   formatClientBuildVersion,
   CLIENT_VERSION_OVERRIDE_ENV,
   readGitCommitCount,
@@ -11,8 +12,8 @@ import {
 
 describe('client build version', () => {
   test('formats the release commit count as the user-facing client version', () => {
-    expect(CLIENT_BUILD_VERSION_PREFIX).toBe('0.1')
-    expect(formatClientBuildVersion(253)).toBe('0.1.253')
+    expect(CLIENT_BUILD_VERSION_PREFIX).toBe('0.2')
+    expect(formatClientBuildVersion(253)).toBe(`${CLIENT_BUILD_VERSION_PREFIX}.253`)
   })
 
   test('rejects invalid commit counts', () => {
@@ -21,7 +22,9 @@ describe('client build version', () => {
   })
 
   test('resolves the version through an injectable commit-count reader', () => {
-    expect(resolveClientBuildVersion({ readCommitCount: () => 42 })).toBe('0.1.42')
+    expect(resolveClientBuildVersion({ readCommitCount: () => 42 })).toBe(
+      `${CLIENT_BUILD_VERSION_PREFIX}.42`,
+    )
   })
 
   test('falls back to the macOS git path when PATH lookup is unavailable', () => {
@@ -63,7 +66,7 @@ describe('resolveOverridableClientVersion — 打包链版本号 SSOT', () => {
         env: { [CLIENT_VERSION_OVERRIDE_ENV]: '  ' },
         readCommitCount: stubCount,
       }),
-    ).toBe('0.1.64')
+    ).toBe(`${CLIENT_BUILD_VERSION_PREFIX}.64`)
   })
 
   test('非法值 fail-loud，不静默打出坏版本号', () => {
@@ -84,5 +87,34 @@ describe('resolveOverridableClientVersion — 打包链版本号 SSOT', () => {
     const src = await readFile(join(dirname(fileURLToPath(import.meta.url)), 'release.mjs'), 'utf8')
     expect(src).not.toContain(CLIENT_VERSION_OVERRIDE_ENV)
     expect(src).not.toContain('resolveOverridableClientVersion')
+  })
+})
+
+describe('版本线不变量 — 必须压过旧仓时代的线上版本', () => {
+  // 本仓 2026-08-04 干净历史重建，提交数从 0 重数；线上最后一个正式版 v0.1.1930 的数字
+  // 来自旧主仓的提交数。electron-updater 只在 feed 版本更高时才更新，所以「新版本线在
+  // semver 下大于 0.1.1930」是存量用户能收到更新的**唯一**保证——这条断言就是那道闸。
+  const LEGACY_ONLINE_LATEST = '0.1.1930'
+
+  function gt(a, b) {
+    const pa = a.split('.').map(Number)
+    const pb = b.split('.').map(Number)
+    for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] > pb[i]
+    return false
+  }
+
+  test('哪怕提交数只有 1，产出的版本号也大于线上旧版', () => {
+    // 用最小提交数取最坏情况：成立则任何提交数下都成立（同一 minor 内计数只增不减）
+    expect(gt(resolveClientBuildVersion({ readCommitCount: () => 1 }), LEGACY_ONLINE_LATEST)).toBe(
+      true,
+    )
+  })
+
+  test('当前真实提交数下同样成立', () => {
+    expect(gt(resolveClientBuildVersion({}), LEGACY_ONLINE_LATEST)).toBe(true)
+  })
+
+  test('前缀若被改回 0.1，这条不变量必须失守（证明断言真的有牙）', () => {
+    expect(gt(`0.1.${64}`, LEGACY_ONLINE_LATEST)).toBe(false)
   })
 })

--- a/scripts/ops-check.mjs
+++ b/scripts/ops-check.mjs
@@ -2,7 +2,11 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { resolveClientBuildVersion } from './client-build-version.mjs'
+import {
+  CLIENT_BUILD_VERSION_PREFIX,
+  CLIENT_BUILD_VERSION_RE,
+  resolveClientBuildVersion,
+} from './client-build-version.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '..')
@@ -114,8 +118,10 @@ function addClientBuildVersionFailures(files, failures, clientBuildVersion) {
     failures.push('scripts/client-build-version.mjs must export formatClientBuildVersion and resolveClientBuildVersion.')
   }
 
-  if (typeof clientBuildVersion === 'string' && !/^0\.1\.\d+$/.test(clientBuildVersion)) {
-    failures.push(`client build version must match 0.1.<commit count>, got ${clientBuildVersion}.`)
+  if (typeof clientBuildVersion === 'string' && !CLIENT_BUILD_VERSION_RE.test(clientBuildVersion)) {
+    failures.push(
+      `client build version must match ${CLIENT_BUILD_VERSION_PREFIX}.<commit count>, got ${clientBuildVersion}.`,
+    )
   }
 }
 

--- a/scripts/ops-check.test.mjs
+++ b/scripts/ops-check.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { CLIENT_BUILD_VERSION_PREFIX } from './client-build-version.mjs'
 import { checkOpsDocs } from './ops-check.mjs'
 
 describe('ops check', () => {
@@ -24,7 +25,7 @@ describe('ops check', () => {
           },
         }),
       },
-      clientBuildVersion: '0.1.12',
+      clientBuildVersion: `${CLIENT_BUILD_VERSION_PREFIX}.12`,
     })
 
     expect(result.ok).toBe(true)
@@ -72,7 +73,7 @@ describe('ops check', () => {
           },
         }),
       },
-      clientBuildVersion: '0.1.227',
+      clientBuildVersion: `${CLIENT_BUILD_VERSION_PREFIX}.227`,
     })
 
     expect(result.ok).toBe(false)
@@ -80,7 +81,7 @@ describe('ops check', () => {
       'scripts/client-build-version.mjs must export formatClientBuildVersion and resolveClientBuildVersion.',
     )
     expect(result.failures).not.toContain(
-      'package.json version must be 0.1.227 for the current OPS client version rule.',
+      `package.json version must be ${CLIENT_BUILD_VERSION_PREFIX}.227 for the current OPS client version rule.`,
     )
   })
 })

--- a/scripts/package-rc.test.mjs
+++ b/scripts/package-rc.test.mjs
@@ -18,6 +18,7 @@ import {
   restoreSourceManifestIfClobbered,
   resolveStepEnv,
 } from './package-rc.mjs'
+import { CLIENT_BUILD_VERSION_RE } from './client-build-version.mjs'
 import { DEFAULT_APP_PATH } from './verify-signed-artifact.mjs'
 
 const packageRcModuleUrl = pathToFileURL(join(dirname(fileURLToPath(import.meta.url)), 'package-rc.mjs')).href
@@ -460,7 +461,7 @@ describe('CLI 入口守卫：node scripts/package-rc.mjs 必须先加载 .env �
 describe('resolvePackageClientVersion — 内测包版本号覆盖', () => {
   test('未设环境变量时走 git 计数（与正式链路同源）', () => {
     const version = resolvePackageClientVersion({ env: {} })
-    expect(version).toMatch(/^0\.1\.\d+$/)
+    expect(version).toMatch(CLIENT_BUILD_VERSION_RE)
   })
 
   test('设了就用它——测试包要能压过线上版本，否则 electron-updater 会静默换掉它', () => {
@@ -469,7 +470,7 @@ describe('resolvePackageClientVersion — 内测包版本号覆盖', () => {
 
   test('空白值视同未设，不产出空版本号', () => {
     const version = resolvePackageClientVersion({ env: { NARRACAT_CLIENT_VERSION: '   ' } })
-    expect(version).toMatch(/^0\.1\.\d+$/)
+    expect(version).toMatch(CLIENT_BUILD_VERSION_RE)
   })
 
   test('非法值 fail-loud，不静默打出坏版本号的包', () => {


### PR DESCRIPTION
## 问题：从这里切版发出去，一个存量用户都收不到

```
线上最新      v0.1.1930   （2026-08-14，数字来自旧主仓的提交数）
本仓提交数    63          →  按现规则切版 = 0.1.63
```

`0.1.63` 在 semver 下**小于** `0.1.1930`。而 `electron-updater` 只在 feed 版本更高时才更新——这样的 release 发出去，用户机器上一动不动。

根因不是谁做错了：本仓 2026-08-04 以干净历史重建，提交数从 0 重数，两套计数撞在同一条 `0.1.x` 线上。

开源准备期判断过「首发版本号会重置变小，属预期……同仓内单调递增即可」。**这话对内部构建成立，漏掉的是存量用户的自动更新路径**——本 PR 补上。

## 解法：抬 minor，不加偏移量

semver 下每个 `0.2.x` 都大于任何 `0.1.x`，**一次性了结**，不必去猜旧线到底数到了多少；偏移量方案则要永远背着那个魔数。

本次发布版本 = **`0.2.63`**。

### 双路验证 semver 比较

两条路径都会做版本比较，都验过：

| 比较 | App 侧 `compareSemver`（release-guard 门控） | `electron-updater` 用的 semver 库 |
|---|---|---|
| `0.2.63` vs `0.1.1930` | 更新 ✓ | `true` |
| `0.2.63` vs `0.1.9999`（本机测试包） | 更新 ✓ | `true` |
| `0.2.63` vs `0.2.62` | 更新 ✓ | `true` |

顺带救回本机那台装了 `0.1.9999` 测试包的机器——它也能正常收到 `0.2.63`。

## 改动

- `CLIENT_BUILD_VERSION_PREFIX` `'0.1'` → `'0.2'`（单点定义，注释写清了为什么抬、为什么不用偏移量）
- 新增 **`CLIENT_BUILD_VERSION_RE`** 作为格式校验 SSOT。`ops-check.mjs` 原先硬编码 `/^0\.1\.\d+$/`，改为引用它——**下次抬线不会再漏掉校验方这一处**
- 测试期望值一律改为常量拼接，不再硬编码版本线（改前抬线会连带红 4 条无关测试）
- **新增版本线不变量**：哪怕提交数只有 1，产出版本也必须压过 `0.1.1930`；并配一条反向用例，证明前缀被改回 `0.1` 时该不变量确实失守（断言有牙，不是摆设）
- ADR-0006 加修订章节（机制未变，只是线移了，并记下当年那句判断漏在哪）；`release-checklist.md` / `workflow.md` 同步

## 验证

- `typecheck` ✓
- 全量 **3147 pass / 0 fail across 311 files** ✓
- `check:architecture` ✓
- `ops:check` 仍红三条，**均为改动前既有**（`progress.md` 早期条目与 ADR-0036/0037 的裸 `bun run`、ADR-0037 占位符），与本次无关，未扩大范围修

## 发布前置状态

| | |
|---|---|
| Developer ID 证书 | ✓ |
| 公证凭证三件套 | ✓ |
| 语料 token | ✓ |

合入后即可跑 `package:release`。**首次跨版本号体系发布，建议先做真机装 + 回退演练再对外放。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A