### PR TITLE
fix(check:design): 路径归一化收口，止住守卫在 Windows 上恒红 (#24)

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -16,3 +16,25 @@ jobs:
       # 设计系统守卫本体也在 CI 跑一遍：它是最容易漏跑的一道，贡献者本机跑不跑得动不该
       # 决定 main 的干净程度（跨平台形态的回归由 scripts/check-design-system.test.mjs 兜）。
       - run: bun --no-cache run check:design
+
+  # 设计系统守卫的 Windows 复跑（#24）。ubuntu 与 mac 都是正斜杠 + LF，证明不了
+  # Windows 那一半：这个 job 提供真实的 Windows checkout（core.autocrlf=true → CRLF）、
+  # 真实的 node:path.relative()（反斜杠）和完整 CLI 入口——正是让守卫恒红的那三样。
+  # 故意不装依赖：check:design 只需要 node 跑一个脚本，几十秒就能出结论，
+  # 原生模块的探路归 windows-build-smoke.yml，两件事不混。
+  design-guard-windows:
+    runs-on: windows-latest
+    steps:
+      - name: 强制 CRLF 检出（复现贡献者本机形态）
+        run: git config --global core.autocrlf true
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: 打印检出形态（留证：路径分隔符与行尾）
+        shell: bash
+        run: |
+          echo "=== core.autocrlf ==="
+          git config core.autocrlf
+          echo "=== 白名单三个文件的 eol（i/lf w/crlf = 索引 LF、工作区 CRLF）==="
+          git ls-files --eol src/components/brand/BrandMark.tsx src/components/brand/BrandStoryBanner.tsx src/components/brand/brand-illustrations.ts
+      - run: bun --no-cache run check:design
+      - run: bun --no-cache test scripts/check-design-system.test.mjs

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -13,3 +13,6 @@ jobs:
       - run: bun install --no-cache
       - run: bun --no-cache run typecheck
       - run: bun --no-cache run test
+      # 设计系统守卫本体也在 CI 跑一遍：它是最容易漏跑的一道，贡献者本机跑不跑得动不该
+      # 决定 main 的干净程度（跨平台形态的回归由 scripts/check-design-system.test.mjs 兜）。
+      - run: bun --no-cache run check:design

--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -6,6 +6,8 @@
 
 `main`（= `db5db0d`，已 push）。**2026-08-25 发布 `v0.2.65` 到线上**（距上一个正式版 `v0.1.1930` 11 天、27 个提交），feed 已切换、真机验收通过。
 
+当前工作分支 `fix/24-check-design-windows-path`（PR #52，修 #24 设计系统守卫在 Windows 恒红），待 Windows CI job 出绿后合并。
+
 ## Current Phase
 
 主线 `main`。产品北极星 = ADR-0030「账房归我们 / 花归用户 / 尺归读者」；产品方向 2026-07-11 定案两大模块「用户编辑 + 可配置底座」。**正文编辑器主战役已收官**（PR #443 合并 main，ADR-0031，引擎 4.0.91，产品主人真机验收通过）；写作质量「脱胎换骨」主线阶段性收刀（arc 速度靶 PR #441 / 获得引擎四刀 PR #442 均已合并）。ADR 已扩至 **0035**。
@@ -590,6 +592,15 @@ P1A-1 完成门已闭合。分支仍未推送、未创建 PR、未合并，继�
 - Agent Core cutover：NarraCat-app 已切到内部维护 `agent-core/narracat/` 作为 NarraCat Agent Core 源码；仓库内 `resources/NarraCat` 已移除，旧 plugin 清单工件仅作为 SDK 运行适配层保留，`mcp-server/dist` 随 Agent Core 提交。
 
 ## Now
+
+**2026-08-25 · #24 `check:design` 在 Windows 恒红已修（分支 `fix/24-check-design-windows-path`，PR #52，待合）**
+
+- **根因是路径分隔符，不是 issue 正文猜的行尾**（社区贡献者 @zfengChen 在 Windows 10 实机诊断并给出证据链）：`listFiles()` 的 `relative('.', path)` 在 Windows 返回反斜杠，而品牌资产白名单存正斜杠 → `Set.has()` 恒 false → 三个合规包装器（`BrandMark` / `BrandStoryBanner` / `brand-illustrations`）被误扫，它们本来就该引用资产目录 → 守卫恒红；mac 恒绿，永远看不见。
+- 修复：扫描结果统一走 `toPosixPath()`；读文件统一 LF 归一化（行尾非本次根因，但跨行子串契约在 `core.autocrlf=true` 下同样假红）；新增 `allowlistCoverageFailure()` 让白名单落空 fail loud 并点名；品牌违规一次报全；待读文件清单由 `requiredContracts` 推导，删掉需人工同步的第二份清单。
+- 补 `scripts/check-design-system.test.mjs`——本仓守卫脚本此前唯一没有测试的一个，喂反斜杠 / CRLF 输入，让这类「mac 上永远看不见」的缺陷在 mac 上就能拦；退化副本（`toPosixPath` 恒等）实测 4 fail，证明测试真拦得住。
+- **CI 接线两处**：`app-ci` 增跑 `check:design`（issue 说它「最容易漏跑」，而 CI 此前从未跑过它）；新增 `design-guard-windows` job（windows-latest + 强制 `core.autocrlf=true` 检出，不装依赖，只跑守卫与其单测）——ubuntu / mac 都是正斜杠 + LF，Windows 那一半只有真 runner 能证，这条也让跨平台守卫缺陷以后不再靠人工真机复现。
+- 验证：全量 `bun --no-cache run test` 3159 pass / 0 fail、`typecheck`、`check:design` 均绿；ubuntu CI 已确认新步骤真跑到（日志有 `Design-system contracts present.`）。
+- 下一步：Windows job 出绿后合并并关 #24；回复 issue 里的贡献者（诊断归功 + 说明为何在他的一行修法上多做了覆盖自检 / 单测 / CI 三件事）。`scripts/check-no-native-details.mjs` 的主模块判断仍是文件名后缀式（本仓惯例是 `pathToFileURL`），留作小债。
 
 **当前（2026-07-30）· 模型上限实验闭环 + 成稿句法根因已修（4.0.150，未 push）**
 

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -1,54 +1,33 @@
+// 设计系统守卫：契约存在性 + 禁用写法 + 品牌资产收口 + 字号刻度。
+//
+// 跨平台纪律（#24）：本脚本内部一律用 POSIX 路径（正斜杠）与 LF 行尾。
+// Windows 上 `relative()` 返回反斜杠，曾让品牌资产白名单的 `Set.has()` 恒 false，
+// 三个合规包装器（BrandMark/BrandStoryBanner/brand-illustrations）被当成违规 → 守卫恒红；
+// `core.autocrlf=true` 检出的 CRLF 同样会让跨行子串契约匹配不上。两者都在 mac 上永远看不见，
+// 所以路径归一化走 toPosixPath()、读文件走 readText()，并由 allowlistCoverageFailure()
+// 在白名单落空时 fail loud——不许再退化成一条「某个平台恒红」的守卫。
+//
+// 用法：node scripts/check-design-system.mjs（退出码 1 = 有违规）。
+
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
-const requiredFiles = {
-  'docs/design.md': readFileSync('docs/design.md', 'utf8'),
-  'docs/agents/workflow.md': readFileSync('docs/agents/workflow.md', 'utf8'),
-  'src/styles/globals.css': readFileSync('src/styles/globals.css', 'utf8'),
-  'src/design-system/surfaces.ts': readFileSync('src/design-system/surfaces.ts', 'utf8'),
-  'src/design-system/typography.ts': readFileSync('src/design-system/typography.ts', 'utf8'),
-  'src/components/workbench/WorkbenchEmptyState.tsx': readFileSync(
-    'src/components/workbench/WorkbenchEmptyState.tsx',
-    'utf8',
-  ),
-  'src/components/workbench/WorkbenchEmptyGuide.tsx': readFileSync(
-    'src/components/workbench/WorkbenchEmptyGuide.tsx',
-    'utf8',
-  ),
-  'src/components/workbench/MarkdownRenderer.tsx': readFileSync(
-    'src/components/workbench/MarkdownRenderer.tsx',
-    'utf8',
-  ),
-  'src/components/workbench/agent/AgentQuestionCard.tsx': readFileSync(
-    'src/components/workbench/agent/AgentQuestionCard.tsx',
-    'utf8',
-  ),
-  'src/components/ui/button.tsx': readFileSync('src/components/ui/button.tsx', 'utf8'),
-  'src/components/AppShell.tsx': readFileSync('src/components/AppShell.tsx', 'utf8'),
-  'src/components/brand/BrandMark.tsx': readFileSync(
-    'src/components/brand/BrandMark.tsx',
-    'utf8',
-  ),
-  'src/components/brand/BrandLockup.tsx': readFileSync(
-    'src/components/brand/BrandLockup.tsx',
-    'utf8',
-  ),
-  'src/components/brand/BrandIllustration.tsx': readFileSync(
-    'src/components/brand/BrandIllustration.tsx',
-    'utf8',
-  ),
-  'src/components/brand/BrandStoryBanner.tsx': readFileSync(
-    'src/components/brand/BrandStoryBanner.tsx',
-    'utf8',
-  ),
-  'src/components/brand/brand-illustrations.ts': readFileSync(
-    'src/components/brand/brand-illustrations.ts',
-    'utf8',
-  ),
-  'src/components/brand/index.ts': readFileSync('src/components/brand/index.ts', 'utf8'),
-  'src/components/brand/README.md': readFileSync('src/components/brand/README.md', 'utf8'),
+/** 路径归一化为 POSIX 分隔符（导出供测试）。 */
+export function toPosixPath(path) {
+  return path.replaceAll('\\', '/')
 }
 
+/** 行尾归一化为 LF（导出供测试）。 */
+export function normalizeLineEndings(text) {
+  return text.replaceAll('\r\n', '\n')
+}
+
+function readText(path) {
+  return normalizeLineEndings(readFileSync(path, 'utf8'))
+}
+
+// 必须存在的契约：[文件, 必须出现的子串]。待读文件清单由本表推导（见 main），
+// 不再手写第二份——两份清单人工同步，漏一条就是 `undefined.includes` 崩栈。
 const requiredContracts = [
   ['docs/design.md', '浮动工作台，而不是平铺后台'],
   ['docs/design.md', 'Active 不被 Hover 覆盖'],
@@ -115,17 +94,6 @@ const requiredContracts = [
   ['src/components/brand/README.md', 'docs/design.md'],
 ]
 
-for (const [file, needle] of requiredContracts) {
-  if (!requiredFiles[file].includes(needle)) {
-    console.error(`${file} is missing required design-system contract: ${needle}`)
-    process.exit(1)
-  }
-}
-
-// src/dev 是 dev-only 调试工具（生产不打包），不属于产品 UI，豁免设计系统守卫。
-const sourceFiles = listFiles('src').filter(
-  (file) => /\.(css|ts|tsx)$/.test(file) && !/^src[\\/]dev[\\/]/.test(file),
-)
 const forbidden = [
   [/text-(blue|purple|green|orange|red|gray|slate)-\d/, 'use semantic text tokens instead of hardcoded palette classes'],
   [/bg-(blue|purple|green|orange|red|gray|slate)-\d/, 'use semantic background tokens instead of hardcoded palette classes'],
@@ -134,57 +102,114 @@ const forbidden = [
   [/var\(--(bg-|fg-|control|sidebar|stage|app-chrome|border-subtle|border-hairline|accent-surface|color-accent)/, 'use design-system semantic tokens/classes instead of legacy visual variables'],
 ]
 
-for (const file of sourceFiles) {
-  const content = readFileSync(file, 'utf8')
-  for (const [pattern, message] of forbidden) {
-    if (pattern.test(content)) {
-      console.error(`${file} violates design-system guard: ${message} (${pattern})`)
-      process.exit(1)
-    }
-  }
-}
-
-const rawBrandAssetDirectories = ['assets/brand/', 'assets/illustrations/narracat/']
-const directBrandAssetPattern = new RegExp(
-  rawBrandAssetDirectories.map((directory) => escapeRegExp(directory)).join('|'),
-)
-const brandAssetAllowlist = new Set([
-  'src/components/brand/BrandMark.tsx',
-  'src/components/brand/BrandStoryBanner.tsx',
-  'src/components/brand/brand-illustrations.ts',
-])
-const productionSourceFiles = sourceFiles.filter((file) => !/\.test\.(ts|tsx)$/.test(file))
-
-for (const file of productionSourceFiles) {
-  if (brandAssetAllowlist.has(file)) {
-    continue
-  }
-
-  const content = readFileSync(file, 'utf8')
-  if (directBrandAssetPattern.test(content)) {
-    console.error(
-      `${file} violates brand asset guard: use BrandMark/BrandLockup/BrandIllustration instead of importing raw brand assets`,
-    )
-    process.exit(1)
-  }
-}
-
 const offScaleFontSizeGuards = [
   [/text-\[13px\]/, 'off-scale font size; use the typography scale or a registered typography role'],
   [/text-\[17px\]/, 'off-scale font size; use the typography scale or a registered typography role'],
 ]
 
-for (const file of productionSourceFiles) {
-  const content = readFileSync(file, 'utf8')
-  for (const [pattern, message] of offScaleFontSizeGuards) {
-    if (pattern.test(content)) {
-      console.error(`${file} violates typography scale guard: ${message} (${pattern})`)
+const rawBrandAssetDirectories = ['assets/brand/', 'assets/illustrations/narracat/']
+const directBrandAssetPattern = new RegExp(
+  rawBrandAssetDirectories.map((directory) => escapeRegExp(directory)).join('|'),
+)
+
+/** 允许直接引用原始品牌资产的合规包装器（POSIX 路径）。 */
+export const BRAND_ASSET_ALLOWLIST = [
+  'src/components/brand/BrandMark.tsx',
+  'src/components/brand/BrandStoryBanner.tsx',
+  'src/components/brand/brand-illustrations.ts',
+]
+
+/**
+ * 白名单覆盖自检（导出供测试）：白名单条目必须真的出现在扫描结果里。
+ * 落空只有两种可能——文件搬迁/改名，或路径形态对不上（Windows 反斜杠，即 #24 的根因）；
+ * 两种都会让白名单静默失效，让守卫在合规文件上恒红，必须 fail loud 而不是让人去猜。
+ * @param {string[]} scannedFiles 扫描到的文件路径
+ * @param {string[]} allowlist 白名单
+ * @returns {string | null} 错误文案；null = 覆盖正常
+ */
+export function allowlistCoverageFailure(scannedFiles, allowlist = BRAND_ASSET_ALLOWLIST) {
+  const scanned = new Set(scannedFiles.map(toPosixPath))
+  const missing = allowlist.filter((file) => !scanned.has(file))
+  if (missing.length === 0) return null
+  return `check-design-system: 品牌资产白名单有 ${missing.length} 条未出现在扫描结果里（${missing.join('、')}）——文件搬迁了，或路径形态对不上（Windows 反斜杠？），白名单已形同虚设，先修白名单/扫描范围。`
+}
+
+/**
+ * 收集品牌资产违规（导出供测试）。
+ * @param {{ files: Array<{ path: string, content: string }>, allowlist?: string[] }} input
+ * @returns {string[]} 违规文件路径（POSIX）
+ */
+export function collectBrandAssetViolations({ files, allowlist = BRAND_ASSET_ALLOWLIST }) {
+  const allowed = new Set(allowlist.map(toPosixPath))
+  const violations = []
+  for (const file of files) {
+    const path = toPosixPath(file.path)
+    if (allowed.has(path)) continue
+    if (directBrandAssetPattern.test(file.content)) violations.push(path)
+  }
+  return violations
+}
+
+function main() {
+  const requiredFiles = {}
+  for (const [file] of requiredContracts) {
+    if (!(file in requiredFiles)) requiredFiles[file] = readText(file)
+  }
+
+  for (const [file, needle] of requiredContracts) {
+    if (!requiredFiles[file].includes(needle)) {
+      console.error(`${file} is missing required design-system contract: ${needle}`)
       process.exit(1)
     }
   }
-}
 
-console.log('Design-system contracts present.')
+  // src/dev 是 dev-only 调试工具（生产不打包），不属于产品 UI，豁免设计系统守卫。
+  const sourceFiles = listFiles('src').filter(
+    (file) => /\.(css|ts|tsx)$/.test(file) && !/^src\/dev\//.test(file),
+  )
+
+  for (const file of sourceFiles) {
+    const content = readText(file)
+    for (const [pattern, message] of forbidden) {
+      if (pattern.test(content)) {
+        console.error(`${file} violates design-system guard: ${message} (${pattern})`)
+        process.exit(1)
+      }
+    }
+  }
+
+  const productionSourceFiles = sourceFiles.filter((file) => !/\.test\.(ts|tsx)$/.test(file))
+
+  const coverageFailure = allowlistCoverageFailure(productionSourceFiles)
+  if (coverageFailure) {
+    console.error(coverageFailure)
+    process.exit(1)
+  }
+
+  const brandAssetViolations = collectBrandAssetViolations({
+    files: productionSourceFiles.map((path) => ({ path, content: readText(path) })),
+  })
+  if (brandAssetViolations.length > 0) {
+    for (const file of brandAssetViolations) {
+      console.error(
+        `${file} violates brand asset guard: use BrandMark/BrandLockup/BrandIllustration instead of importing raw brand assets`,
+      )
+    }
+    process.exit(1)
+  }
+
+  for (const file of productionSourceFiles) {
+    const content = readText(file)
+    for (const [pattern, message] of offScaleFontSizeGuards) {
+      if (pattern.test(content)) {
+        console.error(`${file} violates typography scale guard: ${message} (${pattern})`)
+        process.exit(1)
+      }
+    }
+  }
+
+  console.log('Design-system contracts present.')
+}
 
 function listFiles(root) {
   const results = []
@@ -194,7 +219,7 @@ function listFiles(root) {
     if (stats.isDirectory()) {
       results.push(...listFiles(path))
     } else {
-      results.push(relative('.', path))
+      results.push(toPosixPath(relative('.', path)))
     }
   }
   return results
@@ -202,4 +227,8 @@ function listFiles(root) {
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+if (process.argv[1] && toPosixPath(process.argv[1]).endsWith('check-design-system.mjs')) {
+  main()
 }

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -11,6 +11,7 @@
 
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 /** 路径归一化为 POSIX 分隔符（导出供测试）。 */
 export function toPosixPath(path) {
@@ -168,27 +169,27 @@ function main() {
     (file) => /\.(css|ts|tsx)$/.test(file) && !/^src\/dev\//.test(file),
   )
 
-  for (const file of sourceFiles) {
-    const content = readText(file)
+  // 每个文件只读一次，三道守卫共用同一份内容。
+  const sources = sourceFiles.map((path) => ({ path, content: readText(path) }))
+
+  for (const { path, content } of sources) {
     for (const [pattern, message] of forbidden) {
       if (pattern.test(content)) {
-        console.error(`${file} violates design-system guard: ${message} (${pattern})`)
+        console.error(`${path} violates design-system guard: ${message} (${pattern})`)
         process.exit(1)
       }
     }
   }
 
-  const productionSourceFiles = sourceFiles.filter((file) => !/\.test\.(ts|tsx)$/.test(file))
+  const productionSources = sources.filter(({ path }) => !/\.test\.(ts|tsx)$/.test(path))
 
-  const coverageFailure = allowlistCoverageFailure(productionSourceFiles)
+  const coverageFailure = allowlistCoverageFailure(productionSources.map(({ path }) => path))
   if (coverageFailure) {
     console.error(coverageFailure)
     process.exit(1)
   }
 
-  const brandAssetViolations = collectBrandAssetViolations({
-    files: productionSourceFiles.map((path) => ({ path, content: readText(path) })),
-  })
+  const brandAssetViolations = collectBrandAssetViolations({ files: productionSources })
   if (brandAssetViolations.length > 0) {
     for (const file of brandAssetViolations) {
       console.error(
@@ -198,11 +199,10 @@ function main() {
     process.exit(1)
   }
 
-  for (const file of productionSourceFiles) {
-    const content = readText(file)
+  for (const { path, content } of productionSources) {
     for (const [pattern, message] of offScaleFontSizeGuards) {
       if (pattern.test(content)) {
-        console.error(`${file} violates typography scale guard: ${message} (${pattern})`)
+        console.error(`${path} violates typography scale guard: ${message} (${pattern})`)
         process.exit(1)
       }
     }
@@ -229,6 +229,8 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-if (process.argv[1] && toPosixPath(process.argv[1]).endsWith('check-design-system.mjs')) {
+// ESM 主模块判断走 pathToFileURL（仓内惯例）：文件名后缀判断会把 not-check-design-system.mjs
+// 之类的导入者也当成 CLI 入口，裸 `file://${process.argv[1]}` 则在路径含空格/软链时静默失效。
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()
 }

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -136,6 +136,34 @@ export function allowlistCoverageFailure(scannedFiles, allowlist = BRAND_ASSET_A
 }
 
 /**
+ * 是否生产源码（导出供测试）：测试文件豁免字号与品牌资产守卫——它们会写
+ * `text-[13px]` 之类的负向断言，扫进来就是误伤。
+ * @param {string} path 文件路径
+ * @returns {boolean}
+ */
+export function isProductionSource(path) {
+  return !/\.test\.(ts|tsx)$/.test(toPosixPath(path))
+}
+
+/**
+ * 收集字号刻度违规（导出供测试）。
+ * @param {{ files: Array<{ path: string, content: string }> }} input
+ * @returns {Array<{ file: string, message: string, pattern: RegExp }>}
+ */
+export function collectOffScaleFontSizeViolations({ files }) {
+  const violations = []
+  for (const file of files) {
+    if (!isProductionSource(file.path)) continue
+    for (const [pattern, message] of offScaleFontSizeGuards) {
+      if (pattern.test(file.content)) {
+        violations.push({ file: toPosixPath(file.path), message, pattern })
+      }
+    }
+  }
+  return violations
+}
+
+/**
  * 收集品牌资产违规（导出供测试）。
  * @param {{ files: Array<{ path: string, content: string }>, allowlist?: string[] }} input
  * @returns {string[]} 违规文件路径（POSIX）
@@ -181,7 +209,7 @@ function main() {
     }
   }
 
-  const productionSources = sources.filter(({ path }) => !/\.test\.(ts|tsx)$/.test(path))
+  const productionSources = sources.filter(({ path }) => isProductionSource(path))
 
   const coverageFailure = allowlistCoverageFailure(productionSources.map(({ path }) => path))
   if (coverageFailure) {
@@ -199,13 +227,12 @@ function main() {
     process.exit(1)
   }
 
-  for (const { path, content } of productionSources) {
-    for (const [pattern, message] of offScaleFontSizeGuards) {
-      if (pattern.test(content)) {
-        console.error(`${path} violates typography scale guard: ${message} (${pattern})`)
-        process.exit(1)
-      }
+  const offScaleViolations = collectOffScaleFontSizeViolations({ files: productionSources })
+  if (offScaleViolations.length > 0) {
+    for (const { file, message, pattern } of offScaleViolations) {
+      console.error(`${file} violates typography scale guard: ${message} (${pattern})`)
     }
+    process.exit(1)
   }
 
   console.log('Design-system contracts present.')

--- a/scripts/check-design-system.test.mjs
+++ b/scripts/check-design-system.test.mjs
@@ -3,6 +3,8 @@ import {
   BRAND_ASSET_ALLOWLIST,
   allowlistCoverageFailure,
   collectBrandAssetViolations,
+  collectOffScaleFontSizeViolations,
+  isProductionSource,
   normalizeLineEndings,
   toPosixPath,
 } from './check-design-system.mjs'
@@ -78,5 +80,40 @@ describe('allowlistCoverageFailure（白名单覆盖自检）', () => {
 
   test('扫描范围塌成空时同样 fail loud，不许静默放行', () => {
     expect(allowlistCoverageFailure([])).not.toBeNull()
+  })
+})
+
+describe('isProductionSource（测试文件豁免）', () => {
+  test('.test.ts / .test.tsx 不算生产源码——反斜杠路径同样识别', () => {
+    expect(isProductionSource('src/lib/a.test.ts')).toBe(false)
+    expect(isProductionSource('src/components/B.test.tsx')).toBe(false)
+    expect(isProductionSource(windowsPath('src/components/B.test.tsx'))).toBe(false)
+  })
+
+  test('生产文件算生产源码（含名字里带 test 但不是测试文件的）', () => {
+    expect(isProductionSource('src/components/ui/button.tsx')).toBe(true)
+    expect(isProductionSource('src/lib/test-utils.ts')).toBe(true)
+  })
+})
+
+describe('collectOffScaleFontSizeViolations（字号刻度）', () => {
+  test('生产文件里的 text-[13px] / text-[17px] 判违规', () => {
+    const violations = collectOffScaleFontSizeViolations({
+      files: [
+        { path: 'src/components/A.tsx', content: 'className="text-[13px]"' },
+        { path: 'src/components/B.tsx', content: 'className="text-[17px]"' },
+        { path: 'src/components/C.tsx', content: 'className="text-[15px]"' },
+      ],
+    })
+    expect(violations.map((v) => v.file)).toEqual(['src/components/A.tsx', 'src/components/B.tsx'])
+  })
+
+  test('测试文件里的负向断言不误伤——守卫只扫生产代码', () => {
+    const violations = collectOffScaleFontSizeViolations({
+      files: [
+        { path: 'src/components/A.test.tsx', content: "expect(cls).not.toContain('text-[13px]')" },
+      ],
+    })
+    expect(violations).toEqual([])
   })
 })

--- a/scripts/check-design-system.test.mjs
+++ b/scripts/check-design-system.test.mjs
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  BRAND_ASSET_ALLOWLIST,
+  allowlistCoverageFailure,
+  collectBrandAssetViolations,
+  normalizeLineEndings,
+  toPosixPath,
+} from './check-design-system.mjs'
+
+// Windows 检出形态：反斜杠路径 + CRLF 行尾。mac 上永远看不见，只能靠喂输入拦（#24）。
+const windowsPath = (posixPath) => posixPath.replaceAll('/', '\\')
+
+describe('toPosixPath（路径归一化）', () => {
+  test('反斜杠归一化为正斜杠，POSIX 路径原样通过', () => {
+    expect(toPosixPath('src\\components\\brand\\BrandMark.tsx')).toBe(
+      'src/components/brand/BrandMark.tsx',
+    )
+    expect(toPosixPath('src/components/brand/BrandMark.tsx')).toBe(
+      'src/components/brand/BrandMark.tsx',
+    )
+  })
+})
+
+describe('normalizeLineEndings（行尾归一化）', () => {
+  test('CRLF 归一化后，跨行子串契约才匹配得上', () => {
+    const crlf = 'Record<BrandIllustrationPurpose,\r\n  BrandIllustrationAsset>'
+    expect(crlf.includes('Purpose,\n  Brand')).toBe(false)
+    expect(normalizeLineEndings(crlf).includes('Purpose,\n  Brand')).toBe(true)
+  })
+})
+
+describe('collectBrandAssetViolations（品牌资产收口）', () => {
+  const rawImport = "import mark from '../../assets/brand/narracat-mark.webp'"
+
+  test('白名单里的合规包装器豁免——反斜杠路径同样豁免（#24 回归）', () => {
+    const files = BRAND_ASSET_ALLOWLIST.map((path) => ({
+      path: windowsPath(path),
+      content: rawImport,
+    }))
+    expect(collectBrandAssetViolations({ files })).toEqual([])
+  })
+
+  test('白名单外的文件直接引用原始资产判违规，路径以 POSIX 形态报出', () => {
+    const violations = collectBrandAssetViolations({
+      files: [
+        { path: windowsPath('src/routes/library.tsx'), content: rawImport },
+        {
+          path: 'src/components/workbench/Panel.tsx',
+          content: "import art from '@/assets/illustrations/narracat/empty.webp'",
+        },
+        { path: 'src/components/ui/button.tsx', content: 'export const Button = () => null' },
+      ],
+    })
+    expect(violations).toEqual(['src/routes/library.tsx', 'src/components/workbench/Panel.tsx'])
+  })
+
+  test('全部违规都报出来，不止第一条', () => {
+    const files = ['src/a.tsx', 'src/b.tsx', 'src/c.tsx'].map((path) => ({ path, content: rawImport }))
+    expect(collectBrandAssetViolations({ files })).toHaveLength(3)
+  })
+})
+
+describe('allowlistCoverageFailure（白名单覆盖自检）', () => {
+  test('白名单条目齐全时放行', () => {
+    expect(allowlistCoverageFailure([...BRAND_ASSET_ALLOWLIST, 'src/routes/library.tsx'])).toBeNull()
+  })
+
+  test('扫描结果是反斜杠形态时自检自身也归一化，不假报', () => {
+    expect(allowlistCoverageFailure(BRAND_ASSET_ALLOWLIST.map(windowsPath))).toBeNull()
+  })
+
+  test('白名单条目搬迁/改名后 fail loud，并列出落空条目', () => {
+    const failure = allowlistCoverageFailure(['src/components/brand/BrandMark.tsx'])
+    expect(failure).toContain('src/components/brand/BrandStoryBanner.tsx')
+    expect(failure).toContain('src/components/brand/brand-illustrations.ts')
+    expect(failure).toContain('白名单已形同虚设')
+  })
+
+  test('扫描范围塌成空时同样 fail loud，不许静默放行', () => {
+    expect(allowlistCoverageFailure([])).not.toBeNull()
+  })
+})

--- a/src/design-system/typography-governance.test.ts
+++ b/src/design-system/typography-governance.test.ts
@@ -25,8 +25,11 @@ describe('typography drift governance', () => {
     const checkScript = readFileSync('scripts/check-design-system.mjs', 'utf8')
     expect(checkScript).toContain('offScaleFontSizeGuards')
     expect(checkScript).toContain('typography scale guard')
-    // 守卫只扫生产代码，避免误伤测试里对 text-[13px] 的负向断言
-    expect(checkScript).toContain('for (const file of productionSourceFiles)')
+    // 守卫只扫生产代码，避免误伤测试里对 text-[13px] 的负向断言。这里只认语义命名，
+    // 不再钉具体循环写法（原来钉的是 `for (const file of productionSourceFiles)`，
+    // 一次内部重构就假红）；真正的行为验证在 scripts/check-design-system.test.mjs
+    // ——那边直接喂 .test.tsx 与生产文件断言豁免与命中。
+    expect(checkScript).toContain('isProductionSource')
   })
 
   test('design.md documents drift rules, visual verification and accepted debt', () => {


### PR DESCRIPTION
Closes #24 · Windows 线总跟踪 #25

## 根因

不是 issue 正文猜的行尾，是**路径分隔符**——@zfengChen 在 Windows 10 实体机上诊断并给了完整证据链（issue #24 评论），修法方向也是他给的，这里照收并往前多走了几步。

`listFiles()` 用 `relative('.', path)`，Windows 返回反斜杠；而品牌资产白名单存的是正斜杠：

```
Set.has('src\components\brand\BrandMark.tsx')  // 恒 false
```

→ 三个**合规包装器**（`BrandMark.tsx` / `BrandStoryBanner.tsx` / `brand-illustrations.ts`）全部被误扫。它们作为资产收口层本来就该引用 `assets/brand/`，于是 `bun run check:design` 在 Windows 上恒红，mac 上恒绿。

顺带说明：`check-architecture.mjs` 早就在做 `.replaceAll('\\', '/')`，本仓已有这条约定，只有这个脚本漏了。

## 改动

| | 内容 |
|---|---|
| **根因修复** | 扫描结果统一走 `toPosixPath()`，白名单判定不再受平台分隔符影响 |
| **防御性加固** | 读文件统一走 `readText()`（CRLF → LF）。行尾不是本次根因，但跨行子串契约在 `core.autocrlf=true` 的检出下同样会假红，顺手堵掉 |
| **白名单覆盖自检** | 新增 `allowlistCoverageFailure()`：白名单条目没出现在扫描结果里就 fail loud 并点名落空条目。白名单静默失效正是这次「守卫红了却看不出为什么」的另一半 |
| **报全违规** | 品牌资产违规改为一次报全，不再首个即 `exit(1)`——否则 Windows 上得修一次跑一次才看得全三条 |
| **删掉第二份清单** | 待读文件清单由 `requiredContracts` 推导，不再手写与之并行的 `requiredFiles`（两份人工同步，漏一条就是 `undefined.includes` 崩栈） |
| **补测试** | 新增 `scripts/check-design-system.test.mjs`——本仓 20+ 个守卫脚本里唯独它没有测试，而这次的 bug 恰恰是「mac 上永远看不见」那一类 |
| **CI 挂上守卫** | `app-ci` 增加 `bun run check:design`。issue 正文说它是「最容易漏跑、也最该跑」的一道，而 CI 此前只跑 `typecheck` + `test`，从来没跑过它 |

## 为什么不只改那一行

@zfengChen 给的一行修法（`relative(...).replace(/\\/g, '/')`）是对的，本 PR 的根因修复就是它。多做的三件事都指向 issue 里那句「一个在某个平台上恒红的守卫比没有守卫更糟」：

- 只修一行的话，**下一次**白名单静默失效（文件改名/搬迁/又一种路径形态）还是会以「合规文件恒红」的面目出现，还是得靠人肉诊断 → 所以加覆盖自检，让它自己说出为什么
- 这类缺陷在 mac 上写、在 mac 上测、在 mac 上合并，全程无感 → 所以补上喂反斜杠/CRLF 输入的单测，让 mac 也能拦
- 守卫本身没进 CI，红不红取决于人记不记得跑 → 所以挂进 app-ci

## 验证

| 项 | 结果 |
|---|---|
| `bun --no-cache run check:design` | ✅ 绿 |
| `bun --no-cache test scripts/check-design-system.test.mjs` | ✅ 9 pass |
| `brand-governance.test.ts` / `typography-governance.test.ts`（对脚本源码做子串断言） | ✅ 7 pass，重构没打破 |
| `bun --no-cache run test` 全量 | ✅ 3159 pass / 0 fail（312 files） |
| `bun --no-cache run typecheck` | ✅ 绿 |
| **测试是否真拦得住** | ✅ 造了个 `toPosixPath` 恒等的「修复前」退化副本跑同一份测试 → **4 fail**，报错直接点名三个落空的白名单条目 |

**mac 上跑不出的部分**：真实 Windows 路径形态无法在 mac 端到端复现，回归拦截靠上面的输入级单测。合并前会在 Windows x64 实体机上裸跑一次 `bun --no-cache run check:design` 终验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A