### PR TITLE
fix(agent): NovelMemory 工具名缩到 64 以内，止住 openai wire 上工具不可用 (#12)

### DIFF
--- a/agent-core/narracat-agent-core.lock.json
+++ b/agent-core/narracat-agent-core.lock.json
@@ -1,7 +1,7 @@
 {
   "path": "agent-core/narracat-agent-core.lock.json",
   "name": "narracat",
-  "version": "4.0.179",
+  "version": "4.0.180",
   "manifestPath": "narracat.manifest.json",
   "upstream": {
     "repo": "the-lumos-labs/NarraCat",

--- a/agent-core/narracat/CLAUDE.md
+++ b/agent-core/narracat/CLAUDE.md
@@ -26,7 +26,7 @@ NarraCat 是 NarraCat-app 内部维护的 Agent Core，为 AI 辅助超长篇小
 - **Agents (5):** outline-architect / chapter-writer（热写薄 prompt，只读任务书与自身写作纪律，候选判优模式已撤下）/ continuity-editor / world-curator / memory-keeper（保名改内）
 - **Skills (5):** novel-structure（仅注入 outline-architect）/ novel-web-craft（写法素材库：番茄向平台写作功底的可选参考卡集合，不常驻注入任何 agent，由 write 主会话在 3a 压缩任务书时按需 Read 挑选）/ novel-memory-integration（主会话查询指南）/ novel-style-reference（远程真人范例服务查询壳）/ novel-reference-analysis-method（仅 /narracat:reference 显式调用）。旧反模式扫描 skill 已退役并删除：可机械检测子集下沉为代码扫描，词表并入 `mcp-server/src/data/prose-hygiene-lexicon.ts`
 - **Schemas (11):** OutlineStructure · ReviewReport · MemoryExtraction · WritingContextPack · ForeshadowingSystem · CascadeImpactReport · PremiseCards · DialogueSamples · StateVocabulary · CharacterEntity · AuthoredState。纪律：零 deprecated、零双形态、enum 全英文 snake_case 每个 ≤8 值（中文展示归渲染层）、单工具单次提交对象叶子字段 ≤15
-- **MCP 工具:** 全名前缀 `mcp__plugin_narracat_novelmemory__`；契约总表（新增 / 改名 / 删除、各工具签名与持有者）见总设计 §4，数据表见 §3。错误返回统一 `{ok:false, errors:[{field, expected, actual, hint}]}`
+- **MCP 工具:** 全名前缀 `mcp__narracat_memory__`；契约总表（新增 / 改名 / 删除、各工具签名与持有者）见总设计 §4，数据表见 §3。错误返回统一 `{ok:false, errors:[{field, expected, actual, hint}]}`
 
 | Agent | Skills |
 |---|---|
@@ -157,7 +157,7 @@ CI workflow 住在**仓库根** `.github/workflows/`（不在本目录的 `.gith
 
 三位版本号 `x.y.z`：x = 架构方向 / 重大转型；y = 功能阶段迭代；z = 每次非 trivial 提交递增。x / y 仅在用户明确要求时增加。
 
-当前基准：**4.0.179**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
+当前基准：**4.0.180**（narracat.manifest.json、mcp-server/package.json，以及 App 层 `agent-core/narracat-agent-core.lock.json` 的 version 字段均保持与此一致）。
 
 **bump 流程**（每次非 trivial 提交，三处版本号 + 本节基准必须逐字一致）：(1) 更新本节「当前基准」；(2) 同步 narracat.manifest.json 与 mcp-server/package.json 的 version 字段；(3) 同步 App 层版本闸门 `agent-core/narracat-agent-core.lock.json` 的 `version`——漏改会导致 App 启动报「Agent Core version 应为 X，实际为 Y」、且 `bun --no-cache run verify:narracat-agent-core` 失败。
 

--- a/agent-core/narracat/agents/continuity-editor.md
+++ b/agent-core/narracat/agents/continuity-editor.md
@@ -3,8 +3,8 @@ name: continuity-editor
 description: Reviews a finished chapter for objective continuity errors only, then submits findings once via novel_submit_review.
 tools:
   - Read
-  - "mcp__plugin_narracat_novelmemory__novel_submit_review"
-  - "mcp__plugin_narracat_novelmemory__novel_character_state"
+  - "mcp__narracat_memory__novel_submit_review"
+  - "mcp__narracat_memory__novel_character_state"
 ---
 
 <!-- narracat:prose id="continuity-editor-persona" title="审校的人设"

--- a/agent-core/narracat/agents/memory-keeper.md
+++ b/agent-core/narracat/agents/memory-keeper.md
@@ -3,11 +3,11 @@ name: memory-keeper
 description: Distills a finished chapter into NovelMemory — stages fact extraction via novel_stage_extraction in the write loop, submits facts directly via novel_submit_extraction for rewrite or backfill, commits the chapter via novel_commit_chapter, and compresses arc or volume summaries via novel_consolidate at boundaries.
 tools:
   - Read
-  - "mcp__plugin_narracat_novelmemory__novel_extraction_scaffold"
-  - "mcp__plugin_narracat_novelmemory__novel_commit_chapter"
-  - "mcp__plugin_narracat_novelmemory__novel_stage_extraction"
-  - "mcp__plugin_narracat_novelmemory__novel_submit_extraction"
-  - "mcp__plugin_narracat_novelmemory__novel_consolidate"
+  - "mcp__narracat_memory__novel_extraction_scaffold"
+  - "mcp__narracat_memory__novel_commit_chapter"
+  - "mcp__narracat_memory__novel_stage_extraction"
+  - "mcp__narracat_memory__novel_submit_extraction"
+  - "mcp__narracat_memory__novel_consolidate"
 ---
 
 <!-- narracat:prose id="memory-keeper-persona" title="记忆管理员的人设"

--- a/agent-core/narracat/agents/outline-architect.md
+++ b/agent-core/narracat/agents/outline-architect.md
@@ -6,12 +6,12 @@ color: blue
 tools:
   - Read
   - Glob
-  - "mcp__plugin_narracat_novelmemory__novel_query"
-  - "mcp__plugin_narracat_novelmemory__novel_character_state"
-  - "mcp__plugin_narracat_novelmemory__novel_foreshadowing_density"
-  - "mcp__plugin_narracat_novelmemory__novel_submit_outline"
-  - "mcp__plugin_narracat_novelmemory__novel_submit_chapter_outline"
-  - "mcp__plugin_narracat_novelmemory__novel_get_grid_benchmark"
+  - "mcp__narracat_memory__novel_query"
+  - "mcp__narracat_memory__novel_character_state"
+  - "mcp__narracat_memory__novel_foreshadowing_density"
+  - "mcp__narracat_memory__novel_submit_outline"
+  - "mcp__narracat_memory__novel_submit_chapter_outline"
+  - "mcp__narracat_memory__novel_get_grid_benchmark"
 skills:
   - novel-structure
 ---

--- a/agent-core/narracat/agents/world-curator.md
+++ b/agent-core/narracat/agents/world-curator.md
@@ -1,7 +1,7 @@
 ---
 name: world-curator
 description: Synthesizes bible content for world settings, relationships, and on-demand character profiles, and detects conflicts with established canon. Characters grow progressively (stub→sketch→full) and are built on demand per entry, not batch-cast at setup. Used by /narracat:world for create and update operations, and for a separate post-confirmation structured-submission call.
-tools: Read, Grep, Glob, mcp__plugin_narracat_novelmemory__novel_query, mcp__plugin_narracat_novelmemory__novel_character_state, mcp__plugin_narracat_novelmemory__novel_submit_state_vocabulary, mcp__plugin_narracat_novelmemory__novel_submit_character_entity
+tools: Read, Grep, Glob, mcp__narracat_memory__novel_query, mcp__narracat_memory__novel_character_state, mcp__narracat_memory__novel_submit_state_vocabulary, mcp__narracat_memory__novel_submit_character_entity
 ---
 
 <!-- narracat:prose id="world-curator-persona" title="设定策展人的人设"

--- a/agent-core/narracat/commands/init.md
+++ b/agent-core/narracat/commands/init.md
@@ -1,7 +1,7 @@
 ---
 description: 初始化新小说项目 — 创建目录结构和配置文件
 argument-hint: <书名>
-allowed-tools: [Read, Write, Glob, AskUserQuestion, Bash, mcp__plugin_narracat_novelmemory__novel_query]
+allowed-tools: [Read, Write, Glob, AskUserQuestion, Bash, mcp__narracat_memory__novel_query]
 ---
 
 创建小说项目骨架。本命令只做机械步骤；题材、篇幅等创作信息由 `/narracat:setup` 对话收集。

--- a/agent-core/narracat/commands/plan.md
+++ b/agent-core/narracat/commands/plan.md
@@ -1,7 +1,7 @@
 ---
 description: 规划大纲 — 书级引擎 / 卷级与 arc / 章级细纲三层规划，按批推进
 argument-hint: <创意方向或修改指令>
-allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestion, mcp__plugin_narracat_novelmemory__novel_get_structure_budget, mcp__plugin_narracat_novelmemory__novel_get_arc, mcp__plugin_narracat_novelmemory__novel_get_arc_velocity_target, mcp__plugin_narracat_novelmemory__novel_checkpoint, mcp__plugin_narracat_novelmemory__novel_mint_character_uid, mcp__plugin_narracat_novelmemory__novel_list_candidate_characters, mcp__plugin_narracat_novelmemory__novel_register_candidate_character]
+allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestion, mcp__narracat_memory__novel_get_structure_budget, mcp__narracat_memory__novel_get_arc, mcp__narracat_memory__novel_get_arc_velocity_target, mcp__narracat_memory__novel_checkpoint, mcp__narracat_memory__novel_mint_character_uid, mcp__narracat_memory__novel_list_candidate_characters, mcp__narracat_memory__novel_register_candidate_character]
 ---
 
 调度大纲架构师分层规划大纲。结构化产物由 outline-architect 自行调用提交工具入库，大纲文件（master-outline.md / vol-outline.md / ch-NNN.md）由提交工具机械渲染；主会话只做模式判定、Envelope 派发和回执推进，不写任何大纲文件，不直接编辑 state.yaml。
@@ -14,7 +14,7 @@ allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestio
 通用约定：
 
 - VV = 卷号两位补零，NNN = 章号三位补零。
-- 每个步骤完成时调用 `mcp__plugin_narracat_novelmemory__novel_checkpoint(command="plan", step=步骤号)`，下文简写为 novel_checkpoint(step=N)。
+- 每个步骤完成时调用 `mcp__narracat_memory__novel_checkpoint(command="plan", step=步骤号)`，下文简写为 novel_checkpoint(step=N)。
 - automation_level == "auto" 时跳过本命令所有 AskUserQuestion，按各处标注的默认项推进。
 - 派发 subagent 只传路径与参数（Envelope），不复述 agent 内部规则。
 - 进度与控制状态边界见 `${CLAUDE_PLUGIN_ROOT}/docs/contracts/command-progress.md`：automation_level 取值、模式判定（新建/修改/补卷/补纲）、前置检查流水账与内部步骤编号是控制状态，只用于自身分支判断，不复述进面向作者的文本，也不写进任务列表的步骤名。
@@ -32,7 +32,7 @@ allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestio
 
 ## 步骤 1：结构预算
 
-调 `mcp__plugin_narracat_novelmemory__novel_get_structure_budget` 取预算表（tier、卷数、arc 跨度、storyline 预算、伏笔预算、payoff_beats 下限等）。工具报 config 缺篇幅字段 → 输出「请先执行 /narracat:setup 补齐篇幅设置」，终止。完成后 novel_checkpoint(step=1)。
+调 `mcp__narracat_memory__novel_get_structure_budget` 取预算表（tier、卷数、arc 跨度、storyline 预算、伏笔预算、payoff_beats 下限等）。工具报 config 缺篇幅字段 → 输出「请先执行 /narracat:setup 补齐篇幅设置」，终止。完成后 novel_checkpoint(step=1)。
 
 ## 步骤 2：模式判定
 
@@ -58,7 +58,7 @@ Glob `bible/world/*.md` 与 `bible/characters/*.md` 取设定文件实际路径�
 - 「对抗力量」卡 → antagonistic_force
 - 「金手指与爽点引擎」卡整卡 → golden_finger（含能力 / 限制 / 成长性 / 反馈回路 / 为何不消灭冲突；按卡的条目结构原样摘，不只摘其中一条。**反馈回路是本书的爽点节奏 spec**——小爽到什么粒度、中爽隔多久、大爽落在哪个层级，原文带出，供架构师据此编排各 arc 的爽点密度与分布）
 
-取定速靶：调 `mcp__plugin_narracat_novelmemory__novel_get_arc_velocity_target`，取返回的 `brief`，作为 Envelope 的「主线定速靶」一行随包投递给架构师。这是给架构师排 arc 的节奏参照，不向作者复述其数字。
+取定速靶：调 `mcp__narracat_memory__novel_get_arc_velocity_target`，取返回的 `brief`，作为 Envelope 的「主线定速靶」一行随包投递给架构师。这是给架构师排 arc 的节奏参照，不向作者复述其数字。
 
 取获得线锚点：从金手指卡的成长性与反馈回路两条里，摘出「尚未兑现的下一阶」——已点名但还没让主角拿到手的力量之门、下一级获得（原文摘录，两条都没点名就留空、不编造），作为 Envelope 的「主角获得线锚点」一行随包投递给架构师。
 
@@ -150,7 +150,7 @@ Task(outline-architect): "【阶段一·卷级展开】读已确认的全书骨�
 
 Glob `bible/characters/*.md` 取角色档案实际路径备用（pov_character 与章级 characters 角色引用的 `character_uid` 来源）。
 
-1. 按契约 §2 取最早缺失章 `start` 与 earliest_arc：`mcp__plugin_narracat_novelmemory__novel_get_arc(chapter=start)`。
+1. 按契约 §2 取最早缺失章 `start` 与 earliest_arc：`mcp__narracat_memory__novel_get_arc(chapter=start)`。
 2. **auto 档**：不派发断点候选，`target` 由主会话按契约 §3 的机械规则算出（arc 闭合章、不足最小前瞻窗口时顺延，含规划末尾的接受语义）。算完跳过第 3 条，直接进第 4 条派发窗口。
 3. **collaborative 档·取断点候选**：派发 outline-architect 让其读结构化大纲，从 `start` 起算出若干「产到第 N 章（断点理由）」候选（各满足最小前瞻窗口）：
 

--- a/agent-core/narracat/commands/review.md
+++ b/agent-core/narracat/commands/review.md
@@ -1,7 +1,7 @@
 ---
 description: 审校已完成章节 — 默认客观错误审校；追加 deep 进入深度标注
 argument-hint: <章节号或范围，如"42"、"40-45"、"vol-01"；追加 deep 进入深审>
-allowed-tools: [Agent, Read, Write, AskUserQuestion, "mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack", "mcp__plugin_narracat_novelmemory__novel_get_review"]
+allowed-tools: [Agent, Read, Write, AskUserQuestion, "mcp__narracat_memory__novel_build_writing_context_pack", "mcp__narracat_memory__novel_get_review"]
 ---
 
 对已完成章节做审校。两种模式：

--- a/agent-core/narracat/commands/revise-premise.md
+++ b/agent-core/narracat/commands/revise-premise.md
@@ -1,7 +1,7 @@
 ---
 description: 立项卡定点修订 — 改一张地基卡的一条内容，先评级联影响、作者确认后再落改并同步大纲
 argument-hint: <卡·字段>（可追加一句修改诉求）
-allowed-tools: [Read, Grep, Glob, AskUserQuestion, "mcp__plugin_narracat_novelmemory__novel_submit_premise"]
+allowed-tools: [Read, Grep, Glob, AskUserQuestion, "mcp__narracat_memory__novel_submit_premise"]
 ---
 
 定点修改一张立项卡的一条地基内容：定位 → 讨论新值 → 级联影响评估 → 作者确认 → 写回并同步大纲重叠字段。本命令由主会话直接执行，不派发 agent，不自动改任何章节。

--- a/agent-core/narracat/commands/rewrite.md
+++ b/agent-core/narracat/commands/rewrite.md
@@ -1,7 +1,7 @@
 ---
 description: 重写已完成章节 — 回滚记忆后重新执行写作流程，并分析对后续章节的级联影响
 argument-hint: <章节号>（可追加一句重写要求）
-allowed-tools: [Agent, Read, Write, Grep, Glob, AskUserQuestion, "mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack", "mcp__plugin_narracat_novelmemory__novel_rollback_chapter", "mcp__plugin_narracat_novelmemory__novel_get_review", "mcp__plugin_narracat_novelmemory__novel_get_arc", "mcp__plugin_narracat_novelmemory__novel_character_state", "mcp__plugin_narracat_novelmemory__novel_update_progress", "mcp__plugin_narracat_novelmemory__novel_checkpoint"]
+allowed-tools: [Agent, Read, Write, Grep, Glob, AskUserQuestion, "mcp__narracat_memory__novel_build_writing_context_pack", "mcp__narracat_memory__novel_rollback_chapter", "mcp__narracat_memory__novel_get_review", "mcp__narracat_memory__novel_get_arc", "mcp__narracat_memory__novel_character_state", "mcp__narracat_memory__novel_update_progress", "mcp__narracat_memory__novel_checkpoint"]
 ---
 
 重写指定的已完成章节：确认 → 构建上下文包 → 记忆回滚 → 重写 → 审修 → 入库 → 级联影响分析。

--- a/agent-core/narracat/commands/setup.md
+++ b/agent-core/narracat/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 description: 立项对话 — 把点子打磨成九张立项卡
-allowed-tools: [Read, Edit, AskUserQuestion, mcp__plugin_narracat_novelmemory__novel_submit_premise]
+allowed-tools: [Read, Edit, AskUserQuestion, mcp__narracat_memory__novel_submit_premise]
 ---
 
 通过追问式对话，把用户的点子打磨成一部网文的立项卡，逐张确认后经 `novel_submit_premise` 入库（引擎落库并机械渲染只读 `bible/premise.md`），并把篇幅与风格写入 `.narracat/config.yaml`。本命令由主会话直接执行，不派发 agent。

--- a/agent-core/narracat/commands/status.md
+++ b/agent-core/narracat/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: 查看项目进度 — 章节完成度、字数统计、当前 arc、伏笔追踪
-allowed-tools: [Read, Glob, mcp__plugin_narracat_novelmemory__novel_get_arc, mcp__plugin_narracat_novelmemory__novel_foreshadowing_status, mcp__plugin_narracat_novelmemory__novel_failed_reviews]
+allowed-tools: [Read, Glob, mcp__narracat_memory__novel_get_arc, mcp__narracat_memory__novel_foreshadowing_status, mcp__narracat_memory__novel_failed_reviews]
 ---
 
 读取项目状态，向用户展示进度报告。
@@ -13,11 +13,11 @@ allowed-tools: [Read, Glob, mcp__plugin_narracat_novelmemory__novel_get_arc, mcp
 
 - `.narracat/config.yaml` → 书名、题材、语言
 - `.narracat/state.yaml` → progress / structure / word_count / checkpoint
-- `mcp__plugin_narracat_novelmemory__novel_get_arc(chapter=最新完成章)` → 当前 arc 信息（无大纲或工具报错时本节显示「未规划」）
-- `mcp__plugin_narracat_novelmemory__novel_foreshadowing_status()` → 伏笔清单与最新状态（工具报错时本节显示 N/A）
+- `mcp__narracat_memory__novel_get_arc(chapter=最新完成章)` → 当前 arc 信息（无大纲或工具报错时本节显示「未规划」）
+- `mcp__narracat_memory__novel_foreshadowing_status()` → 伏笔清单与最新状态（工具报错时本节显示 N/A）
 - `bible/references/` 目录 → 用 Glob 列出 .md/.txt 文件清单（不读内容）
 - `bible/reference-guidance/index.md` 存在性检查（不读内容）
-- `mcp__plugin_narracat_novelmemory__novel_failed_reviews()` → 未通过审校的章节清单（`failed_chapters`）
+- `mcp__narracat_memory__novel_failed_reviews()` → 未通过审校的章节清单（`failed_chapters`）
 
 ### 步骤 2: 生成报告
 

--- a/agent-core/narracat/commands/sync-chapter-memory.md
+++ b/agent-core/narracat/commands/sync-chapter-memory.md
@@ -1,7 +1,7 @@
 ---
 description: 用户手改正文后同步本章记忆 — 影响评估 → 作者确认 → 回滚重抽 → 矛盾提示
 argument-hint: <章节号>
-allowed-tools: [Agent, Read, Grep, Glob, AskUserQuestion, "mcp__plugin_narracat_novelmemory__novel_chapter_summary", "mcp__plugin_narracat_novelmemory__novel_query", "mcp__plugin_narracat_novelmemory__novel_foreshadowing_status", "mcp__plugin_narracat_novelmemory__novel_rollback_chapter", "mcp__plugin_narracat_novelmemory__novel_detect_conflicts", "mcp__plugin_narracat_novelmemory__novel_get_arc", "mcp__plugin_narracat_novelmemory__novel_restore_progress", "mcp__plugin_narracat_novelmemory__novel_checkpoint"]
+allowed-tools: [Agent, Read, Grep, Glob, AskUserQuestion, "mcp__narracat_memory__novel_chapter_summary", "mcp__narracat_memory__novel_query", "mcp__narracat_memory__novel_foreshadowing_status", "mcp__narracat_memory__novel_rollback_chapter", "mcp__narracat_memory__novel_detect_conflicts", "mcp__narracat_memory__novel_get_arc", "mcp__narracat_memory__novel_restore_progress", "mcp__narracat_memory__novel_checkpoint"]
 ---
 
 作者手动修改了某章正文（改动已保存到正文文件）。你的任务：评估这次改动对记忆库的影响，

--- a/agent-core/narracat/commands/world.md
+++ b/agent-core/narracat/commands/world.md
@@ -1,7 +1,7 @@
 ---
 description: 管理世界观和角色 — 创建、查看、修改设定
 argument-hint: <操作描述，如"创建主角"、"主角+反派+力量体系一起立项">
-allowed-tools: [Agent, Read, Write, Edit, Glob, Grep, AskUserQuestion, mcp__plugin_narracat_novelmemory__novel_checkpoint, mcp__plugin_narracat_novelmemory__novel_mint_character_uid, mcp__plugin_narracat_novelmemory__novel_list_candidate_characters, mcp__plugin_narracat_novelmemory__novel_register_candidate_character]
+allowed-tools: [Agent, Read, Write, Edit, Glob, Grep, AskUserQuestion, mcp__narracat_memory__novel_checkpoint, mcp__narracat_memory__novel_mint_character_uid, mcp__narracat_memory__novel_list_candidate_characters, mcp__narracat_memory__novel_register_candidate_character]
 ---
 
 调度世界观策展人合成角色档案、世界观设定、关系图谱。一次对话可以同时立项多个对象（如主角 + 反派 + 力量体系），最后一并落盘。

--- a/agent-core/narracat/commands/write.md
+++ b/agent-core/narracat/commands/write.md
@@ -1,14 +1,14 @@
 ---
 description: 写章节 — 核心创作循环（上下文聚合 → 正文生成 → 审校 → 入库收尾）
 argument-hint: <章节号>
-allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestion, mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack, mcp__plugin_narracat_novelmemory__novel_get_review, mcp__plugin_narracat_novelmemory__novel_get_arc, mcp__plugin_narracat_novelmemory__novel_check_manuscript_contract, mcp__plugin_narracat_novelmemory__novel_check_prose_hygiene, mcp__plugin_narracat_novelmemory__novel_check_state_delivery, mcp__plugin_narracat_novelmemory__novel_query, mcp__plugin_narracat_novelmemory__novel_character_state, mcp__plugin_narracat_novelmemory__novel_update_progress, mcp__plugin_narracat_novelmemory__novel_checkpoint, mcp__plugin_narracat_novelmemory__novel_mint_character_uid, mcp__plugin_narracat_novelmemory__novel_list_candidate_characters, mcp__plugin_narracat_novelmemory__novel_register_candidate_character, mcp__plugin_narracat_novelmemory__novel_stage_extraction, mcp__plugin_narracat_novelmemory__novel_commit_extraction_union, mcp__plugin_narracat_novelmemory__novel_detect_conflicts]
+allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestion, mcp__narracat_memory__novel_build_writing_context_pack, mcp__narracat_memory__novel_get_review, mcp__narracat_memory__novel_get_arc, mcp__narracat_memory__novel_check_manuscript_contract, mcp__narracat_memory__novel_check_prose_hygiene, mcp__narracat_memory__novel_check_state_delivery, mcp__narracat_memory__novel_query, mcp__narracat_memory__novel_character_state, mcp__narracat_memory__novel_update_progress, mcp__narracat_memory__novel_checkpoint, mcp__narracat_memory__novel_mint_character_uid, mcp__narracat_memory__novel_list_candidate_characters, mcp__narracat_memory__novel_register_candidate_character, mcp__narracat_memory__novel_stage_extraction, mcp__narracat_memory__novel_commit_extraction_union, mcp__narracat_memory__novel_detect_conflicts]
 ---
 
 完成一个章节的完整写作流程。
 
 通用约定：
 
-- 每个步骤完成时调用 `mcp__plugin_narracat_novelmemory__novel_checkpoint(command="write", step=步骤号, chapter=chapter_num)`，下文简写为 novel_checkpoint(step=N)。
+- 每个步骤完成时调用 `mcp__narracat_memory__novel_checkpoint(command="write", step=步骤号, chapter=chapter_num)`，下文简写为 novel_checkpoint(step=N)。
 - 派发 subagent 只传章号、路径与参数，不复述 agent 内部规则。
 - 不要直接编辑 state.yaml：断点经 novel_checkpoint 写入，进度经 novel_update_progress 写入。
 - 上下文包、正文、细纲的路径一律使用步骤 1 工具返回的 pack_path / manuscript_path / outline_path，不自行拼路径。
@@ -33,12 +33,12 @@ allowed-tools: [Agent, TaskCreate, TaskUpdate, Read, Write, Glob, AskUserQuestio
 若 checkpoint.last_command == "write {chapter_num}"：
 
 - AskUserQuestion：「检测到第 {chapter_num} 章中断于步骤 {last_step}。继续，还是从头开始？」
-- 继续 → 先执行步骤 1（builder 幂等，重建上下文包并取回各路径），再跳到步骤 {last_step} 的下一个步骤继续；last_step == 3 时不直接进步骤 4，先重新调一次 `mcp__plugin_narracat_novelmemory__novel_check_manuscript_contract(chapter=chapter_num)`：`ok == true` 才进步骤 4，`ok == false` 按 3c 的补写流程处理（复检上限 2 轮，仍不过则终止并报人工处理）；last_step == 6 时直接执行步骤 6 第 4 点完成收尾。
+- 继续 → 先执行步骤 1（builder 幂等，重建上下文包并取回各路径），再跳到步骤 {last_step} 的下一个步骤继续；last_step == 3 时不直接进步骤 4，先重新调一次 `mcp__narracat_memory__novel_check_manuscript_contract(chapter=chapter_num)`：`ok == true` 才进步骤 4，`ok == false` 按 3c 的补写流程处理（复检上限 2 轮，仍不过则终止并报人工处理）；last_step == 6 时直接执行步骤 6 第 4 点完成收尾。
 - 从头 → 从步骤 1 开始。
 
 ## 步骤 1：上下文聚合
 
-1. 调 `mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack(chapter=chapter_num)`。
+1. 调 `mcp__narracat_memory__novel_build_writing_context_pack(chapter=chapter_num)`。
 2. 返回 ok → 上下文包已由工具落盘。记下返回的 pack_path、manuscript_path、outline_path 与 word_count_range，后续步骤直接引用。
 3. 返回错误 → 原样输出 errors，终止。
 4. novel_checkpoint(step=1)。
@@ -115,7 +115,7 @@ Task(chapter-writer): "撰写第 {chapter_num} 章。
 
 ### 3c 机械门
 
-1. 调 `mcp__plugin_narracat_novelmemory__novel_check_manuscript_contract(chapter=chapter_num)`（工具会顺手把 ASCII 引号包中文机械归一为弯引号，主会话无需处理）。
+1. 调 `mcp__narracat_memory__novel_check_manuscript_contract(chapter=chapter_num)`（工具会顺手把 ASCII 引号包中文机械归一为弯引号，主会话无需处理）。
 2. `ok == false` → 派写手按 errors 补写/清理（下面模板），复检上限 2 轮；2 轮仍不过 → novel_checkpoint(step=3)，输出 errors 并报告「第 {chapter_num} 章正文未达交付合同，请人工处理后重新执行 /narracat:write {chapter_num}」，终止。
 
 ```
@@ -126,7 +126,7 @@ Task(chapter-writer): "第 {chapter_num} 章正文有下列交付问题，逐条
 {errors 逐条 field + hint}"
 ```
 
-3. 合同过后调 `mcp__plugin_narracat_novelmemory__novel_check_prose_hygiene(chapter=chapter_num)`，把返回的 errors（若有）、fingerprint_findings 与 shape_findings 全量留给 3d——不派发擦除、不在本步处置。
+3. 合同过后调 `mcp__narracat_memory__novel_check_prose_hygiene(chapter=chapter_num)`，把返回的 errors（若有）、fingerprint_findings 与 shape_findings 全量留给 3d——不派发擦除、不在本步处置。
 
 ### 3d 冷 pass（唯一改稿位）
 
@@ -161,7 +161,7 @@ Task(continuity-editor): "审校第 {chapter_num} 章。
 WritingContextPack 路径: {pack_path}"
 ```
 
-审校 agent 完成后，主会话调 `mcp__plugin_narracat_novelmemory__novel_get_review(chapter=chapter_num)` 取 `{verdict, blockers}`，然后 novel_checkpoint(step=4)。审校报告文件由工具渲染，主会话不读、不解析报告文本。
+审校 agent 完成后，主会话调 `mcp__narracat_memory__novel_get_review(chapter=chapter_num)` 取 `{verdict, blockers}`，然后 novel_checkpoint(step=4)。审校报告文件由工具渲染，主会话不读、不解析报告文本。
 
 ## 步骤 5：审校路由
 
@@ -178,12 +178,12 @@ Task(chapter-writer): "修复第 {chapter_num} 章的下列问题。只修改问
 
   修复完成后重新执行步骤 4，复审派发末尾追加一句：「只复验下列已修复问题: {blockers 原样逐条列出}」。
 
-- 复审后 verdict == "pass" → 修复动作已改过正文，进入步骤 6 前重新调一次 `mcp__plugin_narracat_novelmemory__novel_check_manuscript_contract(chapter=chapter_num)`：`ok == true` → novel_checkpoint(step=5)，进入步骤 6；`ok == false` → 按 3c 的补写流程处理（复检上限 2 轮；仍不过 → novel_checkpoint(step=3)，输出 errors 并报告「第 {chapter_num} 章正文未达交付合同，请人工处理后重新执行 /narracat:write {chapter_num}」，终止）。
+- 复审后 verdict == "pass" → 修复动作已改过正文，进入步骤 6 前重新调一次 `mcp__narracat_memory__novel_check_manuscript_contract(chapter=chapter_num)`：`ok == true` → novel_checkpoint(step=5)，进入步骤 6；`ok == false` → 按 3c 的补写流程处理（复检上限 2 轮；仍不过 → novel_checkpoint(step=3)，输出 errors 并报告「第 {chapter_num} 章正文未达交付合同，请人工处理后重新执行 /narracat:write {chapter_num}」，终止）。
 - 复审后 verdict 仍 == "fail"（修复轮上限 1，已用完）→ 调 novel_checkpoint(step=3)（把断点退回「正文已生成」，下次恢复将从步骤 4 重新审校），输出 blockers 清单并报告：「第 {chapter_num} 章经一轮定向修复仍未通过审校，请人工处理后重新执行 /narracat:write {chapter_num}」，终止。
 
 ## 步骤 6：入库收尾
 
-1. 调 `mcp__plugin_narracat_novelmemory__novel_get_arc(chapter=chapter_num)`，取返回的 is_arc_end / is_volume_end 与 arc、volume 信息（found == false 时按非边界处理）。
+1. 调 `mcp__narracat_memory__novel_get_arc(chapter=chapter_num)`，取返回的 is_arc_end / is_volume_end 与 arc、volume 信息（found == false 时按非边界处理）。
 2. 并行派发（四个任务可同时执行，互不依赖）：
 
 ```
@@ -209,12 +209,12 @@ Task B（memory-keeper）: "第 {chapter_num} 章收尾入库。本任务不做�
 {is_volume_end == true 时追加: 本章为第 {volume_no} 卷末章，入库后需提交该卷的压缩摘要。}"
 ```
 
-3. 四个任务全部完成后，主会话调 `mcp__plugin_narracat_novelmemory__novel_commit_extraction_union(chapter=chapter_num)`，把各轮暂存的事实合并落库。看返回的 `staged_runs`：
+3. 四个任务全部完成后，主会话调 `mcp__narracat_memory__novel_commit_extraction_union(chapter=chapter_num)`，把各轮暂存的事实合并落库。看返回的 `staged_runs`：
    - `staged_runs == 0`（三轮抽取均未暂存，疑似全部失败）→ **不进入第 4 点**：调 novel_checkpoint(step=3)（退回正文已生成），向用户报告「第 {chapter_num} 章事实抽取全部失败、本章未沉淀事实，请重试 /narracat:write {chapter_num}」，终止。
    - `1 ≤ staged_runs < 3` → 正常落库，向用户附一句「本章仅 {staged_runs} 轮抽取成功，事实样本偏少」提示后继续。
    - `staged_runs == 3` → 正常继续。
-4. （staged_runs ≥ 1 时）调 `mcp__plugin_narracat_novelmemory__novel_check_state_delivery(chapter=chapter_num)` 做计划状态变更兑现比对（机械匹配，命中项自动落账）：若返回的 `undelivered` 非空，保留待「完成输出」呈现，不阻断收尾、不自动顺延（处置交用户）。
-5. 调 `mcp__plugin_narracat_novelmemory__novel_detect_conflicts(chapter=chapter_num)` 对刚落库的事实做生成后时序 / 状态冲突体检（只读、只标不改）：若 `conflict_count > 0`，保留返回的 `report` 待「完成输出」呈现，不阻断收尾、不自动改记忆（修订交用户）。然后 novel_checkpoint(step=6)，再调 `mcp__plugin_narracat_novelmemory__novel_update_progress(chapter=chapter_num)` 更新进度并清除断点。
+4. （staged_runs ≥ 1 时）调 `mcp__narracat_memory__novel_check_state_delivery(chapter=chapter_num)` 做计划状态变更兑现比对（机械匹配，命中项自动落账）：若返回的 `undelivered` 非空，保留待「完成输出」呈现，不阻断收尾、不自动顺延（处置交用户）。
+5. 调 `mcp__narracat_memory__novel_detect_conflicts(chapter=chapter_num)` 对刚落库的事实做生成后时序 / 状态冲突体检（只读、只标不改）：若 `conflict_count > 0`，保留返回的 `report` 待「完成输出」呈现，不阻断收尾、不自动改记忆（修订交用户）。然后 novel_checkpoint(step=6)，再调 `mcp__narracat_memory__novel_update_progress(chapter=chapter_num)` 更新进度并清除断点。
 
 novel_update_progress 会先核对交付合同并把草稿区正文原子搬进正式路径；返回 manuscript_contract 类错误时退回步骤 3 处理。
 
@@ -234,7 +234,7 @@ novel_update_progress 会先核对交付合同并把草稿区正文原子搬进�
 
 若任务书自检时曾提示需要改写的用词、放行时仍有残留，另起一行用作者能懂的话提醒一句本章任务书已内部检查处理过，不影响正文。
 
-收尾后调 `mcp__plugin_narracat_novelmemory__novel_list_candidate_characters(status="candidate", importance="major")`；若有影响剧情的重要候选角色待建档，另起一行提醒：「影响剧情的重要角色待建档：{名字列表}。需要时可在「小说角色」目录里为 ta 建档，或执行 /narracat:world create {名字}。」无重要候选则不输出此行（次要候选静默在目录里，不提醒）。
+收尾后调 `mcp__narracat_memory__novel_list_candidate_characters(status="candidate", importance="major")`；若有影响剧情的重要候选角色待建档，另起一行提醒：「影响剧情的重要角色待建档：{名字列表}。需要时可在「小说角色」目录里为 ta 建档，或执行 /narracat:world create {名字}。」无重要候选则不输出此行（次要候选静默在目录里，不提醒）。
 
 ## 错误处理
 

--- a/agent-core/narracat/mcp-server/package.json
+++ b/agent-core/narracat/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narracat/mcp-server",
-  "version": "4.0.179",
+  "version": "4.0.180",
   "description": "NovelMemory MCP Server - adapter between NarraCat Agent runtime and OpenMemory",
   "type": "module",
   "main": "dist/index.js",

--- a/agent-core/narracat/narracat.manifest.json
+++ b/agent-core/narracat/narracat.manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "narracat",
-  "version": "4.0.179",
+  "version": "4.0.180",
   "description": "NarraCat Agent Core — AI 辅助超长篇小说创作引擎（自有契约清单，App 层发现与校验的 SSOT）",
   "commands": ["init", "learn-craft", "plan", "reference", "review", "revise-premise", "rewrite", "setup", "status", "sync-chapter-memory", "world", "write", "writer-wizard"],
   "agents": ["outline-architect", "chapter-writer", "continuity-editor", "world-curator", "memory-keeper"],

--- a/agent-core/narracat/skills/novel-style-reference/SKILL.md
+++ b/agent-core/narracat/skills/novel-style-reference/SKILL.md
@@ -21,7 +21,7 @@ description: A real-novel writing style reference library backed by the novel_qu
 
 ## MCP 工具调用
 
-工具全名：`mcp__plugin_narracat_novelmemory__novel_query_style_reference`
+工具全名：`mcp__narracat_memory__novel_query_style_reference`
 
 **入参：**
 

--- a/docs/agents/prompt-ab-acceptance.md
+++ b/docs/agents/prompt-ab-acceptance.md
@@ -77,7 +77,7 @@ bun --no-cache run dev          # 必须在该臂的 checkout 里启动
 - 没有等价的 headless 跑法：一次 Agent run 由主进程装配（pi runtime + 每项目一个 NovelMemory
   utilityProcess + 权限闸），命令行单跑引擎 prompt 不等价，别拿它出 A/B 结论。
 - 工具白名单由 App 装配，`NARRACAT_COMMAND_ALLOWED_TOOLS` 已含全量 NovelMemory 工具
-  （`mcp__plugin_narracat_novelmemory__*`）；若自己写临时 runner，必须显式带上——
+  （`mcp__narracat_memory__*`）；若自己写临时 runner，必须显式带上——
   这是 2026-06-05 dogfood 踩过的坑。
 - 模型基准对齐 dogfood 现状（当前 DeepSeek V4 Pro），两臂必须同 provider 同模型。
 

--- a/electron/main/agent/runs/narracat-command.test.ts
+++ b/electron/main/agent/runs/narracat-command.test.ts
@@ -248,12 +248,12 @@ describe('NarraCat command run resolver', () => {
 
     // 写手只持有文件写入，零 MCP 写工具
     expect(chapterWriterSource).toContain('tools: Read, Write')
-    expect(chapterWriterSource).not.toContain('mcp__plugin_narracat_novelmemory__')
+    expect(chapterWriterSource).not.toContain('mcp__narracat_memory__')
     // 审校与记忆管理员只持有自己产物的提交工具
-    expect(continuityEditorSource).toContain('mcp__plugin_narracat_novelmemory__novel_submit_review')
-    expect(memoryKeeperSource).toContain('mcp__plugin_narracat_novelmemory__novel_commit_chapter')
-    expect(memoryKeeperSource).toContain('mcp__plugin_narracat_novelmemory__novel_submit_extraction')
-    expect(memoryKeeperSource).toContain('mcp__plugin_narracat_novelmemory__novel_consolidate')
+    expect(continuityEditorSource).toContain('mcp__narracat_memory__novel_submit_review')
+    expect(memoryKeeperSource).toContain('mcp__narracat_memory__novel_commit_chapter')
+    expect(memoryKeeperSource).toContain('mcp__narracat_memory__novel_submit_extraction')
+    expect(memoryKeeperSource).toContain('mcp__narracat_memory__novel_consolidate')
   })
 })
 

--- a/electron/main/agent/runs/narracat-command.ts
+++ b/electron/main/agent/runs/narracat-command.ts
@@ -44,7 +44,7 @@ const INTERACTIVE_COMMAND_GUARD = [
   '如果 command source 写了“追问”“收集回答”“用户认可后进入下一步”“确认”“需要调整”，都视为需要通过 AskUserQuestion 等待用户输入。',
 ].join('\n')
 const MEMORY_MCP_GUARD = [
-  'NovelMemory 边界约束：所有记忆查询、提交和回滚都必须通过 NarraCat Agent Core 暴露的 NovelMemory MCP 工具（mcp__plugin_narracat_novelmemory__*）完成。',
+  'NovelMemory 边界约束：所有记忆查询、提交和回滚都必须通过 NarraCat Agent Core 暴露的 NovelMemory MCP 工具（mcp__narracat_memory__*）完成。',
   '结构化数据按提交工具入库：章节收尾由 Task(narracat:memory-keeper) 经 novel_commit_chapter / novel_submit_extraction / novel_consolidate 提交；审校报告由 narracat:continuity-editor 经 novel_submit_review 提交；大纲由 narracat:outline-architect 经 novel_submit_outline / novel_submit_chapter_outline 提交。',
   '不要直接编辑 state.yaml 的 progress 与 checkpoint：进度用 novel_update_progress、检查点用 novel_checkpoint 写入。',
   '禁止生成、写入或执行任何直接访问 .narracat/memory.db 的脚本；禁止 import better-sqlite3、sqlite、sqlite-vec 或手写 SQL 修改 memory.db。',

--- a/electron/main/agent/runs/run-manager.test.ts
+++ b/electron/main/agent/runs/run-manager.test.ts
@@ -7,7 +7,10 @@ import { createNovelProjectFixture } from '../../novel/test-novel-fixture'
 import type { AgentEvent } from '@shared/types/agent'
 import type { AppConfig } from '@shared/types/config'
 import { POOL_DEFAULT_FIELDS } from '@shared/types/config'
-import { NARRACAT_NOVEL_MEMORY_MCP_TOOLS } from '../runtime/allowed-tools'
+import {
+  NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME,
+  NARRACAT_NOVEL_MEMORY_MCP_TOOLS,
+} from '../runtime/allowed-tools'
 import type { SdkLikeStartRunArgs as RunClaudeAgentQueryArgs } from './test-sdk-like-adapter'
 import {
   createSdkLikeTestAdapter,
@@ -900,7 +903,7 @@ describe('createAgentRunManager', () => {
         { type: 'local', path: '/workspace/narracat-decktop/agent-core/narracat' },
       ])
       expect(args.options.mcpServers).toMatchObject({
-        plugin_narracat_novelmemory: {
+        [NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME]: {
           command: expectedDevRuntimePath,
           args: ['/workspace/narracat-decktop/agent-core/narracat/mcp-server/dist/index.js'],
           env: {
@@ -982,10 +985,10 @@ describe('createAgentRunManager', () => {
 
     async function* runSdkQuery(args: RunClaudeAgentQueryArgs): AsyncIterable<unknown> {
       expect(args.options.allowedTools).toContain(
-        'mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack',
+        'mcp__narracat_memory__novel_build_writing_context_pack',
       )
-      expect(args.options.allowedTools).toContain('mcp__plugin_narracat_novelmemory__novel_commit_chapter')
-      expect(args.options.allowedTools).toContain('mcp__plugin_narracat_novelmemory__novel_update_progress')
+      expect(args.options.allowedTools).toContain('mcp__narracat_memory__novel_commit_chapter')
+      expect(args.options.allowedTools).toContain('mcp__narracat_memory__novel_update_progress')
       expect(args.options.allowedTools).toEqual(expect.arrayContaining(NARRACAT_NOVEL_MEMORY_MCP_TOOLS))
       expect(args.options.allowedTools).not.toContain('Bash')
       expect(args.options.allowedTools).not.toContain('WebFetch')
@@ -995,7 +998,7 @@ describe('createAgentRunManager', () => {
       if (!canUseTool) throw new Error('expected canUseTool bridge')
       permissionResolved.resolve(
         await canUseTool(
-          'mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack',
+          'mcp__narracat_memory__novel_build_writing_context_pack',
           { chapter: 2 },
           {
             signal: new AbortController().signal,
@@ -1377,7 +1380,7 @@ describe('createAgentRunManager', () => {
       { type: 'local', path: '/workspace/narracat-decktop/agent-core/narracat' },
     ])
     expect(engineArgs?.options.mcpServers).toMatchObject({
-      plugin_narracat_novelmemory: {
+      [NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME]: {
         env: { NOVEL_CONFIG_PATH: '/novels/stars/.narracat/config.yaml' },
       },
     })

--- a/electron/main/agent/runtime/adapters/pi/pi-memory-tools.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-memory-tools.ts
@@ -1,6 +1,6 @@
 /**
  * NovelMemory 工具在 pi 的注册件（切片⑥）：43 个白名单工具以与 SDK 路径逐字一致的全限定名
- * （mcp__plugin_narracat_novelmemory__novel_*）注册为自定义工具——引擎 agent .md 的 tools 声明
+ * （mcp__narracat_memory__novel_*）注册为自定义工具——引擎 agent .md 的 tools 声明
  * 一字不改即生效。schema 用 Type.Unsafe 包引擎 JSON Schema 原文（tools.js SSOT，不复刻第二份）；
  * execute 剥前缀委托 MemoryToolChannel（生产 = memory-host utilityProcess RPC）。
  */
@@ -12,9 +12,9 @@ import { getMemoryHost } from '../../../../memory/index.ts'
 import type { MemoryHostPaths } from '../../../../memory/index.ts'
 import { loadMemoryToolDefinitions } from '../../../../memory/memory-tool-definitions.ts'
 import type { MemoryToolDefinition } from '../../../../memory/memory-tool-definitions.ts'
-import { NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME } from '../../allowed-tools.ts'
+import { NOVEL_MEMORY_TOOL_PREFIX } from '@shared/lib/novel-memory-tool-names'
 
-export const MEMORY_TOOL_PREFIX = `mcp__${NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME}__`
+export const MEMORY_TOOL_PREFIX = NOVEL_MEMORY_TOOL_PREFIX
 
 export type MemoryToolChannel = (
   tool: string,

--- a/electron/main/agent/runtime/adapters/pi/pi-tool-guard.test.ts
+++ b/electron/main/agent/runtime/adapters/pi/pi-tool-guard.test.ts
@@ -68,24 +68,24 @@ describe('mapSdkToolFaceToPi', () => {
     expect(blocked.includeTaskCards).toBe(false)
   })
 
-  test('mcp__plugin_narracat_novelmemory__* 进 memoryTools，其余 mcp__* 仍丢弃', () => {
+  test('mcp__narracat_memory__* 进 memoryTools，其余 mcp__* 仍丢弃', () => {
     const face = mapSdkToolFaceToPi([
       'Read',
-      'mcp__plugin_narracat_novelmemory__novel_query',
-      'mcp__plugin_narracat_novelmemory__novel_query',
+      'mcp__narracat_memory__novel_query',
+      'mcp__narracat_memory__novel_query',
       'mcp__other_server__something',
     ])
     expect(face.tools).toEqual(['read'])
-    expect(face.memoryTools).toEqual(['mcp__plugin_narracat_novelmemory__novel_query'])
+    expect(face.memoryTools).toEqual(['mcp__narracat_memory__novel_query'])
   })
 
   test('disallowedTools 挡记忆工具全限定名：不进 memoryTools（disallowed 判定在 memory 前缀判定之前生效）', () => {
     const face = mapSdkToolFaceToPi(
-      ['Read', 'mcp__plugin_narracat_novelmemory__novel_query', 'mcp__plugin_narracat_novelmemory__novel_search_memory'],
-      ['mcp__plugin_narracat_novelmemory__novel_query'],
+      ['Read', 'mcp__narracat_memory__novel_query', 'mcp__narracat_memory__novel_search_memory'],
+      ['mcp__narracat_memory__novel_query'],
     )
-    expect(face.memoryTools).toEqual(['mcp__plugin_narracat_novelmemory__novel_search_memory'])
-    expect(face.memoryTools).not.toContain('mcp__plugin_narracat_novelmemory__novel_query')
+    expect(face.memoryTools).toEqual(['mcp__narracat_memory__novel_search_memory'])
+    expect(face.memoryTools).not.toContain('mcp__narracat_memory__novel_query')
   })
 })
 

--- a/electron/main/agent/runtime/allowed-tools.test.ts
+++ b/electron/main/agent/runtime/allowed-tools.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+import {
+  MAX_QUALIFIED_TOOL_NAME_LENGTH,
+  NOVEL_MEMORY_TOOL_PREFIX,
+  qualifyNovelMemoryToolName,
+} from '@shared/lib/novel-memory-tool-names'
+import { NARRACAT_NOVEL_MEMORY_MCP_TOOLS } from './allowed-tools'
+
+/**
+ * 工具全限定名长度守卫（社区 issue #12）。
+ *
+ * 越界不会在开发机上暴露：日常用的 deepseek 端点不校验工具名长度，Anthropic 官方给到
+ * 128。真正会拒的是 OpenAI Chat Completions wire（上限 64，custom 渠道自 #5 刀 1 起可选），
+ * 以及部分把名字截断改写成 hash 的兼容网关——后者更坏，模型收到的是 `Tool not found`，
+ * 现象完全不指向长度。所以这条必须是自动守卫，不能靠人记住。
+ */
+describe('NovelMemory 工具全限定名长度', () => {
+  test(`工具面上注册的每个全限定名都不超过 ${MAX_QUALIFIED_TOOL_NAME_LENGTH} 字符`, () => {
+    const offenders = NARRACAT_NOVEL_MEMORY_MCP_TOOLS.filter(
+      (name) => name.length > MAX_QUALIFIED_TOOL_NAME_LENGTH,
+    ).map((name) => `${name}（${name.length}，超 ${name.length - MAX_QUALIFIED_TOOL_NAME_LENGTH}）`)
+
+    // 报出具体是谁、超了多少——守卫红的时候要能直接改，不要只说「有一个太长」。
+    expect(offenders).toEqual([])
+  })
+
+  test(`引擎 SSOT 里的每个工具都能安全进工具面（不超过 ${MAX_QUALIFIED_TOOL_NAME_LENGTH} 字符）`, () => {
+    // 覆盖面比上一条宽：白名单之外的工具（App 确定性直调那批）当下不进工具面、不受限制，
+    // 但它们随时可能被加进白名单。在引擎侧就守住，比等加白名单那天才发现要早一步。
+    const toolsSource = readFileSync(
+      join(import.meta.dir, '../../../../agent-core/narracat/mcp-server/src/tools.ts'),
+      'utf-8',
+    )
+    const engineToolNames = [
+      ...new Set([...toolsSource.matchAll(/name:\s*"(novel_[a-z_]+)"/g)].map((match) => match[1])),
+    ]
+
+    // 读不到工具定义就是守卫失效（路径变了/正则失配），必须响而不是静默通过。
+    expect(engineToolNames.length).toBeGreaterThan(40)
+
+    const offenders = engineToolNames
+      .map((name) => qualifyNovelMemoryToolName(name))
+      .filter((name) => name.length > MAX_QUALIFIED_TOOL_NAME_LENGTH)
+      .map((name) => `${name}（${name.length}）`)
+
+    expect(offenders).toEqual([])
+  })
+
+  test('前缀本身留有余量，不至于一加工具就越界', () => {
+    // 前缀吃掉的每个字符都从工具名的可用长度里扣。曾用的
+    // `mcp__plugin_narracat_novelmemory__` 是 34 字符，只给工具名留 30——而引擎里最长的
+    // 工具名有 36 字符，于是 7 个工具直接越界。这条把前缀本身钉在合理范围内。
+    expect(NOVEL_MEMORY_TOOL_PREFIX.length).toBeLessThanOrEqual(24)
+  })
+})

--- a/electron/main/agent/runtime/allowed-tools.ts
+++ b/electron/main/agent/runtime/allowed-tools.ts
@@ -3,10 +3,17 @@
  * 两个 adapter 与六条 run 路径共用，不再借住任何具体 runtime 目录。
  */
 
+import {
+  NOVEL_MEMORY_MCP_SERVER_NAME,
+  qualifyNovelMemoryToolName,
+} from '@shared/lib/novel-memory-tool-names'
+
 /** 缺省工具面：pi adapter 与 claude-sdk adapter 共用，避免硬编码副本漂移（切片③终审修复）。 */
 export const DEFAULT_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'Bash', 'Skill']
 
-export const NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME = 'plugin_narracat_novelmemory'
+// server 段与前缀是两进程共用契约（渲染端 tool-phrase.ts 按同一前缀反解人读动作名），
+// 定义在 shared/lib/novel-memory-tool-names.ts；此处 re-export 保持既有 import 路径不变。
+export const NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME = NOVEL_MEMORY_MCP_SERVER_NAME
 
 export const NARRACAT_NOVEL_MEMORY_MCP_TOOL_NAMES = [
   'novel_query',
@@ -64,9 +71,7 @@ export const NARRACAT_NOVEL_MEMORY_MCP_TOOL_NAMES = [
   // 不面向真实小说创作会话，agent 不得调用——engine 侧 tools.ts 描述已写明「App 造包中心专用」。
 ]
 
-export const NARRACAT_NOVEL_MEMORY_MCP_TOOLS = NARRACAT_NOVEL_MEMORY_MCP_TOOL_NAMES.map(
-  (toolName) => `mcp__${NARRACAT_NOVEL_MEMORY_MCP_SERVER_NAME}__${toolName}`,
-)
+export const NARRACAT_NOVEL_MEMORY_MCP_TOOLS = NARRACAT_NOVEL_MEMORY_MCP_TOOL_NAMES.map(qualifyNovelMemoryToolName)
 
 export const NARRACAT_COMMAND_ALLOWED_TOOLS = [
   'Read',

--- a/shared/lib/novel-memory-tool-names.test.ts
+++ b/shared/lib/novel-memory-tool-names.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  MAX_QUALIFIED_TOOL_NAME_LENGTH,
+  NOVEL_MEMORY_MCP_SERVER_NAME,
+  NOVEL_MEMORY_TOOL_PREFIX,
+  qualifyNovelMemoryToolName,
+  unqualifyNovelMemoryToolName,
+} from './novel-memory-tool-names'
+
+describe('NovelMemory 工具名常量', () => {
+  test('前缀由 server 段拼成 mcp__<server>__', () => {
+    expect(NOVEL_MEMORY_TOOL_PREFIX).toBe(`mcp__${NOVEL_MEMORY_MCP_SERVER_NAME}__`)
+  })
+
+  test('长度上限取各家 wire 里最严的 64（OpenAI Chat Completions）', () => {
+    expect(MAX_QUALIFIED_TOOL_NAME_LENGTH).toBe(64)
+  })
+
+  test('qualify 与 unqualify 往返还原', () => {
+    const engineName = 'novel_list_candidate_characters'
+    const qualified = qualifyNovelMemoryToolName(engineName)
+
+    expect(qualified).toBe(`${NOVEL_MEMORY_TOOL_PREFIX}${engineName}`)
+    expect(unqualifyNovelMemoryToolName(qualified)).toBe(engineName)
+  })
+
+  test('unqualify 对不带本前缀的名字原样返回', () => {
+    // 工具面上还有 Read / Grep 这类非 MCP 工具，以及其他 server 的 mcp__ 工具；
+    // 剥前缀时不能把它们误伤成空串或截断。
+    expect(unqualifyNovelMemoryToolName('Read')).toBe('Read')
+    expect(unqualifyNovelMemoryToolName('mcp__other_server__do_thing')).toBe(
+      'mcp__other_server__do_thing',
+    )
+  })
+})

--- a/shared/lib/novel-memory-tool-names.ts
+++ b/shared/lib/novel-memory-tool-names.ts
@@ -1,0 +1,50 @@
+/**
+ * NovelMemory 工具全限定名的单一来源（两进程共用，ADR-0036）。
+ *
+ * 工具以 `mcp__<server>__<tool>` 的形状注册进 pi 的工具面。这个形状是历史遗留的
+ * 命名约定——claude-sdk 时代它确实对应一个 MCP server 连接，pi 时代生产路径上
+ * NovelMemory 工具全部由 `pi-memory-tools.ts` 以自定义工具注册、execute 剥前缀后
+ * 委托 memory-host utilityProcess RPC，没有任何按此名 spawn 的 MCP 进程。
+ * 也就是说：**server 段现在纯粹是标识符**，改它不影响任何进程连接，只需全仓同步。
+ *
+ * 为什么两侧都要用这里的常量：主进程按前缀注册与守卫工具面，渲染进程按前缀把
+ * `mcp__…__novel_*` 反解成人读动作名（`tool-phrase.ts`）。此前渲染端硬编码了
+ * 一份 server 名副本，改名时漏改一侧不会报错，只会让工具卡悄悄退回「记忆引擎操作」
+ * 的兜底文案——这类漂移不该靠人记住。
+ */
+
+/**
+ * 工具全限定名的长度上限，取自各家 wire 里最严的那条。
+ *
+ * - Anthropic Messages wire：`^[a-zA-Z0-9_-]{1,128}$`（128）
+ * - OpenAI Chat Completions wire：`^[a-zA-Z0-9_-]{1,64}$`（**64**）
+ * - 部分 Anthropic 兼容网关：自行按 64 截断并改写成 hash 短名（社区 issue #12）
+ *
+ * custom 渠道自 #5 刀 1 起可选 openai wire，所以 64 是我们必须满足的实际下限，
+ * 不是「某个网关的怪癖」。越界的后果在 openai wire 上是请求被拒，在做 hash 改写的
+ * 网关上是模型收到 `Tool not found`——两者都不会指向真正的原因，所以用守卫挡在前面。
+ */
+export const MAX_QUALIFIED_TOOL_NAME_LENGTH = 64
+
+/**
+ * NovelMemory 工具全名里的 server 段。
+ *
+ * 曾用 `plugin_narracat_novelmemory`（27 字符），光前缀就吃掉 34，导致 7 个工具的
+ * 全限定名越过 64。缩短到 15 字符后最长的一个是 58，留 6 字符余量。
+ */
+export const NOVEL_MEMORY_MCP_SERVER_NAME = 'narracat_memory'
+
+/** 工具全限定名前缀：`mcp__narracat_memory__`。 */
+export const NOVEL_MEMORY_TOOL_PREFIX = `mcp__${NOVEL_MEMORY_MCP_SERVER_NAME}__`
+
+/** 引擎侧短名 → 工具面全限定名。 */
+export function qualifyNovelMemoryToolName(engineToolName: string): string {
+  return `${NOVEL_MEMORY_TOOL_PREFIX}${engineToolName}`
+}
+
+/** 全限定名 → 引擎侧短名；不带本前缀的名字原样返回（调用方按短名兜底）。 */
+export function unqualifyNovelMemoryToolName(qualifiedToolName: string): string {
+  return qualifiedToolName.startsWith(NOVEL_MEMORY_TOOL_PREFIX)
+    ? qualifiedToolName.slice(NOVEL_MEMORY_TOOL_PREFIX.length)
+    : qualifiedToolName
+}

--- a/src/components/workbench/agent/tool-phrase.test.ts
+++ b/src/components/workbench/agent/tool-phrase.test.ts
@@ -83,7 +83,7 @@ describe('getToolPhrase', () => {
   })
 })
 
-const NM = 'mcp__plugin_narracat_novelmemory__'
+const NM = 'mcp__narracat_memory__'
 
 describe('getToolPhrase · NovelMemory MCP 人读动作名', () => {
   test('已知工具映射为人读动作名', () => {

--- a/src/components/workbench/agent/tool-phrase.ts
+++ b/src/components/workbench/agent/tool-phrase.ts
@@ -1,4 +1,5 @@
 import { TOOL_PATH_INPUT_KEYS } from '@shared/lib/agent-path-scrub'
+import { NOVEL_MEMORY_MCP_SERVER_NAME } from '@shared/lib/novel-memory-tool-names'
 
 /**
  * 工具名有两代：当前 pi runtime 用小写内置名（read/write/edit/bash/grep/find/ls，
@@ -25,7 +26,7 @@ export const NARRACAT_AGENT_LABELS: Record<string, string> = {
 /**
  * NovelMemory MCP 工具 → 面向用户的人读动作名（CONTEXT「User-facing Agent action label」）。
  * 工具名定义权威在 agent-core mcp-server/src/tools.ts；本表持人读中文名，落实 ADR-0016 通道二
- * ——对话流不裸露 mcp__plugin_narracat_novelmemory__ / novel_* 技术标识。
+ * ——对话流不裸露 mcp__narracat_memory__ / novel_* 技术标识。
  * 新增/删除工具时与 tool-phrase.test.ts 对照测试同步（工具有而 App 缺 → 失败）。
  */
 export const NARRACAT_TOOL_LABELS: Record<string, string> = {
@@ -87,8 +88,8 @@ export const NARRACAT_TOOL_LABELS: Record<string, string> = {
   novel_list_style_anchors: '查阅本书样章锚',
 }
 
-/** SDK 工具全名 `mcp__<server>__<tool>` 里 NovelMemory MCP 的 server 段。 */
-const NARRACAT_NOVELMEMORY_SERVER = 'plugin_narracat_novelmemory'
+/** 工具全名 `mcp__<server>__<tool>` 里 NovelMemory 的 server 段——与主进程同源，见 shared 常量。 */
+const NARRACAT_NOVELMEMORY_SERVER = NOVEL_MEMORY_MCP_SERVER_NAME
 /** 未登记的 NovelMemory 工具的友好降级名——不裸露技术标识。 */
 const NARRACAT_MEMORY_FALLBACK_LABEL = '记忆引擎操作'
 
@@ -291,7 +292,7 @@ export function getToolPhrase(toolName: string, rawInput?: ToolInput): ToolPhras
         const server = mcpParts[1]
         const tool = mcpParts.slice(2).join('_')
 
-        // NarraCat NovelMemory MCP：映射为人读动作名，绝不裸露 plugin_narracat_novelmemory / novel_* 技术标识
+        // NarraCat NovelMemory MCP：映射为人读动作名，绝不裸露 narracat_memory / novel_* 技术标识
         if (server === NARRACAT_NOVELMEMORY_SERVER) {
           return phrase(NARRACAT_TOOL_LABELS[tool] ?? NARRACAT_MEMORY_FALLBACK_LABEL)
         }


### PR DESCRIPTION
## 改动概述

把 NovelMemory 工具全限定名里的 server 段 `plugin_narracat_novelmemory`(27) 缩短为 `narracat_memory`(15)，让 52 个工具的全限定名全部落到 64 字符以内，并加守卫钉住。

## 为什么要做

**不改会怎样**：工具以 `mcp__<server>__<tool>` 注册，旧前缀 34 字符，导致 7 个工具越过 64：

| 全限定名 | 旧长度 | 新长度 |
|---|---:|---:|
| `…__novel_get_character_dialogue_samples` | 70 | 58 |
| `…__novel_register_candidate_character` | 68 | 56 |
| `…__novel_update_chapter_state_changes` | 68 | 56 |
| `…__novel_build_writing_context_pack` | 66 | 54 |
| `…__novel_list_candidate_characters` | 65 | 53 |
| `…__novel_update_outline_book_field` | 65 | 53 |
| `…__novel_check_manuscript_contract` | 65 | 53 |

各家 wire 的实际上限核实过：**Anthropic Messages 128**（`^[a-zA-Z0-9_-]{1,128}$`）、**OpenAI Chat Completions 64**、部分兼容网关自行按 64 截断改写成 hash 短名。

关键点：自 **#5 刀 1（PR #13）** 起 custom 渠道可选 openai wire，所以 64 是**我们必须满足的下限**，不是某个第三方网关的怪癖——这扇门是我们自己开的，门框没量。日常没暴露只因为 dogfood 一直走 deepseek，它不校验工具名长度。

## 为什么不按 issue 里提的方案做

#12 提的是「按网关算法（前缀 + SHA-256 前 9 位 hex）预注册短名别名」。两个问题：

1. **把第三方私有实现细节焊进主干**——那个 hash 规则不是任何标准的一部分，网关改算法我们就静默失配，表现还是 `Tool not found`。
2. **解决不了 openai wire**——OpenAI 端点不做 hash 改写，它直接拒。而这条路径才是我们自己要负责的。

## 改名为什么安全

claude-sdk 全链退役后，pi 生产路径上 NovelMemory 工具全部由 `pi-memory-tools.ts` 以**自定义工具**注册、`execute` 剥前缀后委托 memory-host utilityProcess RPC，**没有任何按此名 spawn 的 MCP 进程**——`mcpServers` 配置如今只剩 `test-sdk-like-adapter.ts` 这个测试 fixture 在用。`mcp-server/dist` 里不含 server 名也印证了这一点（故 dist 无需重建）。

## 顺手收口的漂移点

server 名此前有**两份硬编码副本**：主进程 `allowed-tools.ts` 与渲染进程 `tool-phrase.ts`。改名时漏改一侧不会报错，只会让工具卡悄悄退回「记忆引擎操作」的兜底文案。现收口到 `shared/lib/novel-memory-tool-names.ts`（两进程共用层，ADR-0036）。

`run-manager.test.ts` 里两处 `mcpServers` 的对象 key 字面量同样改成引用常量——这次全量测试就是被这两处绊住的，留着字面量下次还会绊。

## 守卫（已实测会红）

新增三条断言，把 server 名改回旧值时全部转红，且逐条报出「谁超了多少」：

```
+ "mcp__plugin_narracat_novelmemory__novel_register_candidate_character（68，超 4）",
+ "mcp__plugin_narracat_novelmemory__novel_build_writing_context_pack（66，超 2）",
  ...
```

1. 工具面上注册的每个全限定名 ≤ 64
2. **引擎 SSOT 里每个工具**都能安全进工具面——覆盖面比第 1 条宽，白名单外那批 App 直调工具当下不受限，但随时可能被加进白名单，早红一步
3. 前缀本身 ≤ 24，不至于一加工具就越界

## 已知影响

改名前开始、改名后 resume 的老会话，历史消息里带的是旧工具名，模型可能照旧名调用一次再改用新名。工作台写章节默认跑干净上下文，影响面很小。**不为此保留旧名别名**——旧名超 64，留着等于把问题带回来。

## 测试

| 验证 | 结果 |
|---|---|
| `typecheck` | ✅ |
| `bun test` | ✅ 3179 pass / 0 fail（317 文件，新增 7 条断言） |
| `check:design` | ✅ |
| `check:architecture` | ✅ 0 violation |
| `build` | ✅ |
| `verify:narracat-agent-core` | ✅ 版本一致 4.0.180 |

引擎版本按 bump 流程走四处：`CLAUDE.md` 基准 + `narracat.manifest.json` + `mcp-server/package.json` + `narracat-agent-core.lock.json`。

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A