### PR TITLE
feat(diagnostics): 渲染进程崩溃 / 子进程退出 / 主线程卡死留痕 (#39 取证半边)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -13,6 +13,53 @@ import { createAgentQuitController } from './agent/runs/agent-quit-controller.ts
 import { resolveNarraCatAgentCorePath } from './engine/engine.ts'
 import { maybeRunMemorySmoke } from './memory/memory-smoke.ts'
 import { startUpdater } from './updater/updater-runtime.ts'
+import {
+  attachAppProcessHealthWatcher,
+  attachWindowProcessHealthWatchers,
+  createProcessHealthStore,
+  type ProcessHealthStore,
+} from './process-health.ts'
+import { setProcessHealthStore } from './ipc/app.ts'
+
+/**
+ * 进程健康取证（#39）的 store。窗口创建早于 app.whenReady 完成的场景不存在，
+ * 但 restoreMainWindow / activate 在模块顶层定义，故用懒初始化而不是模块常量。
+ */
+let processHealthStore: ProcessHealthStore | null = null
+
+function ensureProcessHealthStore(): ProcessHealthStore {
+  processHealthStore ??= createProcessHealthStore({
+    userDataPath: app.getPath('userData'),
+    appVersion: app.getVersion(),
+  })
+  return processHealthStore
+}
+
+/**
+ * 唯一的建窗口入口：createMainWindow 之外还要挂进程健康监听。
+ * 三处建窗口的地方（首启 / activate / restoreMainWindow）都必须走这里，
+ * 否则那个窗口的崩溃与挂死就是静默的——正是 #39 要消灭的状态。
+ */
+function spawnMainWindow(): BrowserWindow {
+  const win = createMainWindow()
+  attachWindowProcessHealthWatchers(win, {
+    store: ensureProcessHealthStore(),
+    promptReload: async (message, detail) => {
+      const { response } = await dialog.showMessageBox({
+        type: 'error',
+        title: 'NarraCat 界面需要重新加载',
+        message,
+        detail,
+        buttons: ['重新加载', '稍后'],
+        defaultId: 0,
+        cancelId: 1,
+        noLink: true,
+      })
+      return response === 0
+    },
+  })
+  return win
+}
 
 async function main() {
   await app.whenReady()
@@ -24,9 +71,17 @@ async function main() {
   if (await maybeRunMemorySmoke({ appRoot, resourcesPath, userDataPath, agentCorePath })) return
 
   registerAllIpcHandlers()
+  // 子进程崩溃是进程级事件（GPU / utility，NovelMemory 就跑在 utilityProcess 上），
+  // 只挂一次；挂在窗口上会随窗口数量重复记录同一次崩溃。
+  const healthStore = ensureProcessHealthStore()
+  setProcessHealthStore(healthStore)
+  attachAppProcessHealthWatcher({
+    store: healthStore,
+    onChildGone: (listener) => app.on('child-process-gone', listener),
+  })
   app.on('activate', () => {
     // macOS：关闭所有窗口后点 dock 重新打开
-    if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
+    if (BrowserWindow.getAllWindows().length === 0) spawnMainWindow()
   })
   // 必须排在 createMainWindow() 之前：拦截页（版本过旧强更）在门控判定一回来就渲染，
   // 用户可能立刻点「立即更新并重启」；若 startUpdater() 排在 reconcileAgentRuntimeStartup()
@@ -35,7 +90,7 @@ async function main() {
   // 发起首次检查，提前调用没有副作用代价。
   startUpdater()
   await reconcileAgentRuntimeStartup()
-  if (BrowserWindow.getAllWindows().length === 0) createMainWindow()
+  if (BrowserWindow.getAllWindows().length === 0) spawnMainWindow()
 }
 
 app.on('window-all-closed', () => {
@@ -44,7 +99,7 @@ app.on('window-all-closed', () => {
 })
 
 function restoreMainWindow(): void {
-  const window = BrowserWindow.getAllWindows()[0] ?? createMainWindow()
+  const window = BrowserWindow.getAllWindows()[0] ?? spawnMainWindow()
   if (window.isMinimized()) window.restore()
   window.show()
   window.focus()

--- a/electron/main/ipc/app.ts
+++ b/electron/main/ipc/app.ts
@@ -17,6 +17,8 @@ import { deleteApiKey, getApiKey, hasApiKey, setApiKey } from '../secrets.ts'
 import { testProviderConnection, type ConnectionTestResult } from '../provider-test.ts'
 import { fetchProviderModels } from '../provider-models.ts'
 import type { ProviderModelListResult } from '@shared/types/ipc'
+import type { ProcessHealthReport } from '@shared/types/process-health'
+import type { ProcessHealthStore } from '../process-health.ts'
 import {
   listResultNotifications,
   markAllResultNotificationsRead,
@@ -100,6 +102,16 @@ function sessionConfigBasis(config: AppConfig): string {
   })
 }
 
+/**
+ * 进程健康取证 store（#39）。由 index.ts 在 app ready 后注入——handler 注册早于 store 创建，
+ * 未注入时诊断页拿到空记录而不是报错（取证缺失不该让设置页打不开）。
+ */
+let processHealthStore: ProcessHealthStore | null = null
+
+export function setProcessHealthStore(store: ProcessHealthStore): void {
+  processHealthStore = store
+}
+
 export function registerAppIpcHandlers(): void {
   // 测试端点：渲染端调用 window.electron.ping() 应该拿到 'pong-{timestamp}'
   ipcMain.handle('ping', () => {
@@ -117,6 +129,12 @@ export function registerAppIpcHandlers(): void {
         // 窗口销毁竞态等边缘情况静默忽略，不影响主流程。
       }
     }
+  })
+
+  // 进程健康记录（#39）：设置-关于的诊断折叠读它，作者截图即可求助。
+  ipcMain.handle('app:get-process-health', async (): Promise<ProcessHealthReport> => {
+    if (!processHealthStore) return { events: [], logPath: '' }
+    return processHealthStore.read()
   })
 
   // 内测软过期 + 远程急刹车（#354）：渲染端启动时查一次，命中则显示拦截页。

--- a/electron/main/process-health.test.ts
+++ b/electron/main/process-health.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from 'bun:test'
+import type { BrowserWindow } from 'electron'
+import {
+  attachAppProcessHealthWatcher,
+  attachWindowProcessHealthWatchers,
+  createProcessHealthStore,
+  CRASH_PROMPT_COOLDOWN_MS,
+  type ChildProcessGoneDetails,
+} from './process-health.ts'
+
+function createMemoryStore() {
+  let content: string | null = null
+  const store = createProcessHealthStore({
+    userDataPath: '/tmp/narracat-test',
+    appVersion: '0.2.65',
+    now: () => new Date('2026-08-25T10:30:00.000Z'),
+    readFileImpl: (async () => {
+      if (content === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return content
+    }) as never,
+    writeFileImpl: async (_path, next) => {
+      content = next
+    },
+  })
+  return store
+}
+
+/** 最小 BrowserWindow 替身：只实现被监听的三个事件与 reload / isDestroyed。 */
+function createFakeWindow() {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+  const add = (event: string, listener: (...args: unknown[]) => void) => {
+    listeners.set(event, [...(listeners.get(event) ?? []), listener])
+  }
+  const remove = (event: string, listener: (...args: unknown[]) => void) => {
+    listeners.set(event, (listeners.get(event) ?? []).filter((item) => item !== listener))
+  }
+
+  let reloadCount = 0
+  const win = {
+    webContents: { on: add, off: remove },
+    on: add,
+    off: remove,
+    isDestroyed: () => false,
+    reload: () => {
+      reloadCount += 1
+    },
+  }
+
+  return {
+    win: win as unknown as BrowserWindow,
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of listeners.get(event) ?? []) listener(...args)
+    },
+    listenerCount: (event: string) => (listeners.get(event) ?? []).length,
+    reloadCount: () => reloadCount,
+  }
+}
+
+describe('createProcessHealthStore', () => {
+  test('记录带上时间戳与客户端版本——作者未必说得清当时用的哪版', async () => {
+    const store = createMemoryStore()
+    await store.record({ kind: 'renderer-gone', reason: 'crashed', exitCode: 133 })
+
+    const { events } = await store.read()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      kind: 'renderer-gone',
+      reason: 'crashed',
+      exitCode: 133,
+      at: '2026-08-25T10:30:00.000Z',
+      appVersion: '0.2.65',
+    })
+  })
+
+  test('记录文件不存在时读出空记录，不抛错', async () => {
+    const store = createMemoryStore()
+    expect(await store.read()).toMatchObject({ events: [] })
+  })
+
+  test('落盘失败不把 App 拖垮——取证跑在「已经出事了」的路径上', async () => {
+    const store = createProcessHealthStore({
+      userDataPath: '/tmp/narracat-test',
+      appVersion: '0.2.65',
+      readFileImpl: (async () => '[]') as never,
+      writeFileImpl: async () => {
+        throw new Error('磁盘满了')
+      },
+    })
+
+    // 不 reject 即为通过
+    await store.record({ kind: 'renderer-gone', reason: 'crashed', exitCode: 1 })
+  })
+})
+
+describe('attachWindowProcessHealthWatchers', () => {
+  test('clean-exit 不记录也不提示——正常关窗口就会触发它', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+    let prompts = 0
+
+    attachWindowProcessHealthWatchers(fake.win, {
+      store,
+      promptReload: async () => {
+        prompts += 1
+        return false
+      },
+    })
+    fake.emit('render-process-gone', {}, { reason: 'clean-exit', exitCode: 0 })
+    await Promise.resolve()
+
+    expect(prompts).toBe(0)
+    expect((await store.read()).events).toHaveLength(0)
+  })
+
+  test('崩溃时留痕并询问作者，选「重新加载」才 reload', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+
+    attachWindowProcessHealthWatchers(fake.win, { store, promptReload: async () => true })
+    fake.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events[0]).toMatchObject({ kind: 'renderer-gone', reason: 'crashed' })
+    expect(fake.reloadCount()).toBe(1)
+  })
+
+  test('作者选「稍后」时不 reload', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+
+    attachWindowProcessHealthWatchers(fake.win, { store, promptReload: async () => false })
+    fake.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fake.reloadCount()).toBe(0)
+  })
+
+  test('崩溃循环时冷却期内只提示一次，但每次都留痕', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+    let prompts = 0
+    let clock = 0
+
+    attachWindowProcessHealthWatchers(fake.win, {
+      store,
+      now: () => clock,
+      promptReload: async () => {
+        prompts += 1
+        return false
+      },
+    })
+
+    fake.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    clock = CRASH_PROMPT_COOLDOWN_MS - 1
+    fake.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(prompts).toBe(1)
+    // 提示被抑制不代表事件被丢弃——取证要完整，否则崩溃循环反而看不出来
+    expect((await store.read()).events).toHaveLength(2)
+
+    clock = CRASH_PROMPT_COOLDOWN_MS + 1
+    fake.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 133 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(prompts).toBe(2)
+  })
+
+  test('unresponsive 只在配对到 responsive 后落一条带时长的记录，且不弹框', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+    let prompts = 0
+    let clock = 1_000
+
+    attachWindowProcessHealthWatchers(fake.win, {
+      store,
+      now: () => clock,
+      promptReload: async () => {
+        prompts += 1
+        return false
+      },
+    })
+
+    fake.emit('unresponsive')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // 还没恢复：不该有记录，更不该打断作者
+    expect((await store.read()).events).toHaveLength(0)
+    expect(prompts).toBe(0)
+
+    clock = 9_400
+    fake.emit('responsive')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events[0]).toMatchObject({
+      kind: 'main-thread-blocked',
+      blockedMs: 8_400,
+    })
+    expect(prompts).toBe(0)
+  })
+
+  test('没有配对的 responsive 不产生记录', async () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+
+    attachWindowProcessHealthWatchers(fake.win, { store, promptReload: async () => false })
+    fake.emit('responsive')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events).toHaveLength(0)
+  })
+
+  test('返回的解绑函数摘干净三个监听', () => {
+    const store = createMemoryStore()
+    const fake = createFakeWindow()
+
+    const detach = attachWindowProcessHealthWatchers(fake.win, { store, promptReload: async () => false })
+    expect(fake.listenerCount('render-process-gone')).toBe(1)
+    expect(fake.listenerCount('unresponsive')).toBe(1)
+    expect(fake.listenerCount('responsive')).toBe(1)
+
+    detach()
+    expect(fake.listenerCount('render-process-gone')).toBe(0)
+    expect(fake.listenerCount('unresponsive')).toBe(0)
+    expect(fake.listenerCount('responsive')).toBe(0)
+  })
+})
+
+describe('attachAppProcessHealthWatcher', () => {
+  test('记录 utility 进程崩溃——NovelMemory 就跑在 utilityProcess 上', async () => {
+    const store = createMemoryStore()
+    let listener: ((event: unknown, details: ChildProcessGoneDetails) => void) | null = null
+
+    attachAppProcessHealthWatcher({
+      store,
+      onChildGone: (fn) => {
+        listener = fn
+      },
+    })
+    listener?.({}, {
+      type: 'Utility',
+      reason: 'crashed',
+      exitCode: 11,
+      name: 'Node Utility Process',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events[0]).toMatchObject({
+      kind: 'child-gone',
+      processType: 'Utility',
+      processName: 'Node Utility Process',
+      reason: 'crashed',
+      exitCode: 11,
+    })
+  })
+
+  test('子进程 clean-exit 同样不记录', async () => {
+    const store = createMemoryStore()
+    let listener: ((event: unknown, details: ChildProcessGoneDetails) => void) | null = null
+
+    attachAppProcessHealthWatcher({ store, onChildGone: (fn) => { listener = fn } })
+    listener?.({}, { type: 'GPU', reason: 'clean-exit', exitCode: 0 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events).toHaveLength(0)
+  })
+
+  test('没有 name 时退化到 serviceName', async () => {
+    const store = createMemoryStore()
+    let listener: ((event: unknown, details: ChildProcessGoneDetails) => void) | null = null
+
+    attachAppProcessHealthWatcher({ store, onChildGone: (fn) => { listener = fn } })
+    listener?.({}, { type: 'Utility', reason: 'oom', exitCode: 9, serviceName: 'network.mojom.NetworkService' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect((await store.read()).events[0]).toMatchObject({
+      processName: 'network.mojom.NetworkService',
+    })
+  })
+})

--- a/electron/main/process-health.ts
+++ b/electron/main/process-health.ts
@@ -1,0 +1,175 @@
+/**
+ * 进程健康取证（#39）：渲染进程崩溃 / 子进程崩溃 / 主线程挂死留痕。
+ *
+ * 在此之前这三类事件在 App 里完全静默——作者看到白屏或点不动，我们拿不到任何信息。
+ * 这里做三件事，且只做这三件：
+ *   1. 留痕：事件落进 userData 的 JSON，重启后仍在（崩溃诊断最需要的恰恰是「上次崩的那条」）
+ *   2. 给作者一句能看懂的话 + 一个「重新加载」的出口，而不是白屏干等
+ *   3. 把记录暴露到设置-关于的诊断信息里，作者截图即可求助
+ *
+ * 刻意不做的事：不自动重载（崩溃循环时会变成无限重启，且掩盖问题）、不上报任何服务端、
+ * 不因为 `unresponsive` 弹框（主线程阻塞几秒就会触发，写作中偶发一次不值得打断作者）。
+ */
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type { BrowserWindow } from 'electron'
+import type {
+  ProcessGoneReason,
+  ProcessHealthEvent,
+  ProcessHealthReport,
+} from '@shared/types/process-health'
+import {
+  describeReasonForAuthor,
+  isAbnormalReason,
+  parseProcessHealthEvents,
+  retainRecentEvents,
+  shouldPromptAuthor,
+} from '@shared/lib/process-health'
+import { atomicWriteFile } from './atomic-write.ts'
+
+/** 同一窗口两次崩溃提示的最小间隔：崩溃循环时不至于把作者按在弹框里。 */
+export const CRASH_PROMPT_COOLDOWN_MS = 60_000
+
+export const PROCESS_HEALTH_LOG_FILENAME = 'process-health.json'
+
+export interface ProcessHealthStoreDeps {
+  userDataPath: string
+  appVersion: string
+  now?: () => Date
+  readFileImpl?: typeof readFile
+  writeFileImpl?: (path: string, content: string) => Promise<void>
+}
+
+export interface ProcessHealthStore {
+  record(event: Omit<ProcessHealthEvent, 'at' | 'appVersion'>): Promise<void>
+  read(): Promise<ProcessHealthReport>
+  logPath: string
+}
+
+export function createProcessHealthStore({
+  userDataPath,
+  appVersion,
+  now = () => new Date(),
+  readFileImpl = readFile,
+  writeFileImpl = (path, content) => atomicWriteFile(path, content),
+}: ProcessHealthStoreDeps): ProcessHealthStore {
+  const logPath = join(userDataPath, PROCESS_HEALTH_LOG_FILENAME)
+
+  async function readEvents(): Promise<ProcessHealthEvent[]> {
+    try {
+      return parseProcessHealthEvents(await readFileImpl(logPath, 'utf-8'))
+    } catch {
+      return []
+    }
+  }
+
+  return {
+    logPath,
+    async read() {
+      return { events: await readEvents(), logPath }
+    },
+    async record(event) {
+      const entry: ProcessHealthEvent = { ...event, at: now().toISOString(), appVersion }
+      const next = retainRecentEvents(await readEvents(), entry)
+      try {
+        await writeFileImpl(logPath, `${JSON.stringify(next, null, 2)}\n`)
+      } catch (error) {
+        // 取证写不进去不能反过来拖垮 App——它本来就是在「已经出事了」的路径上运行的。
+        console.error('[process-health] 事件落盘失败:', error)
+      }
+    },
+  }
+}
+
+export interface AttachProcessHealthWatchersDeps {
+  store: ProcessHealthStore
+  /** 崩溃后询问作者是否重新加载；返回 true 表示作者选择重载。 */
+  promptReload: (message: string, detail: string) => Promise<boolean>
+  now?: () => number
+}
+
+/**
+ * 给一个窗口挂上三类监听。返回解绑函数（测试与多窗口场景用）。
+ *
+ * `app.on('child-process-gone')` 是进程级的，不属于任何窗口，由 attachAppProcessHealthWatcher
+ * 单独挂一次——挂在窗口上会随窗口数量重复记录同一次崩溃。
+ */
+export function attachWindowProcessHealthWatchers(
+  win: BrowserWindow,
+  { store, promptReload, now = () => Date.now() }: AttachProcessHealthWatchersDeps,
+): () => void {
+  // null = 从未提示过。用 0 会让「首次崩溃」落进冷却窗口里被误抑制——真实环境的
+  // Date.now() 数值巨大所以碰巧不触发，但那是靠运气，注入时钟的测试一下就撞出来了。
+  let lastPromptAt: number | null = null
+  let blockedSince: number | null = null
+
+  const onRenderProcessGone = (_event: unknown, details: { reason: ProcessGoneReason; exitCode: number }) => {
+    if (!isAbnormalReason(details.reason)) return
+    void store.record({ kind: 'renderer-gone', reason: details.reason, exitCode: details.exitCode })
+    if (!shouldPromptAuthor(details.reason)) return
+
+    // 崩溃循环保护：reload 后立刻又崩时，不把作者按在连续弹框里。
+    const at = now()
+    if (lastPromptAt !== null && at - lastPromptAt < CRASH_PROMPT_COOLDOWN_MS) return
+    lastPromptAt = at
+
+    void promptReload(
+      describeReasonForAuthor(details.reason),
+      '已写入的小说内容都在磁盘上，不会因此丢失。可以重新加载界面继续；如果反复出现，请到「设置 - 关于 - 诊断信息」把记录发给我们。',
+    ).then((shouldReload) => {
+      if (shouldReload && !win.isDestroyed()) win.reload()
+    })
+  }
+
+  const onUnresponsive = () => {
+    blockedSince = now()
+  }
+
+  const onResponsive = () => {
+    if (blockedSince === null) return
+    void store.record({ kind: 'main-thread-blocked', blockedMs: now() - blockedSince })
+    blockedSince = null
+  }
+
+  win.webContents.on('render-process-gone', onRenderProcessGone)
+  win.on('unresponsive', onUnresponsive)
+  win.on('responsive', onResponsive)
+
+  return () => {
+    win.webContents.off('render-process-gone', onRenderProcessGone)
+    win.off('unresponsive', onUnresponsive)
+    win.off('responsive', onResponsive)
+  }
+}
+
+export interface AppProcessHealthWatcherDeps {
+  store: ProcessHealthStore
+  onChildGone: (listener: (event: unknown, details: ChildProcessGoneDetails) => void) => void
+}
+
+export interface ChildProcessGoneDetails {
+  type: string
+  reason: ProcessGoneReason
+  exitCode: number
+  serviceName?: string
+  name?: string
+}
+
+/**
+ * 进程级子进程崩溃留痕：覆盖 GPU 与 utility 进程。
+ *
+ * NovelMemory 跑在 utilityProcess 上，它挂掉目前只会让下一次工具调用报错，进程本身怎么没的
+ * 没有任何记录——而记忆库是产品的命根，这条留痕的价值高于 GPU 那条。
+ */
+export function attachAppProcessHealthWatcher({ store, onChildGone }: AppProcessHealthWatcherDeps): void {
+  onChildGone((_event, details) => {
+    if (!isAbnormalReason(details.reason)) return
+    void store.record({
+      kind: 'child-gone',
+      reason: details.reason,
+      exitCode: details.exitCode,
+      processType: details.type,
+      processName: details.name ?? details.serviceName,
+    })
+  })
+}

--- a/electron/preload/index.cts
+++ b/electron/preload/index.cts
@@ -6,6 +6,7 @@ const api = {
   revealProjectFolder: (projectPath: string) => ipcRenderer.invoke('novel:reveal-folder', projectPath),
   setTitleBarOverlaySymbolColor: (symbolColor: string) =>
     ipcRenderer.invoke('window:set-titlebar-overlay-symbol-color', symbolColor),
+  getProcessHealth: () => ipcRenderer.invoke('app:get-process-health'),
   checkReleaseGuard: () => ipcRenderer.invoke('release-guard:check'),
   getUpdaterState: () => ipcRenderer.invoke('updater:get-state'),
   checkForUpdates: () => ipcRenderer.invoke('updater:check'),

--- a/shared/lib/process-health.test.ts
+++ b/shared/lib/process-health.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test'
+import type { ProcessHealthEvent } from '@shared/types/process-health'
+import {
+  describeReasonForAuthor,
+  isAbnormalReason,
+  parseProcessHealthEvents,
+  retainRecentEvents,
+  shouldPromptAuthor,
+  summarizeProcessHealthEvent,
+} from './process-health'
+
+describe('isAbnormalReason', () => {
+  test('clean-exit 不算异常——关窗口与正常 reload 都会触发它', () => {
+    expect(isAbnormalReason('clean-exit')).toBe(false)
+  })
+
+  test('其余原因都要留痕', () => {
+    for (const reason of [
+      'abnormal-exit',
+      'killed',
+      'crashed',
+      'oom',
+      'launch-failed',
+      'integrity-failure',
+      'memory-eviction',
+    ] as const) {
+      expect(isAbnormalReason(reason)).toBe(true)
+    }
+  })
+})
+
+describe('shouldPromptAuthor', () => {
+  test('界面真的没了才打断作者', () => {
+    for (const reason of ['crashed', 'oom', 'abnormal-exit', 'killed'] as const) {
+      expect(shouldPromptAuthor(reason)).toBe(true)
+    }
+  })
+
+  test('clean-exit 不提示——否则每次关窗都弹一个「崩溃了」的框', () => {
+    expect(shouldPromptAuthor('clean-exit')).toBe(false)
+  })
+
+  test('memory-eviction 只留痕不提示：系统回收后台页面，Electron 会自行恢复', () => {
+    expect(shouldPromptAuthor('memory-eviction')).toBe(false)
+    expect(isAbnormalReason('memory-eviction')).toBe(true)
+  })
+})
+
+describe('describeReasonForAuthor', () => {
+  test('给作者的话里不出现 reason 原文这类技术黑话', () => {
+    for (const reason of ['crashed', 'oom', 'killed', 'launch-failed', 'integrity-failure'] as const) {
+      const message = describeReasonForAuthor(reason)
+      expect(message).not.toContain(reason)
+      expect(message.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('summarizeProcessHealthEvent', () => {
+  test('渲染进程退出保留 reason 与 exitCode，供回传排查', () => {
+    const summary = summarizeProcessHealthEvent({
+      kind: 'renderer-gone',
+      at: '2026-08-25T10:30:00.000Z',
+      reason: 'crashed',
+      exitCode: 133,
+    })
+
+    expect(summary).toContain('2026-08-25 10:30:00')
+    expect(summary).toContain('crashed')
+    expect(summary).toContain('133')
+  })
+
+  test('子进程退出优先显示进程名，退化到进程类型', () => {
+    const named = summarizeProcessHealthEvent({
+      kind: 'child-gone',
+      at: '2026-08-25T10:30:00.000Z',
+      reason: 'crashed',
+      exitCode: 1,
+      processType: 'Utility',
+      processName: 'Node Utility Process',
+    })
+    expect(named).toContain('Node Utility Process')
+
+    const unnamed = summarizeProcessHealthEvent({
+      kind: 'child-gone',
+      at: '2026-08-25T10:30:00.000Z',
+      reason: 'crashed',
+      exitCode: 1,
+      processType: 'GPU',
+    })
+    expect(unnamed).toContain('GPU')
+  })
+
+  test('主线程阻塞显示秒数；一直没恢复显示「未恢复」而不是 0s', () => {
+    expect(
+      summarizeProcessHealthEvent({
+        kind: 'main-thread-blocked',
+        at: '2026-08-25T10:30:00.000Z',
+        blockedMs: 8_400,
+      }),
+    ).toContain('8s')
+
+    expect(
+      summarizeProcessHealthEvent({
+        kind: 'main-thread-blocked',
+        at: '2026-08-25T10:30:00.000Z',
+      }),
+    ).toContain('未恢复')
+  })
+})
+
+describe('retainRecentEvents', () => {
+  const event = (at: string): ProcessHealthEvent => ({ kind: 'renderer-gone', at, reason: 'crashed', exitCode: 1 })
+
+  test('最近的在前', () => {
+    const result = retainRecentEvents([event('older')], event('newer'))
+    expect(result.map((item) => item.at)).toEqual(['newer', 'older'])
+  })
+
+  test('超出上限的丢弃，避免记录文件无限增长', () => {
+    const existing = Array.from({ length: 50 }, (_, index) => event(`old-${index}`))
+    const result = retainRecentEvents(existing, event('newest'), 50)
+
+    expect(result).toHaveLength(50)
+    expect(result[0].at).toBe('newest')
+    expect(result.at(-1)?.at).toBe('old-48')
+  })
+})
+
+describe('parseProcessHealthEvents', () => {
+  test('损坏的 JSON 当作没有记录——取证不该成为启动失败的原因', () => {
+    expect(parseProcessHealthEvents('{ 不是 json')).toEqual([])
+    expect(parseProcessHealthEvents('{"not":"an array"}')).toEqual([])
+  })
+
+  test('过滤掉形状不对的条目，保留合法的', () => {
+    const raw = JSON.stringify([
+      { kind: 'renderer-gone', at: '2026-08-25T10:30:00.000Z', reason: 'crashed', exitCode: 1 },
+      { garbage: true },
+      null,
+    ])
+
+    const parsed = parseProcessHealthEvents(raw)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].kind).toBe('renderer-gone')
+  })
+})

--- a/shared/lib/process-health.ts
+++ b/shared/lib/process-health.ts
@@ -1,0 +1,85 @@
+/**
+ * 进程健康事件的纯判定与格式化（#39），两进程共用：
+ * 主进程按这里的规则决定「记不记、提不提示」，渲染端按这里的规则把记录渲染成人话。
+ */
+import type { ProcessGoneReason, ProcessHealthEvent } from '@shared/types/process-health'
+
+/** 记录上限。取证只关心最近发生了什么，留太多既没用又会让文件无限长。 */
+export const MAX_RETAINED_EVENTS = 50
+
+/**
+ * `clean-exit` 是正常退出——关窗口、正常 reload 都会触发。记录它等于往取证里灌噪声，
+ * 提示它等于每次关窗都弹一个「崩溃了」的框。
+ */
+export function isAbnormalReason(reason: ProcessGoneReason): boolean {
+  return reason !== 'clean-exit'
+}
+
+/**
+ * 该不该打断作者。
+ *
+ * 只有渲染进程真的没了、UI 已经不可用时才提示——这时作者面对的是白屏，不提示他就只能干等。
+ * `launch-failed` / `integrity-failure` 同样致命（窗口起不来），一并提示。
+ * `memory-eviction` 是系统主动回收后台页面、Electron 会自行恢复，不打扰。
+ */
+export function shouldPromptAuthor(reason: ProcessGoneReason): boolean {
+  return (
+    reason === 'crashed' ||
+    reason === 'oom' ||
+    reason === 'abnormal-exit' ||
+    reason === 'killed' ||
+    reason === 'launch-failed' ||
+    reason === 'integrity-failure'
+  )
+}
+
+/** 给作者看的一句话——不出现 reason 原文这类技术黑话。 */
+export function describeReasonForAuthor(reason: ProcessGoneReason): string {
+  if (reason === 'oom') return '界面因为内存不足被系统回收了。'
+  if (reason === 'killed') return '界面进程被系统结束了。'
+  if (reason === 'launch-failed') return '界面没能启动起来。'
+  if (reason === 'integrity-failure') return '界面文件校验没通过。'
+  return '界面进程意外退出了。'
+}
+
+/**
+ * 诊断折叠里的一行摘要。
+ *
+ * 保留 reason / exitCode 原文——这一行的读者是「作者截图发给我们」之后的我们，
+ * 可读性让位于可诊断性；真正给作者读的是 describeReasonForAuthor 那句。
+ */
+export function summarizeProcessHealthEvent(event: ProcessHealthEvent): string {
+  const when = event.at.replace('T', ' ').replace(/\.\d+Z$/, '')
+  if (event.kind === 'main-thread-blocked') {
+    const duration = event.blockedMs === undefined ? '未恢复' : `${Math.round(event.blockedMs / 1000)}s`
+    return `${when} 界面卡住（${duration}）`
+  }
+  if (event.kind === 'child-gone') {
+    const who = event.processName ?? event.processType ?? '子进程'
+    return `${when} ${who} 退出（${event.reason}, code ${event.exitCode}）`
+  }
+  return `${when} 界面进程退出（${event.reason}, code ${event.exitCode}）`
+}
+
+/** 最近的在前，超出上限的丢弃。 */
+export function retainRecentEvents(
+  existing: ProcessHealthEvent[],
+  incoming: ProcessHealthEvent,
+  max: number = MAX_RETAINED_EVENTS,
+): ProcessHealthEvent[] {
+  return [incoming, ...existing].slice(0, max)
+}
+
+/** 读回落盘记录；文件缺失或损坏都当作「没有记录」——取证本身不该成为启动失败的原因。 */
+export function parseProcessHealthEvents(raw: string): ProcessHealthEvent[] {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (item): item is ProcessHealthEvent =>
+        typeof item === 'object' && item !== null && 'kind' in item && 'at' in item,
+    )
+  } catch {
+    return []
+  }
+}

--- a/shared/types/ipc.d.ts
+++ b/shared/types/ipc.d.ts
@@ -96,6 +96,7 @@ import type {
   RestoreNovelProjectBackupDialogResult,
 } from './project-backup'
 import type { UpdaterState } from './updater'
+import type { ProcessHealthReport } from './process-health'
 export type { AppConfig, ModelPoolEntry, ProviderId } from './config'
 export type {
   AgentEvent,
@@ -368,6 +369,8 @@ export interface ElectronApi {
   /** Windows 标题栏 overlay 符号颜色跟随主题（mac/Linux 上为 no-op）。 */
   setTitleBarOverlaySymbolColor: (symbolColor: string) => Promise<void>
   ping: () => Promise<string>
+  /** 进程健康记录（#39）：渲染进程崩溃 / 子进程崩溃 / 主线程挂死的留痕。 */
+  getProcessHealth: () => Promise<ProcessHealthReport>
   /** 在系统文件管理器中定位项目文件夹（损坏项目的自救入口，#38）。 */
   revealProjectFolder: (projectPath: string) => Promise<void>
   checkReleaseGuard: () => Promise<ReleaseGateVerdict>

--- a/shared/types/process-health.ts
+++ b/shared/types/process-health.ts
@@ -1,0 +1,54 @@
+/**
+ * 进程健康事件契约（#39 取证半边）。
+ *
+ * 渲染进程崩溃、GPU / utility 子进程崩溃、主线程挂死——这三类事件此前在 App 里**完全静默**：
+ * 作者只看到白屏或点不动，我们拿不到一行日志，只能靠外部工具猜。这个缺口有前科：#1
+ * （Windows 打包版渲染原生 `<details>` 挂死主线程）是贡献者靠 9 轮打包二分才定位的，
+ * 有 `unresponsive` 事件的话第一轮就能看出是主线程同步阻塞而非应用逻辑。
+ */
+
+/** 事件种类。三类分别对应 Electron 的 render-process-gone / child-process-gone / unresponsive。 */
+export type ProcessHealthEventKind = 'renderer-gone' | 'child-gone' | 'main-thread-blocked'
+
+/**
+ * 进程消失的原因，取自 Electron 的 `RenderProcessGoneDetails['reason']` 与 `Details['reason']`。
+ *
+ * 注意 `clean-exit` 是正常退出（关窗口时也会触发），**不记录、不提示**——否则每次正常关窗
+ * 都会往取证记录里塞噪声，还会弹出莫名其妙的崩溃提示框。
+ */
+export type ProcessGoneReason =
+  | 'clean-exit'
+  | 'abnormal-exit'
+  | 'killed'
+  | 'crashed'
+  | 'oom'
+  | 'launch-failed'
+  | 'integrity-failure'
+  | 'memory-eviction'
+
+export interface ProcessHealthEvent {
+  kind: ProcessHealthEventKind
+  /** ISO 时间戳。作者截图求助时，这一条决定了「什么时候发生的」。 */
+  at: string
+  /** 进程消失类事件的原因；主线程阻塞事件没有。 */
+  reason?: ProcessGoneReason
+  exitCode?: number
+  /** child-gone 专有：'GPU' | 'Utility' | … 。NovelMemory 跑在 utilityProcess 上，挂了会落在这里。 */
+  processType?: string
+  /** child-gone 专有：进程名（如 `Audio Service`）。 */
+  processName?: string
+  /**
+   * main-thread-blocked 专有：阻塞时长（毫秒）。
+   * 只有配对到 `responsive` 才有值；一直没恢复就保持 undefined（那通常意味着作者已经强退了）。
+   */
+  blockedMs?: number
+  /** 客户端版本——跨版本对比时用得上，作者未必说得清当时用的哪版。 */
+  appVersion?: string
+}
+
+export interface ProcessHealthReport {
+  /** 最近的事件在前。上限见主进程侧 MAX_RETAINED_EVENTS。 */
+  events: ProcessHealthEvent[]
+  /** 记录文件路径——诊断信息里展示出来，作者可以直接找到并回传。 */
+  logPath: string
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -76,6 +76,7 @@ import type {
   ReadPlannedStateInput,
 } from '@shared/types/planned-state'
 import type { ProseBlockView } from '@shared/types/prose-block'
+import type { ProcessHealthReport } from '@shared/types/process-health'
 
 export function ping(): Promise<string> {
   return window.electron.ping()
@@ -135,6 +136,11 @@ export function listProviderModels(provider: ProviderId): Promise<ProviderModelL
 
 export function getNarraCatDiagnostics(): Promise<NarraCatAgentCoreDiagnostics> {
   return window.electron.getNarraCatDiagnostics()
+}
+
+/** 进程健康记录（#39）：界面崩溃 / 子进程退出 / 主线程卡死的留痕。 */
+export function getProcessHealth(): Promise<ProcessHealthReport> {
+  return window.electron.getProcessHealth()
 }
 
 /**

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -36,6 +36,7 @@ import {
   deleteApiKey,
   getConfig,
   getNarraCatDiagnostics,
+  getProcessHealth,
   listProviderModels,
   runCorpusHealthProbe,
   runEmbeddingHealthProbe,
@@ -58,6 +59,8 @@ import type {
   EmbeddingHealthProbeResult,
   ProviderId,
 } from '@shared/types/ipc'
+import { summarizeProcessHealthEvent } from '@shared/lib/process-health'
+import type { ProcessHealthReport } from '@shared/types/process-health'
 
 declare const __NARRACAT_CLIENT_VERSION__: string | undefined
 
@@ -181,6 +184,19 @@ function AboutBetaNotice() {
 }
 
 /**
+ * 稳定性事件的一行摘要（#39）。
+ *
+ * 「未记录到异常」是有意义的信息，不是空态占位——它告诉作者「查过了，没事」，
+ * 与「读取中」（可能自己就是故障信号）必须分开显示。
+ */
+function formatProcessHealthSummary(report: ProcessHealthReport | null): string {
+  if (!report) return '读取中'
+  if (report.events.length === 0) return '未记录到异常'
+  const latest = summarizeProcessHealthEvent(report.events[0])
+  return report.events.length === 1 ? latest : `${latest}（共 ${report.events.length} 条）`
+}
+
+/**
  * 关于页诊断折叠（通用 Disclosure 的薄封装：钉住 data 锚点与摘要行样式）。
  *
  * 为什么不用原生 <details>：Windows 打包版（asar）实测渲染原生 details 元素会把渲染主线程
@@ -236,6 +252,7 @@ export function SettingsRoute() {
   const [status, setStatus] = useState<string | null>(null)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null)
+  const [processHealth, setProcessHealth] = useState<ProcessHealthReport | null>(null)
   const [embeddingProbe, setEmbeddingProbe] = useState<EmbeddingHealthProbeResult | null>(null)
   const [embeddingProbeRunning, setEmbeddingProbeRunning] = useState(false)
   const [embeddingProbeStatus, setEmbeddingProbeStatus] = useState<string | null>(null)
@@ -298,6 +315,22 @@ export function SettingsRoute() {
       cancelled = true
     }
   }, [setDiagnostics])
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadProcessHealth() {
+      try {
+        const report = await getProcessHealth()
+        if (!cancelled) setProcessHealth(report)
+      } catch {
+        // 取证读不出来不该让设置页打不开——诊断行会停在「读取中」，本身也是一种信号。
+      }
+    }
+    void loadProcessHealth()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   // 池 / 槽位改动的统一落盘 helper：模型池化后这些改动不再走「改草稿 + 手动保存设置」，
   // 一律即时持久化，杜绝「忘了保存」。
@@ -877,6 +910,27 @@ export function SettingsRoute() {
                               {diagnostics?.agentCorePath ?? '未检测'}
                             </div>
                           </SettingsRow>
+                          <SettingsRow
+                            title="稳定性事件"
+                            description="界面崩溃、子进程退出、主线程卡死的留痕。反馈问题时把这里和下面的记录文件一起发来。"
+                          >
+                            <div
+                              className={`text-right text-xs ${
+                                processHealth && processHealth.events.length > 0
+                                  ? 'text-destructive'
+                                  : 'text-muted-foreground'
+                              }`}
+                            >
+                              {formatProcessHealthSummary(processHealth)}
+                            </div>
+                          </SettingsRow>
+                          {processHealth && processHealth.events.length > 0 ? (
+                            <SettingsRow title="记录文件">
+                              <div className="truncate text-right font-mono text-xs">
+                                {processHealth.logPath}
+                              </div>
+                            </SettingsRow>
+                          ) : null}
                           <SettingsRow
                             title="向量语义检索"
                             description="检查 embedding 模型与检索链路是否正常，区分「语义检索」与「降级为纯 FTS」。"


### PR DESCRIPTION
## 改动概述

给 App 补上渲染进程崩溃、GPU/utility 子进程崩溃、主线程挂死这三类事件的取证能力。**只做 #39 的取证半边**，Electron 升级那半没动（理由见末尾）。

## 为什么要做

**不改会怎样**：全仓 `electron/` 下搜不到任何一处 `render-process-gone` / `child-process-gone` / `unresponsive`。这三类事件发生时 App **完全静默**——作者只看到白屏或点不动，我们拿不到一行日志，只能靠外部工具猜「大概是 Electron 的锅」。#39 本身就是这么来的：一位作者反馈不稳定，但**原始症状没留下**，拿到的是一份没有取证的三步处方。

这个缺口有前科：**#1（Windows 打包版渲染原生 `<details>` 挂死主线程）是贡献者靠 9 轮打包二分才定位的**。有 `unresponsive` 事件的话，第一轮就能看出是主线程同步阻塞而非应用逻辑。

而且 **NovelMemory 跑在 utilityProcess 上**——它挂了目前只会让下一次工具调用报错，进程本身怎么没的没有任何记录。记忆库是产品的命根，这条留痕的价值高于 GPU 那条。

## 做了什么

| | 内容 |
|---|---|
| **留痕** | 三类事件落进 `userData/process-health.json`（原子写，最近 50 条），重启后仍在——崩溃诊断最需要的恰恰是「上次崩的那条」 |
| **给作者出路** | 渲染进程真的没了时弹原生 dialog（UI 已死，这是唯一还能工作的通道）：一句人话 + 「重新加载」/「稍后」 |
| **可回传** | 设置-关于诊断折叠新增「稳定性事件」行；有记录时另附记录文件路径，作者截图或发文件即可 |

## 关键边界（都有测试钉住）

- **`clean-exit` 不记录也不提示** —— 正常关窗口就会触发它。记录它等于往取证里灌噪声，提示它等于**每次关窗都弹一个「崩溃了」的框**。
- **`unresponsive` 只留痕不弹框** —— 主线程阻塞几秒就会触发，写作中偶发一次不值得打断作者。配对到 `responsive` 才落一条带时长的记录；一直没恢复记「未恢复」而不是 0s。
- **崩溃循环保护**：同一窗口 60s 内只提示一次，但**每次都留痕**——提示被抑制不代表事件被丢弃，否则崩溃循环反而看不出来。
- **不自动重载**（崩溃循环会变成无限重启，且掩盖问题）、**不上报服务端**、**没有碰 `disableHardwareAcceleration`**（issue 里明确列为不建议做的事：那是拿全量用户的滚动/字体渲染体验，去赌一个连症状都没记下来的个案）。

## 单测抓出的一个真实缺陷

`lastPromptAt` 初始写 `0` 时，**首次崩溃会落进冷却窗口被误抑制**。真实环境 `Date.now()` 数值巨大所以碰巧不触发——但那是靠运气。注入时钟的测试一下就撞出来了，已改为 `null` 表示「从未提示过」。

## 分层

纯函数（判定 / 格式化 / 保留策略）下沉 `shared/lib/process-health.ts`，两进程共用（渲染端要把记录渲染成人话）；`electron/main/process-health.ts` 只留 store 与 watcher 等副作用部分，fs 与时钟均可注入。

三处建窗口的地方统一收口到 `spawnMainWindow()`——漏挂一个窗口，那个窗口的崩溃就是静默的，正是本 issue 要消灭的状态。

## 测试

| 验证 | 结果 |
|---|---|
| `typecheck` | ✅ |
| `bun test` | ✅ 3205 pass / 0 fail（319 文件，新增 26 条断言） |
| `check:design` | ✅ |
| `check:architecture` | ✅ 0 violation |
| `build` | ✅（关于页新行已确认进产物） |

## ⚠️ 端到端未验证

单测覆盖了全部代码路径（含 fake window 的事件模拟），但**「Electron 真的以这个形状触发这三个事件」只能真机验证**。事件签名是照 `electron.d.ts` 核对的，不是凭记忆写的，但那证明的是类型不是行为。

建议并入 #25 的 Windows 真机走查一起做——那台机器上一旦白屏或卡死，正好是这套取证的第一个真实用例。

## 为什么不在这个 PR 里升 Electron

#39 的另一半是 41.2.1 → 41.10.x（落后 8 个 minor）。押后的理由：现在升，Windows 真机走查出问题时分不清是「Windows 适配没做对」还是「新 Electron 引入的」。先用 CI 已经出过包的 41.2.1 基线把 Windows 走通，再升级并双平台一起回归，变量才干净。

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mGJcc8oBPAY8Hxnhgac8A