### PR TITLE
feat(skill): 加发版 skill —— mac + Windows 双平台一次走完，含发版预检

### DIFF
--- a/.claude/skills/release-app/SKILL.md
+++ b/.claude/skills/release-app/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: release-app
+description: Cut and publish a new NarraCat-app version — bump the version number, build the Windows x64 package in CI, package + sign + notarize the macOS build locally, and publish both platforms into one GitHub Release. Use this whenever the user wants to ship a new version, asks what version is live, or wants to know whether a release is ready to go — 发新版 / 发版 / 发布新包 / 打包发出去 / 上线新版本 / 给用户推更新 / 出个正式版 / 现在线上是哪一版. Also use it for anything that goes wrong before, during, or after a release: notarization or signing looks stuck or failed, the release build fails to produce a shippable package, users report they are not receiving updates, the update feed looks broken, or a bad version needs rolling back — 公证卡住 / 签名失败 / 出包失败 / 用户收不到更新 / 更新链断了 / 退回上一版. This covers the release pipeline itself, not everyday CI, build or test failures. Releasing is irreversible and must always cover both platforms, so route any release-shaped request through this skill rather than improvising the commands.
+---
+
+# 发版：mac + Windows 双平台
+
+发一个新版本 = 抬版本号 → CI 出 Windows 包 → 本机打 mac 包并签名公证 → 两个平台的产物进**同一个** GitHub Release。
+
+**这件事不可逆**：Release 一旦发布，所有装了 App 的用户都会自动收到。所以下面每一步的顺序和闸都不是形式主义，撞到闸就停下来问人，不要绕过去。
+
+## 唯一一条不能违反的规则：必须双平台
+
+更新代理（`workers/narracat-update`）把**两个平台的更新清单都**翻译成 `releases/latest/download/<清单名>`：
+
+```
+/mac-arm64/latest-mac.yml  →  releases/latest/download/latest-mac.yml
+/win-x64/latest.yml        →  releases/latest/download/latest.yml
+```
+
+所以一个**只含单平台产物**的 Release 一旦成为 `latest`，另一个平台的清单查询直接 404 —— 那条更新链就此断掉，直到下一次带上该平台产物的发布为止。不是"用户停在上一版"，是**从此收不到任何更新，两端都没有报错**。
+
+`release.mjs` 已经加了闸（必须显式给 `--with-win` 或 `--mac-only`），但闸拦得住命令、拦不住判断：`--mac-only` 只在 Windows 从未发布过、或 Windows CI 出不了包而 mac 有紧急修复要发时才用。**Windows 正式发布之后，用它就等于主动掐断 Windows 用户的更新链。**
+
+## 两个平台为什么不能在同一个地方打
+
+| 平台 | 在哪打 | 为什么只能在那儿 |
+|---|---|---|
+| macOS arm64 | 本机 | 签名要读本机钥匙串里的 Developer ID 证书，之后还要跑 Apple 公证 |
+| Windows x64 | GitHub CI | mac 交叉编译不出能用的 Windows 包（keytar / better-sqlite3 是 mac 原生二进制）；且 SignPath 的免费签名硬要求"可验证地从源码构建" |
+
+版本号一致不靠人盯：两边都读同一个 `package.json`（ADR-0038）。
+
+---
+
+## 步骤 0：预检
+
+先跑这个，它把该确认的一切一次报全（只读，不改任何东西）：
+
+```bash
+node .claude/skills/release-app/scripts/preflight.mjs
+```
+
+拿到 Windows 产物之后再跑一次，带上目录一并核对：
+
+```bash
+node .claude/skills/release-app/scripts/preflight.mjs --win-dir <目录>
+```
+
+它检查：在不在 main、工作区干不干净、与远端同步没、版本号是否合法且高于已交付的最高版、这个 tag 是不是已经发过、三样凭证齐不齐、签名身份在不在、Windows 三件产物齐不齐且版本号对不对得上。
+
+有 `✗` 就先解决再往下走 —— 这些问题在后面每一步都会重新撞上，只是那时候人已经等了半小时。把结果用大白话转述给用户，不要只甩脚本输出。
+
+## 步骤 1：定版本号
+
+版本号由人决定，不会自己往上走（ADR-0038）。改 `package.json` 的 `version` 一处即可，其余全部从它派生。
+
+| 这次发的是 | 怎么走 |
+|---|---|
+| 修 bug、小改进 | patch：`0.3.0` → `0.3.1` |
+| 有用户能感知的新能力 | minor：`0.3.0` → `0.4.0` |
+| 正式公开发布 | `1.0.0`（留给那一刻，不要提前用掉） |
+
+**改完要走 PR 合进 main**，不要直接推 main（有分支保护，直推不会被拒、只会留一条绕过记录）。
+
+发版前值得先问用户一句：**这一版对用户来说是什么？** 这既决定 patch 还是 minor，也是 Release notes 的内容。可以用 `git log --oneline v<上一版>..main` 看这一版实际包含什么，用大白话总结给用户确认 —— 用户关心的是"能感觉到什么变化"，不是提交列表。
+
+## 步骤 2：CI 出 Windows 包
+
+```bash
+gh workflow run windows-release-build.yml --ref main
+gh run watch <run-id> --exit-status    # 约 5 分钟
+```
+
+跑完从 Actions 页下载 artifact `windows-x64-unsigned`，解压得到三个文件（`.exe` / `.exe.blockmap` / `latest.yml`），放进一个目录备用。
+
+⚠️ **CI 全绿不构成任何功能保证** —— 这条流水线从不启动界面，而已知的 Windows 崩溃全在渲染层。CI 只证明"包能打出来"。
+
+⚠️ 确认包里的版本号是这次要发的那个。如果 CI 跑在版本号还没抬的提交上，出来的是旧版本号的包，`--with-win` 那一步会对不上。预检脚本带 `--win-dir` 就是查这个。
+
+## 步骤 3：打 mac 包并发布双平台
+
+```bash
+bun --no-cache run release --with-win <放着三件 Windows 产物的目录>
+```
+
+这一条命令会：打 mac 包 → 签名 → 公证 → 建 draft Release → 传两个平台的全部产物 → 最后才 publish。**20-40 分钟**，其中大部分是公证在等 Apple。
+
+顺序纪律：先建 draft、传完全部资产、最后才 publish。draft 不被匿名 API 与 `releases/latest` 看见，所以在资产全部传完之前没有任何用户能看到这个版本 —— 任一步失败，Release 停在 draft，线上仍是上一版，零影响。
+
+中途会有一个确认界面列出待传的全部文件。**这是最后一道人工闸**，让用户过目再确认，尤其核对 Windows 那三件在不在。
+
+## 步骤 4：发完之后（不要跳过）
+
+**把 `scripts/client-version.mjs` 里的 `HIGHEST_SHIPPED_VERSION` 抬到刚发出去的版本。**
+
+它是"版本号别改小、别忘了抬"那道测试闸的唯一依据。不抬的话闸就形同虚设 —— 下一次发版时它比的还是老版本，改小了也不会红。同样走 PR 合进 main。
+
+然后验证线上真的通了：
+
+```bash
+curl -sS -o /dev/null -w "mac %{http_code}\n" https://update.narracat.com/mac-arm64/latest-mac.yml
+curl -sS -o /dev/null -w "win %{http_code}\n" https://update.narracat.com/win-x64/latest.yml
+```
+
+两个都应该是 200。**任何一个是 404，就说明那个平台的更新链断了** —— 多半是这次的 Release 少传了那个平台的产物。
+
+---
+
+## 会撞上的几件事
+
+**公证轮询超时 ≠ 公证失败。** 脚本等不到不代表 Apple 没批。先查：
+
+```bash
+xcrun notarytool info <submission-id> --key ... --key-id ... --issuer ...
+```
+
+状态是 `Accepted` 的话，公证早就过了，只差把票据钉上去：`xcrun stapler staple <path>`。这能省掉重新公证的二十多分钟 —— 别急着重跑整条流水线。
+
+**dmg 的 sha512 与清单里的值对不上是正常的**，不是要修的 bug。electron-builder 的清单记的是 zip 的哈希，dmg 是另外打的。
+
+**三样凭证缺一不可**（签名证书 / 公证凭证 / 语料 token），发版档在第一步就断言。其中语料 token 最阴 —— 缺了 App 照常能开、照常能写，只是永远不注入真人范例，**静默降质**，没人会发现。
+
+**bun 不把 `.env` 传给 node 子进程**（`package:release` 正是 bun run → node），所以脚本自己加载 `.env.local` / `.env`。凭证明明配好了却报缺失，先往这个方向查。
+
+**发版是给所有用户推送**，所以 mac 包发出去之前值得本机装一下走一遍（能打开、能新建项目、能写一章）。CI 和单测都证明不了这件事。
+
+**Windows 首个 beta 是未签名的**，用户必然撞 SmartScreen 蓝屏警告（点"更多信息"→"仍要运行"）。这是 SignPath Foundation 免费签名的硬条款要求的必经步骤 —— 必须先以未签名形态发布过才能申请 —— 不是疏忽，发之前跟用户说清楚。
+
+## 出事了要回退
+
+不需要传任何文件，也不需要发新版本：打开 Release 页 → 编辑上一个正常版本 → 勾选 "Set as the latest release" → 保存。
+
+更新代理认的就是 GitHub 的 `latest` 标记，所以这个动作立刻让所有客户端回到上一版。
+
+## 完成判据
+
+说"发好了"之前，这几条都要成立：
+
+- Release 页上这个 tag 存在、不是 draft、被标记为 latest
+- 两个平台的产物都在资产列表里（mac 五件 + Windows 三件）
+- 上面两条 `curl` 都返回 200
+- `HIGHEST_SHIPPED_VERSION` 已抬到这一版并合进 main
+
+前三条任何一条不成立，都要如实告诉用户哪里没成，而不是报告"发布成功"。

--- a/.claude/skills/release-app/scripts/preflight.mjs
+++ b/.claude/skills/release-app/scripts/preflight.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// 发版预检：把「按下发布键之前该确认的一切」一次报全，只读、不改任何东西。
+//
+// 为什么值得单独一个脚本：发布是不可逆的外向操作，而它的前置条件散落在四处——git 状态、
+// package.json 的版本号、线上已发布的 tag、三样凭证。`release.mjs` 里确实有闸，但那些闸是
+// 发版**过程中**才触发的，撞上时人已经在等一条要跑 20-40 分钟的签名 + 公证流水线了。
+// 这个脚本把撞墙的时刻提前到零成本的地方，并且一次报全部问题，而不是修一个撞下一个。
+//
+// 所有判据都从真实契约 import，不重新实现一遍——版本号规则改了这里自动跟上（ADR-0038）。
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+
+function findRepoRoot(start) {
+  let dir = start
+  for (let i = 0; i < 10; i += 1) {
+    if (existsSync(join(dir, 'scripts', 'client-version.mjs'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+const repoRoot = findRepoRoot(scriptDir)
+if (!repoRoot) {
+  process.stderr.write('找不到仓库根（向上十层都没有 scripts/client-version.mjs）。\n')
+  process.exit(1)
+}
+
+const { HIGHEST_SHIPPED_VERSION, isVersionGreater, readPackageVersion } = await import(
+  pathToFileURL(join(repoRoot, 'scripts', 'client-version.mjs')).href
+)
+const { releaseTag, winReleaseAssetFileNames, RELEASE_REPO } = await import(
+  pathToFileURL(join(repoRoot, 'scripts', 'update-feed.mjs')).href
+)
+const { CORPUS_ENV_VARS, NOTARIZE_ENV_VARS, loadEnvFiles } = await import(
+  pathToFileURL(join(repoRoot, 'scripts', 'package-rc.mjs')).href
+)
+
+const checks = []
+/** blocker：不解决就不该发。warning：需要人判断，不一定拦。 */
+function add(level, label, detail) {
+  checks.push({ level, label, detail })
+}
+
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim()
+}
+
+// ── 1. git 状态 ─────────────────────────────────────────────
+// 发版打的是工作区当前状态。在功能分支上发、或带着未提交改动发，产物与 main 上的代码
+// 对不上，事后无从复现「用户手上那一版到底是什么」。
+let branch = ''
+try {
+  branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+  if (branch === 'main') add('ok', '在 main 分支上', branch)
+  else add('blocker', '不在 main 分支上', `当前在 ${branch}；发版要从 main 出，先把改动合进去`)
+
+  const dirty = git(['status', '--porcelain'])
+  if (dirty) {
+    const n = dirty.split('\n').length
+    add('blocker', '工作区有未提交改动', `${n} 个文件；先提交或清理，否则产物与 main 对不上`)
+  } else {
+    add('ok', '工作区干净', '')
+  }
+
+  try {
+    git(['fetch', 'origin', branch, '--quiet'])
+  } catch {
+    add('warning', '拉取 origin 失败', '可能没网；下面的「与远端同步」结论可能过期')
+  }
+  const ahead = git(['rev-list', '--count', `origin/${branch}..HEAD`])
+  const behind = git(['rev-list', '--count', `HEAD..origin/${branch}`])
+  if (ahead === '0' && behind === '0') add('ok', '与远端同步', '')
+  else add('blocker', '与远端不同步', `本地领先 ${ahead} 个、落后 ${behind} 个提交`)
+} catch (error) {
+  add('blocker', 'git 状态读取失败', String(error?.message ?? error))
+}
+
+// ── 2. 版本号 ───────────────────────────────────────────────
+// ADR-0038：版本号由人在 package.json 里定。它不会自己往上走，所以「忘了抬」是真实可能，
+// 而后果是资产被传进已发布的 tag、线上文件被悄悄换掉而版本号没变，自动更新那边完全无感。
+let version = null
+try {
+  version = readPackageVersion(repoRoot)
+  add('ok', `版本号 ${version}`, 'package.json（ADR-0038 的唯一真相源）')
+
+  if (isVersionGreater(version, HIGHEST_SHIPPED_VERSION)) {
+    add('ok', `高于已交付的 ${HIGHEST_SHIPPED_VERSION}`, '存量用户能收到这一版')
+  } else {
+    add(
+      'blocker',
+      `没有高过已交付的 ${HIGHEST_SHIPPED_VERSION}`,
+      '装了那一版的机器会认为自己已是最新，收不到更新且无任何提示——先抬 package.json 的 version',
+    )
+  }
+} catch (error) {
+  add('blocker', '版本号读取失败', String(error?.message ?? error))
+}
+
+// ── 3. 这个版本号是不是已经发过了 ──────────────────────────
+if (version) {
+  const tag = releaseTag(version)
+  try {
+    const out = execFileSync(
+      'gh',
+      ['release', 'view', tag, '--repo', RELEASE_REPO, '--json', 'isDraft'],
+      { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    )
+    const isDraft = JSON.parse(out)?.isDraft
+    if (isDraft) {
+      add('warning', `${tag} 停在 draft`, '上次发版中途失败的残留；线上仍是上一版，重跑前先处理它')
+    } else {
+      add('blocker', `${tag} 已经发布过了`, '多半是忘了抬版本号；照原样发会把线上那一版的文件悄悄换掉')
+    }
+  } catch {
+    add('ok', `${tag} 尚未发布`, '')
+  }
+}
+
+// ── 4. 凭证（只报有无，绝不打印值）────────────────────────────
+// bun 不把 .env 传给 node 子进程，所以脚本自己加载——与 package-rc.mjs / release.mjs 同款处置。
+try {
+  loadEnvFiles(repoRoot)
+} catch (error) {
+  add('warning', '.env 文件解析失败', String(error?.message ?? error))
+}
+
+const missingNotarize = NOTARIZE_ENV_VARS.filter((key) => !String(process.env[key] ?? '').trim())
+if (missingNotarize.length === 0) add('ok', 'Apple 公证凭证齐备', `${NOTARIZE_ENV_VARS.length} 项`)
+else add('blocker', 'Apple 公证凭证缺失', `缺 ${missingNotarize.join(' / ')}（配在 .env.local）`)
+
+const missingCorpus = CORPUS_ENV_VARS.filter((key) => !String(process.env[key] ?? '').trim())
+if (missingCorpus.length === 0) add('ok', '语料服务 token 齐备', '')
+else
+  add(
+    'blocker',
+    '语料 token 缺失',
+    `缺 ${missingCorpus.join(' / ')}——它是构建期烧进产物的，缺了 App 照常能开，只是写作永远不注入真人范例（静默降质）`,
+  )
+
+try {
+  execFileSync('node', [join(repoRoot, 'scripts', 'check-signing-identity.mjs')], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  add('ok', 'Developer ID 签名身份可用', '')
+} catch {
+  add('blocker', '找不到 Developer ID 签名身份', '钥匙串里没有可分发身份，mac 包签不了')
+}
+
+// ── 5. Windows 产物（给了目录才查）──────────────────────────
+// 两个平台的更新清单都指向 releases/latest，所以只含单平台产物的 Release 一旦成为 latest，
+// 另一边的清单查询直接 404、更新链就此断掉。带齐三件是发版的硬前提，不是可选项。
+const winDirArg = process.argv.indexOf('--win-dir')
+if (winDirArg !== -1 && process.argv[winDirArg + 1] && version) {
+  const winDir = resolve(process.argv[winDirArg + 1])
+  if (!existsSync(winDir)) {
+    add('blocker', 'Windows 产物目录不存在', winDir)
+  } else {
+    const expected = winReleaseAssetFileNames(version)
+    const missing = expected.filter((name) => !existsSync(join(winDir, name)))
+    if (missing.length === 0) {
+      add('ok', `Windows 三件产物齐全（${version}）`, winDir)
+    } else {
+      add(
+        'blocker',
+        'Windows 产物不齐或版本号对不上',
+        `缺 ${missing.join(' / ')}——若目录里是别的版本号，说明 CI 出包时 package.json 还没抬到 ${version}，要重新出包`,
+      )
+    }
+  }
+} else {
+  add(
+    'warning',
+    '没检查 Windows 产物',
+    '加 --win-dir <目录> 可一并核对。发版必须双平台：只发一边会让另一边的更新链断掉',
+  )
+}
+
+// ── 输出 ────────────────────────────────────────────────────
+const icon = { ok: '✓', warning: '!', blocker: '✗' }
+process.stdout.write('\n发版预检\n────────────────────────────────────────\n')
+for (const c of checks) {
+  process.stdout.write(`${icon[c.level]} ${c.label}${c.detail ? `\n    ${c.detail}` : ''}\n`)
+}
+
+const blockers = checks.filter((c) => c.level === 'blocker')
+const warnings = checks.filter((c) => c.level === 'warning')
+process.stdout.write('────────────────────────────────────────\n')
+if (blockers.length === 0) {
+  process.stdout.write(
+    warnings.length ? `可以发版（${warnings.length} 条提醒需要你确认）\n\n` : '可以发版\n\n',
+  )
+} else {
+  process.stdout.write(`还不能发：${blockers.length} 个问题要先解决\n\n`)
+}
+process.exitCode = blockers.length === 0 ? 0 : 1

--- a/.claude/skills/release-guard/SKILL.md
+++ b/.claude/skills/release-guard/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: release-guard
+description: View or change NarraCat-app's internal-test release gate / remote kill switch (the release-guard Cloudflare Worker in workers/release-guard). Use when the user wants to check the gate's current status (is it blocking users right now?), set or clear the internal-test deadline, trigger or release the emergency brake (kill switch), raise the minimum allowed version, or edit the block-screen notice. 触发词：内测开关 / 急刹车 / 看后台配置 / 改截止日 / 下线版本 / 释放门控 / release guard.
+---
+
+# 内测释放门控（release-guard）
+
+控制内测包的「软过期 + 远程急刹车」。一个已部署的 Cloudflare Worker 返回一段 JSON，App 启动时拉取后决定要不要把用户挡在外面。**改这个 Worker、不动 App、不发新包**，约 10s 全员生效。
+
+- 线上配置真相：Worker（`workers/release-guard/src/index.ts` 是它的源码）
+- App 调用地址：写在 `electron/main/release-guard-runtime.ts` 的 `RELEASE_GUARD_URL`
+- 纯判定逻辑：`electron/main/release-guard.ts`（单测 `release-guard.test.ts`）
+
+## 1. 查看状态（默认动作）
+
+先跑状态脚本，把结果原样转述给用户（它会显示线上当前配置、现在拦不拦人、以及本地有没有改了没部署）：
+
+```bash
+node .claude/skills/release-guard/scripts/status.mjs
+```
+
+脚本自定位仓库根，任意 cwd 可跑、只读不改。读完用一两句话总结「现在是放行还是拦人、有没有截止日」。
+
+## 2. 调整配置
+
+只改 `workers/release-guard/src/index.ts` 里的 `RELEASE_GATE` 这一个对象，然后部署、再复验。
+
+| 想干嘛 | 改 `RELEASE_GATE` | 效果 |
+|---|---|---|
+| 定内测截止日 | `deadline: "2026-09-30T00:00:00Z"`（ISO 8601，建议带 Z/时区） | 过期后所有版本启动被拦 |
+| 取消截止日 | `deadline: ""` | 不再按日期拦 |
+| 🚨 紧急下线坏版本 | `kill: true` | 立即拦所有版本 |
+| 解除急刹车 | `kill: false` | 恢复（再按 deadline/minVersion 判） |
+| 逼旧版升级 | `minVersion: "0.1.320"`（semver） | 低于此版本被拦 |
+| 改拦截页文案 | `notice: "……"` | 用户看到的提示语 |
+
+部署（已 `wrangler login` 过；若 token 过期会提示重登）：
+
+```bash
+cd workers/release-guard && bunx wrangler deploy
+```
+
+**部署后必须复验**：再跑一次第 1 步的 status 脚本，确认线上确实变了、判定符合预期。改完务必把 `RELEASE_GATE` 和线上对上（status 脚本会报「改了没部署」的漂移）。
+
+## 安全须知
+
+- `kill: true` 或过期的 `deadline` 会拦**所有**装了内测包的用户，最坏 ~60s 缓存后全员生效——确认是想要的再部署。
+- App 端拉取失败时 **fail-open（放行）**，不因断网误伤正常用户；唯一断网也拦的是 App 构建期烤死的「构建后 90 天」硬过期，那条与本 Worker 无关、改不了（要改得重新打包）。
+- 这是公开只读端点，不收/不存任何用户数据，不带密钥。
+
+## 完成判据
+
+调整类操作，在说"已生效"前必须：部署成功 + status 脚本复验线上配置已更新 + 解读判定正确。仅查看则无需部署。

--- a/.claude/skills/release-guard/scripts/status.mjs
+++ b/.claude/skills/release-guard/scripts/status.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// 内测「释放门控」状态查看：拉线上 Worker 当前配置 + 解读现在拦不拦人 + 检测本地未部署的改动。
+// 自定位仓库根（向上找 electron/main/release-guard-runtime.ts），可在任意 cwd 下运行。
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PLACEHOLDER = 'https://narracat-release-guard.example.workers.dev'
+
+function findRepoRoot(start) {
+  let dir = start
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, 'electron/main/release-guard-runtime.ts'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+function extractUrl(src) {
+  const m = src.match(/RELEASE_GUARD_URL\s*=\s*['"]([^'"]+)['"]/)
+  return m ? m[1] : null
+}
+
+// 从 worker src/index.ts 的 RELEASE_GATE 抠 4 个字段（容错；全抠不到返回 null）
+function extractGate(src) {
+  const pick = (re) => {
+    const m = src.match(re)
+    return m ? m[1] : null
+  }
+  const minVersion = pick(/minVersion:\s*['"]([^'"]*)['"]/)
+  const deadline = pick(/deadline:\s*['"]([^'"]*)['"]/)
+  const killStr = pick(/kill:\s*(true|false)/)
+  const notice = pick(/notice:\s*['"]([^'"]*)['"]/)
+  if (minVersion === null && deadline === null && killStr === null) return null
+  return {
+    minVersion: minVersion ?? '',
+    deadline: deadline ?? '',
+    kill: killStr === 'true',
+    notice: notice ?? '',
+  }
+}
+
+async function fetchLive(url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 6000)
+  try {
+    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' })
+    if (!res.ok) return { error: `HTTP ${res.status}` }
+    return { config: await res.json() }
+  } catch (e) {
+    return { error: e?.message || String(e) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function interpret(cfg) {
+  if (!cfg || typeof cfg !== 'object') return '⚠ 无法解读线上配置'
+  if (cfg.kill === true) return '🔴 急刹车开启 —— 所有版本启动即被拦'
+  const now = Date.now()
+  const deadline = typeof cfg.deadline === 'string' ? cfg.deadline.trim() : ''
+  const minVersion = typeof cfg.minVersion === 'string' ? cfg.minVersion.trim() : ''
+  if (deadline) {
+    const dMs = Date.parse(deadline)
+    if (Number.isFinite(dMs)) {
+      if (now >= dMs) return `🔴 已过截止日（${deadline}）—— 所有版本被拦`
+      const days = Math.ceil((dMs - now) / 86400000)
+      let line = `🟢 放行 —— 截止日 ${deadline}，还有 ${days} 天`
+      if (minVersion) line += `；且低于 ${minVersion} 的版本会被拦`
+      return line
+    }
+    return `⚠ deadline 格式无法解析（${deadline}）—— App 会忽略该日期`
+  }
+  if (minVersion) return `🟢 放行 —— 但低于 ${minVersion} 的版本会被拦`
+  return '🟢 全放行 —— 未设任何拦截条件'
+}
+
+function gateEqual(a, b) {
+  if (!a || !b) return false
+  return (
+    (a.minVersion ?? '') === (b.minVersion ?? '') &&
+    (a.deadline ?? '') === (b.deadline ?? '') &&
+    Boolean(a.kill) === Boolean(b.kill) &&
+    (a.notice ?? '') === (b.notice ?? '')
+  )
+}
+
+const root = findRepoRoot(dirname(fileURLToPath(import.meta.url)))
+if (!root) {
+  console.error('找不到仓库根（缺 electron/main/release-guard-runtime.ts）。请在 NarraCat-app 仓库内运行。')
+  process.exit(1)
+}
+
+const runtimeSrc = await readFile(join(root, 'electron/main/release-guard-runtime.ts'), 'utf8')
+const url = extractUrl(runtimeSrc)
+
+console.log('# 内测释放门控 · 状态\n')
+console.log(`App 调用地址：${url ?? '（未在 release-guard-runtime.ts 找到 RELEASE_GUARD_URL）'}`)
+
+if (!url || url === PLACEHOLDER) {
+  console.log('\n⚠ 尚未部署 / 未回填真实 Worker URL（仍是占位）。')
+  console.log('  App 当前会跳过远程拉取，只剩「构建后 90 天」硬过期兜底。')
+  console.log('  部署见 workers/release-guard/README.md，或让我直接 wrangler deploy 并回填 URL。')
+  process.exit(0)
+}
+
+const workerSrcPath = join(root, 'workers/release-guard/src/index.ts')
+const localGate = existsSync(workerSrcPath) ? extractGate(await readFile(workerSrcPath, 'utf8')) : null
+
+const { config, error } = await fetchLive(url)
+console.log('\n## 线上当前配置（已部署、对所有用户生效）')
+if (error) {
+  console.log(`⚠ 拉取失败：${error}`)
+  console.log('  （App 端遇到拉取失败会 fail-open 放行，只靠硬过期兜底。）')
+} else {
+  console.log('```json')
+  console.log(JSON.stringify(config, null, 2))
+  console.log('```')
+  console.log(`\n判定：${interpret(config)}`)
+}
+
+if (localGate && config && !error) {
+  if (!gateEqual(localGate, config)) {
+    console.log('\n⚠ 本地 workers/release-guard/src/index.ts 与线上不一致 —— 改了但还没部署。')
+    console.log(`  本地（待部署）：${JSON.stringify(localGate)}`)
+    console.log('  跑 `cd workers/release-guard && bunx wrangler deploy` 才会生效。')
+  } else {
+    console.log('\n✓ 本地源码与线上一致（无未部署改动）。')
+  }
+}
+
+console.log('\n提示：另有「构建后 90 天」硬过期由 App 构建期烤死，与本 Worker 无关、断网也生效。')

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,16 @@ corpus-factory-data/
 # 2026-08-16：本仓升格为唯一开发仓，工程契约文档（CLAUDE.md / CONTEXT.md / AGENTS.md / docs/adr / docs/agents
 # / agent-core 引擎文档）已随代码入仓；此处只留私产（战略罗盘、过程流水、研究工具、语料）。
 docs/COMPASS.md
-.claude/
+# 写成 .claude/* 而不是 .claude/：git 不会递归进一个被整体排除的目录，
+# 父目录被排除时里面的 ! 例外规则一律失效（官方文档明写的行为）。
+.claude/*
+# 例外：.claude/skills/ 放的是工程工具（发版、内测门控），不是上面注释说的「私产」。
+# 它们必须随代码走——换台机器要还在、契约腐烂了要有守卫拦得住
+# （scripts/release-skill-preflight.test.mjs 就引用 release-app 的预检脚本，
+# 不跟踪的话那条测试在 CI 上必红）。只开 skills/ 这一层，其余 .claude/ 仍全忽略。
+!.claude/skills/
+# 触发测试的中间产物不进仓库（每次跑都重新生成，含大量临时文件）
+.claude/skills/*-workspace/
 .agents/
 docs/superpowers/
 docs/plans/

--- a/scripts/check-public-boundary.test.mjs
+++ b/scripts/check-public-boundary.test.mjs
@@ -32,6 +32,16 @@ const TRACKED_ALLOWLIST = new Set([
   'agent-core/narracat/docs/plans/2026-06-13-legacy-capability-backlog.md',
   'agent-core/narracat/docs/reports/2026-03-28-system-audit-anti-template.md',
   'agent-core/narracat/docs/reports/2026-04-26-system-debt-analysis.md',
+  // 2026-08-30：`.claude/skills/` 下的工程工具（发版、内测门控）随代码入仓——它们是
+  // 团队工具而非上面注释所指的「私产」，且 scripts/release-skill-preflight.test.mjs
+  // 引用 release-app 的预检脚本，不跟踪的话那条守卫在 CI 上必红。
+  // 仍按文件粒度放行、不整目录开口：`.claude/` 里还有 settings.local.json 这类本机配置，
+  // 而 skill 正文最容易夹带本机绝对路径或内部端点。以下 4 份已过内容扫描，
+  // 今后新增的 skill 文件依旧会被前缀规则拦下，逼人再审一次——这正是本表的用法。
+  '.claude/skills/release-app/SKILL.md',
+  '.claude/skills/release-app/scripts/preflight.mjs',
+  '.claude/skills/release-guard/SKILL.md',
+  '.claude/skills/release-guard/scripts/status.mjs',
 ])
 // 允许 yannikzz；禁其余个人标识与私有基础设施标识。
 // Yannik Zhang / AHRB2HD27M（Apple Team ID）是 2026-08-16 人工扫描才发现的正则盲区，补入防复发。

--- a/scripts/release-skill-preflight.test.mjs
+++ b/scripts/release-skill-preflight.test.mjs
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { describe, expect, test } from 'bun:test'
+
+// 发版 skill 的预检脚本（.claude/skills/release-app/scripts/preflight.mjs）刻意不重新实现任何
+// 判据——版本号规则、产物命名、凭证清单全部从本目录的真实契约 import，这样 ADR-0038 那类规则
+// 变化时它自动跟上。代价是它对这些模块的导出面有依赖，而**它平时不跑**：谁改了导出名，
+// 要到下一次发版当天才撞见，那正是人最急、最不想调试脚本的时候。
+//
+// 这一组就是那道守卫。它不重复各模块自己的行为测试，只钉「预检脚本引用的符号还在不在」——
+// 而且是从脚本源码里解析出 import 清单再逐个核对，所以将来给预检加新 import 也自动纳入覆盖，
+// 不需要有人记得回来补断言。
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(scriptsDir)
+const preflightPath = join(repoRoot, '.claude/skills/release-app/scripts/preflight.mjs')
+
+/**
+ * 从预检脚本源码里解析出 `const { A, B } = await import(...'scripts/x.mjs'...)` 形态的依赖。
+ * 返回 [{ moduleFile, symbols }]。
+ */
+function parseContractImports(source) {
+  const pattern = /const\s*\{([^}]+)\}\s*=\s*await import\(\s*pathToFileURL\(join\(repoRoot,\s*'scripts',\s*'([^']+)'\)\)\.href\s*\)/g
+  const found = []
+  for (const match of source.matchAll(pattern)) {
+    const symbols = match[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    found.push({ moduleFile: match[2], symbols })
+  }
+  return found
+}
+
+describe('发版预检脚本与真实契约同源', () => {
+  const source = readFileSync(preflightPath, 'utf8')
+  const contractImports = parseContractImports(source)
+
+  test('解析出了依赖清单（解析器本身失效就等于守卫静默失守）', () => {
+    // 空数组会让下面的 for 循环一条断言都不跑、测试却全绿——守卫必须先证明自己在工作。
+    expect(contractImports.length).toBeGreaterThan(0)
+    expect(contractImports.map((i) => i.moduleFile).sort()).toContain('client-version.mjs')
+  })
+
+  for (const { moduleFile, symbols } of contractImports) {
+    test(`${moduleFile} 仍导出预检用到的 ${symbols.length} 个符号`, async () => {
+      const mod = await import(pathToFileURL(join(scriptsDir, moduleFile)).href)
+
+      for (const symbol of symbols) {
+        expect(`${moduleFile}:${symbol}`).toBe(
+          symbol in mod ? `${moduleFile}:${symbol}` : `${moduleFile}: 缺少导出 ${symbol}`,
+        )
+        expect(mod[symbol]).toBeDefined()
+      }
+    })
+  }
+
+  test('预检只读——不含任何写入、发布或部署动作', () => {
+    // 预检的全部价值在于「跑它没有任何代价」。一旦它开始改东西，人就会犹豫要不要跑，
+    // 而一个让人犹豫的检查等于没有检查。
+    for (const forbidden of ['writeFile', 'release create', 'release upload', 'wrangler deploy']) {
+      expect(source).not.toContain(forbidden)
+    }
+    // git 只允许读状态与 fetch，不许改本地历史或推送
+    for (const forbidden of ['git push', "'push'", "'commit'", "'reset'", "'checkout'"]) {
+      expect(source).not.toContain(forbidden)
+    }
+  })
+
+  test('不打印凭证值——只报有无', () => {
+    // 凭证名可以出现（要报缺了哪个），值绝不能进 stdout：发版时人常把输出贴给别人看。
+    expect(source).toContain('绝不打印值')
+    expect(source).not.toMatch(/process\.env\[[^\]]+\]\s*\)?\s*\}?\s*`/)
+    // 缺失项走的是 key 名拼接，不是值
+    expect(source).toContain('missingNotarize.join')
+    expect(source).toContain('missingCorpus.join')
+  })
+})


### PR DESCRIPTION
## 为什么要做

发版这件事的知识此前散在三处：`docs/agents/release-checklist.md`、ADR-0038、以及一堆只存在于人脑里的坑（公证超时≠失败、语料 token 缺了会静默降质、只发单平台会掐断另一边的更新链）。而发版是**不可逆的外向操作**——记错一步的代价是全体用户。

这个 skill 把它们收在一处，让「发个新版本」变成一句话。

## 预检脚本

一条命令把该确认的一切一次报全，只读、不改任何东西：

```
✓ 在 main 分支上          ✓ 版本号 0.3.0
✓ 工作区干净              ✓ 高于已交付的 0.2.92
✓ 与远端同步              ✓ v0.3.0 尚未发布
✓ Apple 公证凭证齐备       ✓ 语料服务 token 齐备
✓ Developer ID 签名身份可用
────────────────────────────────
可以发版
```

**为什么值得单独一个脚本**：这些前置条件散落四处，而 `release.mjs` 里的闸是发版**过程中**才触发的——撞上时人已经在等一条要跑 20-40 分钟的签名 + 公证流水线。预检把撞墙时刻提前到零成本的地方，且一次报全部问题而不是修一个撞下一个。

所有判据从真实契约 import（`client-version` / `update-feed` / `package-rc`），不重新实现一遍——ADR-0038 那类规则变化时它自动跟上。凭证只报有无、**绝不打印值**（发版时人常把输出贴给别人看）。

实测三条拦截路径均正确报错并给出修法；退出码 0/1 分明。

## 守卫

预检脚本对上述模块的导出面有依赖，而**它平时不跑**：谁改了导出名，要到下一次发版当天才撞见，那正是人最急的时候。

`scripts/release-skill-preflight.test.mjs` 从脚本源码解析出 import 清单再逐个核对，所以将来加新 import 也自动纳入覆盖，不需要有人记得回来补断言。另钉住它必须保持只读、且不打印凭证值。

**变异验证**：故意改掉一个导出名，守卫立刻红并点名缺哪个符号。

## .gitignore 与公私边界

`.claude/skills/` 放的是工程工具（发版、内测门控），不是 ignore 注释所指的「私产」。不跟踪的话上面那条守卫在 CI 上必红——它引用的路径根本不存在（与本仓踩过的「gitignore 的产物掩盖断链」同族）。顺带把此前同样未跟踪的 `release-guard` 一并纳入。

两处细节：

- 写成 `.claude/*` 而非 `.claude/`：**git 不会递归进一个被整体排除的目录**，父目录被排除时里面的 `!` 例外一律失效（官方文档明写的行为，第一版就是这么写错的，`git status` 里什么都没出现才发现）
- `check-public-boundary` 当场拦住了这个改动（守卫工作正常）。按本表既有模式处置：**前缀禁令保留，已过内容扫描的文件按文件粒度进 allowlist**，不整目录开口——`.claude/` 里还有 `settings.local.json` 这类本机配置，而 skill 正文最容易夹带本机绝对路径或内部端点。今后新增的 skill 文件依旧会被拦下，逼人再审一次。**变异验证**：放一个未审文件进索引，守卫当场变红并点名

在**干净检出**（零依赖）里实测：skill 文件都在、预检脚本能跑、守卫 6/6 通过——CI 上不会红。

## 触发验证：20/20

用真实 claude 会话跑 20 条测试（9 条该触发 / 11 条不该），检测**真实 skill 名**是否被 Skill 工具调用：

| | 结果 |
|---|---|
| 该触发 | **9/9** |
| 不该触发 | **11/11** |

两条最危险的近似项精准路由到 `release-guard` 而非本 skill——两个 skill 边界干净：

```
"内测开关现在是拦人还是放行"      → release-guard  ✓
"急刹车打开，0.2.65有致命bug"     → release-guard  ✓
```

中途修了两轮描述，补的是**场景类别**而非测试用例关键词：原描述只覆盖「要发版」，漏了「发版相关的事出问题了」（公证卡住、用户收不到更新）。补完后一度把「windows-build-smoke 挂了」也吞进来——仓库里有两个 Windows workflow，只有 `windows-release-build` 归发版管——故加了一句明确的负向边界排除日常 CI/构建失败。

### ⚠️ 一个方法论教训（值得记下来）

skill-creator 自带的描述优化循环在本仓给出的分数是**无效**的：它把描述复制成 `.claude/commands/<name>-skill-<hash>.md` 再看那个副本有没有被调用，而真实 skill 已存在于 `.claude/skills/`，**模型调用真的那个（正确行为）会被判成「未触发」**。它报 recall≈0 并据此迭代了 5 轮，实测 recall 是 78%。

判据本身失效时，优化它只会把描述带偏。这与本仓「max_tokens 探针打错了函数」那次是同一类：**先验证测量方法本身有效，再解读它的数字**。

（顺带：第一次想验证时用了 `timeout 120 claude -p ...`，macOS 没有 `timeout` 这个命令，整条命令失败、输出为空，差点把空结果读成「模型没调用任何工具」。所以正式重测前先拿一条必中查询验证了检测确实在工作。）

## 测试

| 验证 | 结果 |
|---|---|
| `bun --no-cache run test` | ✅ **3284 pass / 0 fail across 323 files** |
| `typecheck` | ✅ |
| `check:architecture` | ✅ 0 violations |
| 干净检出复验 | ✅ 守卫 6/6，预检脚本可跑 |

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXwrAUKwxx3cUkCSpmSca
