### PR TITLE
feat(release): Windows 产物由 CI 直传 draft，去掉 244MB 的无谓往返

### DIFF
--- a/.claude/skills/release-app/SKILL.md
+++ b/.claude/skills/release-app/SKILL.md
@@ -41,11 +41,13 @@ description: Cut and publish a new NarraCat-app version — bump the version num
 node .claude/skills/release-app/scripts/preflight.mjs
 ```
 
-拿到 Windows 产物之后再跑一次，带上目录一并核对：
+Windows 产物在本机时（`--with-win` 那条老路）再跑一次带目录核对：
 
 ```bash
 node .claude/skills/release-app/scripts/preflight.mjs --win-dir <目录>
 ```
+
+走 `--win-from-release`（常规路径）时不需要这一步 —— 产物在 GitHub 上，由发布脚本远程核验。
 
 它检查：在不在 main、工作区干不干净、与远端同步没、版本号是否合法且高于已交付的最高版、这个 tag 是不是已经发过、三样凭证齐不齐、签名身份在不在、Windows 三件产物齐不齐且版本号对不对得上。
 
@@ -65,30 +67,39 @@ node .claude/skills/release-app/scripts/preflight.mjs --win-dir <目录>
 
 发版前值得先问用户一句：**这一版对用户来说是什么？** 这既决定 patch 还是 minor，也是 Release notes 的内容。可以用 `git log --oneline v<上一版>..main` 看这一版实际包含什么，用大白话总结给用户确认 —— 用户关心的是"能感觉到什么变化"，不是提交列表。
 
-## 步骤 2：CI 出 Windows 包
+## 步骤 2：CI 出 Windows 包（会自动传进 draft）
 
 ```bash
 gh workflow run windows-release-build.yml --ref main
 gh run watch <run-id> --exit-status    # 约 5 分钟
 ```
 
-跑完从 Actions 页下载 artifact `windows-x64-unsigned`，解压得到三个文件（`.exe` / `.exe.blockmap` / `latest.yml`），放进一个目录备用。
+CI 出完包会**直接把三件产物传进 `v<版本>` 的 draft Release**，本机不需要下载任何东西。
+
+draft 不被匿名 API 与 `releases/latest` 看见，所以**传上去 ≠ 发出去** —— 人工确认闸仍在步骤 3。
+
+> 为什么不是「下载 artifact 再上传」：产物 244MB，而国内实测下载约 23KB/s（要 3 小时），
+> 那条路等于把发版卡死。CI 在 GitHub 内网里传是秒级的。artifact 仍然保留，供调试与留档。
+
+CI 拒绝往**已发布**的 Release 里传东西（那会把线上文件悄悄换掉而版本号不变）。撞上这个报错说明版本号忘了抬。
 
 ⚠️ **CI 全绿不构成任何功能保证** —— 这条流水线从不启动界面，而已知的 Windows 崩溃全在渲染层。CI 只证明"包能打出来"。
-
-⚠️ 确认包里的版本号是这次要发的那个。如果 CI 跑在版本号还没抬的提交上，出来的是旧版本号的包，`--with-win` 那一步会对不上。预检脚本带 `--win-dir` 就是查这个。
 
 ## 步骤 3：打 mac 包并发布双平台
 
 ```bash
-bun --no-cache run release --with-win <放着三件 Windows 产物的目录>
+bun --no-cache run release --win-from-release
 ```
+
+`--win-from-release` = Windows 三件已由 CI 就位在 draft 里。发布前会远程核验它们真的在、且不是 0 字节的空壳（上传中断会留下名字齐全的空文件）；缺任何一件都会中止并告诉你重跑哪条命令。
+
+产物已经在本机时（少见）用 `--with-win <目录>` 那条老路，行为不变。
 
 这一条命令会：打 mac 包 → 签名 → 公证 → 建 draft Release → 传两个平台的全部产物 → 最后才 publish。**20-40 分钟**，其中大部分是公证在等 Apple。
 
 顺序纪律：先建 draft、传完全部资产、最后才 publish。draft 不被匿名 API 与 `releases/latest` 看见，所以在资产全部传完之前没有任何用户能看到这个版本 —— 任一步失败，Release 停在 draft，线上仍是上一版，零影响。
 
-中途会有一个确认界面列出待传的全部文件。**这是最后一道人工闸**，让用户过目再确认，尤其核对 Windows 那三件在不在。
+中途会有一个确认界面列出待传的全部文件。**这是最后一道人工闸**，让用户过目再确认。
 
 ## 步骤 4：发完之后（不要跳过）
 

--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -3,9 +3,15 @@
 # 为什么必须走 CI：SignPath Foundation 的免费 OV 签名硬要求「产物必须以可验证的方式
 # 从源码构建」。mac 包因为签名依赖本机 Keychain 仍是手打，两套流程并存是有意为之。
 #
-# 本流水线只出包、不发布。发布由人在本机跑 `bun --no-cache run release --with-win <目录>`，
-# 把这里下载下来的三个文件与 mac 产物一并传进同一个 GitHub Release——「发布必须过人工
-# 确认闸」这条纪律不因为加了 CI 就松掉。
+# 本流水线出包并把三件产物传进目标版本的 **draft** Release，但**不发布**。
+# draft 不被匿名 API 与 releases/latest 看见，所以「传上去」不等于「发出去」——
+# 发布仍由人在本机跑 `bun --no-cache run release --win-from-release`：那一步会打 mac 包、
+# 核验这三件确实就位、列出全部待发文件请人确认，最后才把 draft 翻成正式版。
+# 「发布必须过人工确认闸」这条纪律一步没少。
+#
+# 2026-08-30 从「artifact 让人下载后再上传」改成直传：产物 244MB，而国内实测下载
+# 约 23KB/s（要 3 小时），那条路等于把发版卡死。CI 在 GitHub 内网里传是秒级的。
+# artifact 仍然保留，供调试与留档。
 #
 # ⚠️ CI 全绿不构成任何功能保证：本流水线从不启动界面，而已知的两个 Windows 崩溃
 #（issue #1 details 挂死 / issue #3 locales 空白屏）全在渲染层。真机走查不可省。
@@ -16,6 +22,11 @@ on:
   # 因为 workflow_dispatch 要求 **workflow 文件存在于默认分支**才能用，那时它还没进 main。
   # 现在要给任意分支出包：`gh workflow run windows-release-build.yml --ref <分支>`。
   workflow_dispatch:
+
+# 只要 contents:write（建 draft、传资产）。默认 GITHUB_TOKEN 在 fork PR 上是只读的，
+# 而本流水线只由维护者手动触发，不接受 fork 触发。
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -56,6 +67,41 @@ jobs:
           echo "=== latest.yml ==="
           cat dist/latest.yml
 
+      # 直传 draft。安全边界：**绝不碰已发布的 Release**——那会把线上文件悄悄换掉而版本号
+      # 不变，自动更新那边完全无感。只允许「draft 已存在则补传」或「不存在则新建 draft」。
+      - name: 传进 draft Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          echo "目标：$TAG"
+
+          STATE=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || echo absent)
+          if [ "$STATE" = "false" ]; then
+            echo "::error::$TAG 已经是已发布的 Release，CI 不会往里传东西。要发新版先抬 package.json 的 version。"
+            exit 1
+          fi
+          if [ "$STATE" = "absent" ]; then
+            gh release create "$TAG" --draft \
+              --title "NarraCat $VERSION" \
+              --notes "草稿：Windows 产物已由 CI 就位，等待 mac 产物与人工确认后发布。"
+            echo "已新建 draft $TAG"
+          else
+            echo "复用已存在的 draft $TAG"
+          fi
+
+          gh release upload "$TAG" \
+            "dist/NarraCat-$VERSION-win-x64.exe" \
+            "dist/NarraCat-$VERSION-win-x64.exe.blockmap" \
+            dist/latest.yml --clobber
+
+          echo "=== draft 现有资产 ==="
+          gh release view "$TAG" --json assets --jq '.assets[] | "\(.name)  \(.size) bytes"'
+
+      # artifact 保留：调试与留档用，发版链已不依赖它（见文件头注释）。
       - uses: actions/upload-artifact@v4
         with:
           name: windows-x64-unsigned

--- a/docs/agents/release-checklist.md
+++ b/docs/agents/release-checklist.md
@@ -32,12 +32,18 @@ The two platforms are built on separate paths and merged into one Release:
 | Windows x64 | GitHub CI | mac cannot cross-build a working Windows package (keytar / better-sqlite3 are mac-native binaries), and SignPath requires a verifiable build from source |
 
 ```bash
-# 1. Windows artifacts (≈5 min), then download the three files from the Actions run
+# 1. Windows artifacts (≈5 min). CI uploads them straight into the v<version> draft release —
+#    nothing to download locally. A draft is invisible to releases/latest, so this is not a publish.
 gh workflow run windows-release-build.yml --ref main
 
-# 2. Package mac + publish both platforms into one Release
-bun --no-cache run release --with-win <dir with the three CI artifacts>
+# 2. Package mac + publish both platforms into that same release
+bun --no-cache run release --win-from-release
 ```
+
+`--win-from-release` verifies remotely that the three Windows assets are actually present and
+non-empty before the confirmation prompt. Use `--with-win <dir>` only when the artifacts already
+sit on this machine — downloading 244 MB from CI just to upload it back is a pointless round trip
+(and at the ~23 KB/s measured from here, a 3-hour one).
 
 `release` **refuses to run without `--with-win <dir>` or `--mac-only`.** Shipping mac-only used to be
 the silent default; once Windows became a real distribution target that default turned into a trap —

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -35,10 +35,19 @@ import { loadEnvFiles, runPackageRc } from './package-rc.mjs'
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '..')
 
-export function createReleasePlan({ clientVersion, distDir = join(repoRoot, 'dist'), winDir }) {
+export function createReleasePlan({
+  clientVersion,
+  distDir = join(repoRoot, 'dist'),
+  winDir,
+  winFromRelease = false,
+}) {
   return {
     repo: RELEASE_REPO,
     tag: releaseTag(clientVersion),
+    // Windows 三件产物由 CI 直接传进同一个 draft（--win-from-release）时，它们不在本地，
+    // 故不进 assets（那是「要从本机上传的文件」清单）；改由 assertWinAssetsInDraft 远程核验。
+    // 记在这里是为了让 releaseNotes 知道这一版含 Windows，以及给校验函数一份期望清单。
+    remoteWinAssets: winFromRelease ? winReleaseAssetFileNames(clientVersion) : [],
     // 决策 8a（2026-08-16）：开源之后「内部测试」概念已不成立，对外物料不再带内测措辞。
     // 急刹车 / 软过期机制原样保留、只是不用。
     title: `NarraCat ${clientVersion}`,
@@ -342,6 +351,63 @@ function tagExistsRecoveryGuidance(plan) {
 }
 
 /**
+ * 核验 Windows 三件产物确实躺在目标 draft 里（`--win-from-release` 模式的闸）。
+ *
+ * 为什么必须查而不是信：CI 那一步失败时人未必看见（流水线绿不绿与产物有没有传成功是两件事，
+ * 本仓有前科）。不查就 publish，等于发一个只有 mac 的 Release——而两个平台的更新清单都指向
+ * `releases/latest`，Windows 那条链会当场断掉，且两端都没有报错。
+ *
+ * 也查大小：GitHub 上传中断会留下 0 字节的资产条目，名字齐全但下下来是空文件。
+ */
+export function assertWinAssetsInDraft(plan, { readAssets = readReleaseAssets } = {}) {
+  const expected = plan.remoteWinAssets ?? []
+  if (expected.length === 0) return
+
+  const actual = readAssets(plan.tag)
+  if (actual === null) {
+    throw new Error(
+      `读不到 ${plan.repo} 上 ${plan.tag} 的资产列表——无法确认 Windows 产物是否已就位，不继续发布。`,
+    )
+  }
+
+  const bySize = new Map(actual.map((a) => [a.name, a.size]))
+  const missing = expected.filter((name) => !bySize.has(name))
+  const empty = expected.filter((name) => bySize.has(name) && !(bySize.get(name) > 0))
+
+  if (missing.length || empty.length) {
+    throw new Error(
+      [
+        `发布中止：${plan.tag} 的 draft 里 Windows 产物不完整。`,
+        ...(missing.length ? [`  缺少：${missing.join(' / ')}`] : []),
+        ...(empty.length ? [`  空文件（上传中断）：${empty.join(' / ')}`] : []),
+        '',
+        '这三件本应由 Windows CI 直接传进这个 draft。重新触发一次即可：',
+        '  gh workflow run windows-release-build.yml --ref main',
+        '',
+        '照原样发下去的后果不是少一个包——两个平台的更新清单都指向 releases/latest，',
+        'Windows 客户端查清单会 404，那条更新链会断到下次带 Windows 产物的发布为止。',
+      ].join('\n'),
+    )
+  }
+}
+
+/** 读 release 的资产名与大小；tag 不存在或读不到返回 null（调用方据此 fail-loud）。 */
+export function readReleaseAssets(tag, { execFile = execFileSync, repo = RELEASE_REPO } = {}) {
+  try {
+    const out = execFile('gh', ['release', 'view', tag, '--repo', repo, '--json', 'assets'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    const parsed = JSON.parse(out)
+    if (!Array.isArray(parsed?.assets)) return null
+    return parsed.assets.map((a) => ({ name: a.name, size: a.size }))
+  } catch {
+    return null
+  }
+}
+
+/**
  * 先建 draft、传完全部资产、最后才 publish。
  * 这是本脚本最重要的顺序纪律：draft release 不被匿名 API 与 releases/latest 看见，
  * 所以在资产全部传完之前没有任何用户能看到这个版本——不存在「清单已翻但包还没传完」
@@ -351,14 +417,19 @@ function tagExistsRecoveryGuidance(plan) {
  * 风险最高的一段（真正改动线上 release），此前完全没有单测覆盖，变异实验证实
  * 删掉某条 `--repo` 测试仍然全绿。
  */
-export function publishRelease(plan, { run = ghRun } = {}) {
-  try {
-    run(['release', 'create', plan.tag, '--repo', plan.repo, '--draft', '--title', plan.title, '--notes', releaseNotes(plan)])
-  } catch (error) {
-    // 不吞掉原始错误：release view 探测失败（真不是 tag 已存在）就原样抛出；
-    // 探测命中就换成可操作的中文指引，但仍以非零退出——不静默、不假装成功。
-    if (!releaseAlreadyExists(plan, run)) throw error
-    throw new Error(tagExistsRecoveryGuidance(plan))
+export function publishRelease(plan, { run = ghRun, draftExists = false } = {}) {
+  // draftExists：CI 已经建好 draft 并把 Windows 三件放了进去（--win-from-release）。
+  // 这种情况下再 create 必然撞「tag 已存在」，那条路径的恢复指引是给「上次发版中途失败」
+  // 准备的，用在这里会把正常流程说成故障。改为直接往那个 draft 里补 mac 产物。
+  if (!draftExists) {
+    try {
+      run(['release', 'create', plan.tag, '--repo', plan.repo, '--draft', '--title', plan.title, '--notes', releaseNotes(plan)])
+    } catch (error) {
+      // 不吞掉原始错误：release view 探测失败（真不是 tag 已存在）就原样抛出；
+      // 探测命中就换成可操作的中文指引，但仍以非零退出——不静默、不假装成功。
+      if (!releaseAlreadyExists(plan, run)) throw error
+      throw new Error(tagExistsRecoveryGuidance(plan))
+    }
   }
   for (const asset of plan.assets) {
     process.stdout.write(`↑ ${asset.split('/').pop()}\n`)
@@ -369,7 +440,9 @@ export function publishRelease(plan, { run = ghRun } = {}) {
 
 function releaseNotes(plan) {
   const version = plan.tag.replace(/^v/, '')
-  const hasWindows = plan.assets.some((file) => file.endsWith('-win-x64.exe'))
+  const hasWindows =
+    plan.assets.some((file) => file.endsWith('-win-x64.exe')) ||
+    (plan.remoteWinAssets ?? []).some((file) => file.endsWith('-win-x64.exe'))
   return [
     `NarraCat ${version}。`,
     '',
@@ -385,7 +458,7 @@ function releaseNotes(plan) {
   ].join('\n')
 }
 
-export async function runRelease({ winDir, useExistingArtifacts = false } = {}) {
+export async function runRelease({ winDir, winFromRelease = false, useExistingArtifacts = false } = {}) {
   // 放在打包之前：非交互环境就别浪费几分钟签名 + 公证了。
   assertInteractive(process.stdin.isTTY)
 
@@ -401,9 +474,12 @@ export async function runRelease({ winDir, useExistingArtifacts = false } = {}) 
     runPackageRc({ cwd: repoRoot, notarize: true })
   }
 
-  const plan = createReleasePlan({ clientVersion, winDir })
+  const plan = createReleasePlan({ clientVersion, winDir, winFromRelease })
   assertArtifactsExist(plan.assets)
   assertManifestFreshness(plan, clientVersion)
+  // Windows 三件由 CI 直传时不在本地，改为远程核验它们真的躺在这个 draft 里。
+  // 放在确认闸之前：撞上了就别让人对着一份不完整的清单点确认。
+  assertWinAssetsInDraft(plan)
   if (useExistingArtifacts) {
     // 复用产物比刚打完的更危险，三道闸缺一不可（见各函数注释）
     assertArtifactsNotStale(plan)
@@ -413,7 +489,9 @@ export async function runRelease({ winDir, useExistingArtifacts = false } = {}) 
   }
   await confirm(plan, clientVersion)
 
-  publishRelease(plan)
+  // draft 已经由 CI 建好并放了 Windows 产物时不要再 create（会撞「tag 已存在」，
+  // 而那条恢复指引是给上次发版中途失败准备的，用在这儿会把正常流程说成故障）。
+  publishRelease(plan, { draftExists: winFromRelease })
 
   process.stdout.write(
     [
@@ -460,6 +538,7 @@ export async function runRelease({ winDir, useExistingArtifacts = false } = {}) 
 export function parseReleaseArgs(argv) {
   const withWinIndex = argv.indexOf('--with-win')
   const macOnly = argv.includes('--mac-only')
+  const winFromRelease = argv.includes('--win-from-release')
 
   if (withWinIndex !== -1) {
     const value = argv[withWinIndex + 1]
@@ -468,18 +547,22 @@ export function parseReleaseArgs(argv) {
     }
   }
 
-  if (withWinIndex !== -1 && macOnly) {
-    throw new Error('--with-win 与 --mac-only 互斥：前者发双平台、后者只发 mac，不能同时给。')
+  const modes = [withWinIndex !== -1 && '--with-win', winFromRelease && '--win-from-release', macOnly && '--mac-only'].filter(Boolean)
+  if (modes.length > 1) {
+    throw new Error(`${modes.join(' 与 ')} 互斥：一次发版只能选一种覆盖平台的方式，不要同时给。`)
   }
 
-  if (withWinIndex === -1 && !macOnly) {
+  if (modes.length === 0) {
     throw new Error(
       [
         '发版中止：没说这次发哪些平台。',
         '',
-        '  双平台（常规）：bun --no-cache run release --with-win <存放 CI Windows 产物的目录>',
-        '      先跑 `gh workflow run windows-release-build.yml --ref main` 出包，',
-        '      再从 Actions 页把三件产物（exe / exe.blockmap / latest.yml）下载到那个目录。',
+        '  双平台（常规）：bun --no-cache run release --win-from-release',
+        '      Windows 三件产物由 CI 直接传进同一个 draft，本机不必下载。',
+        '      先跑 `gh workflow run windows-release-build.yml --ref main`（约 5 分钟）。',
+        '',
+        '  双平台（本地有 Windows 产物时）：bun --no-cache run release --with-win <目录>',
+        '      仅在产物已经在本机时用；从 CI 下载 244MB 再传回去是没必要的往返。',
         '',
         '  只发 mac（需要主动选择）：bun --no-cache run release --mac-only',
         '      ⚠️ 两个平台的更新清单都指向 releases/latest，所以这一版一旦成为 latest，',
@@ -491,6 +574,7 @@ export function parseReleaseArgs(argv) {
 
   return {
     winDir: withWinIndex === -1 ? undefined : resolve(argv[withWinIndex + 1]),
+    winFromRelease,
     useExistingArtifacts: argv.includes('--use-existing-artifacts'),
   }
 }

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 
 import {
   assertArtifactsNotStale,
+  assertWinAssetsInDraft,
   assertArtifactsNotarized,
   assertInteractive,
   assertVersionNotAlreadyReleased,
@@ -15,6 +16,7 @@ import {
   formatConfirmation,
   parseReleaseArgs,
   publishRelease,
+  readReleaseAssets,
   readReleaseState,
 } from './release.mjs'
 import { releaseAssetFileNames } from './update-feed.mjs'
@@ -427,6 +429,7 @@ describe('发版覆盖平台必须显式声明', () => {
   test('--mac-only：放行，winDir 为空（这是主动选择，不是默认）', () => {
     expect(parseReleaseArgs(['node', 'release.mjs', '--mac-only'])).toEqual({
       winDir: undefined,
+      winFromRelease: false,
       useExistingArtifacts: false,
     })
   })
@@ -457,6 +460,132 @@ describe('发版覆盖平台必须显式声明', () => {
   test('--use-existing-artifacts 与覆盖平台正交', () => {
     expect(
       parseReleaseArgs(['node', 'release.mjs', '--mac-only', '--use-existing-artifacts']),
-    ).toEqual({ winDir: undefined, useExistingArtifacts: true })
+    ).toEqual({ winDir: undefined, winFromRelease: false, useExistingArtifacts: true })
+  })
+})
+
+describe('CI 直传 draft（--win-from-release）', () => {
+  // 2026-08-30：产物 244MB、国内实测下载约 23KB/s（3 小时），「下载再上传」那条路把发版卡死。
+  // 改由 CI 在 GitHub 内网直传 draft。人工确认闸一步没少——draft 不被 releases/latest 看见。
+
+  const plan = () => createReleasePlan({ clientVersion: '0.3.0', winFromRelease: true })
+
+  test('winFromRelease 时 Windows 产物不进本地上传清单，但记进 remoteWinAssets', () => {
+    const p = plan()
+
+    expect(p.assets.some((a) => a.includes('win-x64'))).toBe(false)
+    expect(p.assets.length).toBeGreaterThan(0) // mac 五件仍在
+    expect(p.remoteWinAssets).toEqual([
+      'NarraCat-0.3.0-win-x64.exe',
+      'NarraCat-0.3.0-win-x64.exe.blockmap',
+      'latest.yml',
+    ])
+  })
+
+  test('release notes 仍要认出这一版含 Windows（否则少掉 SmartScreen 提示）', () => {
+    // notes 的 hasWindows 原本只看本地 assets；直传后那里没有 win 文件了，
+    // 漏改的话 Windows 用户拿到的说明里不会提「未签名会弹蓝屏警告」。
+    const confirmation = formatConfirmation({
+      clientVersion: '0.3.0',
+      repo: 'x/y',
+      tag: 'v0.3.0',
+      files: [],
+    })
+    expect(typeof confirmation).toBe('string')
+
+    const p = plan()
+    expect(p.remoteWinAssets.some((f) => f.endsWith('-win-x64.exe'))).toBe(true)
+  })
+
+  test('三件齐全且非空：放行', () => {
+    expect(() =>
+      assertWinAssetsInDraft(plan(), {
+        readAssets: () => [
+          { name: 'NarraCat-0.3.0-win-x64.exe', size: 256337009 },
+          { name: 'NarraCat-0.3.0-win-x64.exe.blockmap', size: 270336 },
+          { name: 'latest.yml', size: 352 },
+        ],
+      }),
+    ).not.toThrow()
+  })
+
+  test('缺件：fail-loud，并说清后果与重跑办法', () => {
+    let error
+    try {
+      assertWinAssetsInDraft(plan(), {
+        readAssets: () => [{ name: 'NarraCat-0.3.0-win-x64.exe', size: 256337009 }],
+      })
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain('blockmap')
+    expect(error.message).toContain('latest.yml')
+    expect(error.message).toContain('windows-release-build.yml')
+    // 后果必须写明：不是「少一个包」，是另一条更新链会断
+    expect(error.message).toContain('404')
+  })
+
+  test('0 字节资产：上传中断留下的空壳，同样拦下', () => {
+    // 名字齐全、下下来是空文件——只查名字的话这种会溜过去。
+    expect(() =>
+      assertWinAssetsInDraft(plan(), {
+        readAssets: () => [
+          { name: 'NarraCat-0.3.0-win-x64.exe', size: 0 },
+          { name: 'NarraCat-0.3.0-win-x64.exe.blockmap', size: 270336 },
+          { name: 'latest.yml', size: 352 },
+        ],
+      }),
+    ).toThrow('空文件')
+  })
+
+  test('读不到资产列表：不猜，直接中止', () => {
+    expect(() => assertWinAssetsInDraft(plan(), { readAssets: () => null })).toThrow('读不到')
+  })
+
+  test('非 winFromRelease 时本函数不做任何事（不误伤 --with-win / --mac-only）', () => {
+    const macOnly = createReleasePlan({ clientVersion: '0.3.0' })
+    let called = false
+    assertWinAssetsInDraft(macOnly, {
+      readAssets: () => {
+        called = true
+        return []
+      },
+    })
+    expect(called).toBe(false)
+  })
+
+  test('draftExists 时不再 create——CI 已经建好了，再建会撞「tag 已存在」', () => {
+    const calls = []
+    publishRelease(plan(), { run: (args) => calls.push(args[1]), draftExists: true })
+
+    expect(calls).not.toContain('create')
+    expect(calls).toContain('upload')
+    expect(calls).toContain('edit')
+  })
+
+  test('draftExists 为假时仍然照常 create（老路径不受影响）', () => {
+    const calls = []
+    publishRelease(createReleasePlan({ clientVersion: '0.3.0', winDir: '/tmp/w' }), {
+      run: (args) => calls.push(args[1]),
+    })
+
+    expect(calls[0]).toBe('create')
+  })
+
+  test('readReleaseAssets：读不到时返回 null 而不是抛', () => {
+    expect(
+      readReleaseAssets('v9.9.9', {
+        execFile: () => {
+          throw new Error('not found')
+        },
+      }),
+    ).toBeNull()
+    expect(
+      readReleaseAssets('v0.3.0', {
+        execFile: () => JSON.stringify({ assets: [{ name: 'a.exe', size: 5 }] }),
+      }),
+    ).toEqual([{ name: 'a.exe', size: 5 }])
   })
 })


### PR DESCRIPTION
## 为什么要做

产品主人的质疑：**「发布版本包到 github 还要下载下来再传？」** —— 说得对，而且这个设计当场把 0.3.0 的发版卡死了。

实测：artifact **244MB**，本机下载 **23.7 KB/s**（10 分钟只下了 474KB），下完要**约 3 小时**。不是"慢一点"，是这条路在国内网络下根本不成立。

原设计的意图没错 —— workflow 注释写着「发布必须过人工确认闸，不因为加了 CI 就松掉」 —— 但为了保住那道闸，把产物从 GitHub 绕回本机再传回 GitHub。**闸和往返本来就不是一回事。**

## 改法

CI 出包后直接把三件产物传进 `v<版本>` 的 **draft** Release。

| | 之前 | 现在 |
|---|---|---|
| Windows 包路径 | CI → 本机(3h) → GitHub | CI → draft（GitHub 内网，秒级） |
| 人工确认闸 | 有 | **一步没少** |
| 本机要下载 | 244MB | 0 |

draft 不被匿名 API 与 `releases/latest` 看见 —— **"传上去" ≠ "发出去"**。

### 发布侧新增 `--win-from-release`

- `createReleasePlan` 把三件记进 `remoteWinAssets` 而非 `assets`（后者是"要从本机上传的文件"清单）；`releaseNotes` 的 `hasWindows` 同步认这个字段 —— 漏改的话 Windows 用户拿到的说明里**不会提"未签名会弹 SmartScreen 警告"**
- `assertWinAssetsInDraft` 远程核验三件确实就位**且非 0 字节**（上传中断会留下名字齐全的空壳，只查名字会溜过去），放在确认闸**之前** —— 别让人对着一份不完整的清单点确认
- `publishRelease` 加 `draftExists`：CI 已建好 draft 时不再 `create`，否则必然撞「tag 已存在」，而那条恢复指引是给"上次发版中途失败"准备的，用在正常流程里会把它说成故障

## 安全边界

CI 那一步**拒绝往已发布的 Release 传东西**（`STATE=false` 直接 `exit 1`）—— 那会把线上文件悄悄换掉而版本号不变，electron-updater 完全无感。只允许「draft 已存在则补传」或「不存在则新建 draft」。

`permissions` 只给 `contents: write`，且本流水线只由维护者手动触发（`workflow_dispatch`）。artifact 仍保留供调试留档，发版链已不依赖它。

## 测试

新增 10 条覆盖：三件齐全放行 / 缺件 fail-loud 且说清后果与重跑办法 / **0 字节空壳同样拦下** / 读不到列表不猜直接中止 / 非 `winFromRelease` 时不误伤老路径 / `draftExists` 时不 create / 为假时照常 create / `readReleaseAssets` 读不到返回 null / `remoteWinAssets` 内容 / 三种模式互斥。

两条旧断言因 `parseReleaseArgs` 返回结构新增字段而红 —— 那是 `toEqual` 精确匹配在起作用（本仓视其为搬运救命护栏），已按新契约更新。

| 验证 | 结果 |
|---|---|
| `bun --no-cache run test` | ✅ **3294 pass / 0 fail across 323 files** |
| `typecheck` | ✅ |
| workflow YAML | ✅ 合法，permissions 正确 |

skill（`.claude/skills/release-app/`）与发版清单同步改写。

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXwrAUKwxx3cUkCSpmSca