### PR TITLE
fix(release): 陈旧闸改比「最后一次影响产物的改动」，不再拿 HEAD 当代理

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -221,18 +221,68 @@ export function assertZipMatchesManifest(plan) {
  * 产物不得早于 HEAD 提交——防的是「改完代码忘了重新打包，直接复用上一次的产物发版」。
  * 版本号校验挡不住这一类：同一个提交数下改动源码，版本号一模一样，清单也「新鲜」。
  */
-export function assertArtifactsNotStale(plan, { cwd = repoRoot, distDir = join(repoRoot, 'dist') } = {}) {
+/**
+ * 确定**不进 App 产物**的路径。改这些不该逼人重打一次二十到四十分钟的包。
+ *
+ * ⚠️ 方向性判断：这是**排除清单**而不是包含清单，因为两种漏写的代价完全不对称——
+ * 漏写一条排除项，最坏是多打一次包（安全）；漏写一条包含项，就会发出一份不含新代码的包
+ * 且无人察觉（危险）。所以只把**确定**不进产物的放进来，拿不准的一律不加、让它触发重打。
+ *
+ * `scripts/` 整体不排除：里面既有发版脚本（不进产物），也有 prepare-narracat-agent-core /
+ * prepare-embedding-model / package-rc 这些实打实决定产物内容的。只点名排除确知无关的几个。
+ */
+const NON_PRODUCT_PATHSPECS = [
+  ':(exclude)docs/',
+  ':(exclude).github/',
+  ':(exclude).claude/',
+  ':(exclude).agents/',
+  ':(exclude)workers/',
+  ':(exclude)*.md',
+  ':(exclude).gitignore',
+  ':(exclude)scripts/release.mjs',
+  ':(exclude)scripts/ops-*.mjs',
+  ':(exclude)*.test.mjs',
+  ':(exclude)*.test.ts',
+  ':(exclude)*.test.tsx',
+]
+
+/**
+ * 最后一次改动「可能进产物的文件」的提交时间。
+ *
+ * 为什么不直接用 HEAD：闸的语义是「产物不能比它所代表的代码旧」，而 HEAD 时间只是那个语义的
+ * 粗糙代理。发版前顺手改发版脚本、补文档、调 CI——这些都会推高 HEAD 却一个字节都不进产物，
+ * 于是闸会逼人重打一份逐字节相同的包（2026-08-30 实撞：#62 只改了发版脚本与文档，
+ * 却让一份刚验收过的 mac 包被判为「比当前提交还旧」）。
+ *
+ * 拿不到结果时回退 HEAD——宁可误判成需要重打，不可放过一份真的过期的产物。
+ */
+export function lastProductChangeIso({ cwd = repoRoot, execFile = execFileSync } = {}) {
+  const read = (args) => String(execFile('git', args, { cwd, encoding: 'utf8' })).trim()
+  try {
+    const scoped = read(['log', '-1', '--format=%cI', '--', '.', ...NON_PRODUCT_PATHSPECS])
+    if (scoped) return scoped
+  } catch {
+    // 落到下面的 HEAD 回退
+  }
+  return read(['log', '-1', '--format=%cI'])
+}
+
+export function assertArtifactsNotStale(
+  plan,
+  { cwd = repoRoot, distDir = join(repoRoot, 'dist'), readProductChangeIso = lastProductChangeIso } = {},
+) {
   const app = join(distDir, 'mac-arm64', 'NarraCat.app')
   if (!existsSync(app)) return
-  const headIso = execFileSync('git', ['log', '-1', '--format=%cI'], { cwd, encoding: 'utf8' }).trim()
-  const headTime = new Date(headIso).getTime()
+  const changeIso = readProductChangeIso({ cwd })
+  const changeTime = new Date(changeIso).getTime()
   const builtTime = statSync(app).mtimeMs
-  if (builtTime >= headTime) return
+  if (builtTime >= changeTime) return
   throw new Error(
     [
-      '产物比当前提交还旧，复用它等于发布一份不含最新代码的包：',
+      '产物比最后一次影响产物的代码改动还旧，复用它等于发布一份不含最新代码的包：',
       `  产物构建于：${new Date(builtTime).toISOString()}`,
-      `  HEAD 提交于：${headIso}`,
+      `  代码改动于：${changeIso}`,
+      '（只改文档 / CI / 发版脚本不算数，那些不进产物，见 NON_PRODUCT_PATHSPECS）',
       '请走完整打包发版（去掉 --use-existing-artifacts）。',
     ].join('\n'),
   )

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import {
   assertArtifactsNotStale,
   assertWinAssetsInDraft,
+  lastProductChangeIso,
   assertArtifactsNotarized,
   assertInteractive,
   assertVersionNotAlreadyReleased,
@@ -324,7 +325,7 @@ describe('复用现成产物的三道加严闸（--use-existing-artifacts）', (
     }
   })
 
-  test('陈旧闸：产物早于 HEAD 提交就必须拒绝——防「改完代码忘了重新打包」', async () => {
+  test('陈旧闸：产物早于最后一次产物代码改动就必须拒绝——防「改完代码忘了重新打包」', async () => {
     const { dir, distDir, plan } = await makeDist()
     try {
       // 刚建出来的产物晚于 HEAD → 放行
@@ -332,7 +333,7 @@ describe('复用现成产物的三道加严闸（--use-existing-artifacts）', (
       // 把产物时间推回 2020 年 → 拒绝
       const app = join(distDir, 'mac-arm64', 'NarraCat.app')
       await utimes(app, new Date('2020-01-01'), new Date('2020-01-01'))
-      expect(() => assertArtifactsNotStale(plan, { distDir })).toThrow(/产物比当前提交还旧/)
+      expect(() => assertArtifactsNotStale(plan, { distDir })).toThrow(/不含最新代码/)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -587,5 +588,99 @@ describe('CI 直传 draft（--win-from-release）', () => {
         execFile: () => JSON.stringify({ assets: [{ name: 'a.exe', size: 5 }] }),
       }),
     ).toEqual([{ name: 'a.exe', size: 5 }])
+  })
+})
+
+describe('stale 闸比的是「最后一次影响产物的改动」而非 HEAD', () => {
+  // 2026-08-30 实撞：#62 只改了发版脚本与文档，却把一份刚验收过的 mac 包判成「比当前提交还旧」，
+  // 逼人重打一份逐字节相同的包（20-40 分钟，大部分在等 Apple 公证）。
+  // 闸的语义一直是「产物不能比它所代表的代码旧」，HEAD 时间只是那个语义的粗糙代理。
+
+  const { mkdtempSync, mkdirSync, utimesSync } = require('node:fs')
+  const { tmpdir } = require('node:os')
+
+  function fakeDist(builtAtMs) {
+    const dir = mkdtempSync(join(tmpdir(), 'narracat-stale-'))
+    const app = join(dir, 'mac-arm64', 'NarraCat.app')
+    mkdirSync(app, { recursive: true })
+    utimesSync(app, new Date(builtAtMs), new Date(builtAtMs))
+    return dir
+  }
+
+  const plan = () => createReleasePlan({ clientVersion: '0.3.0' })
+
+  test('产物晚于最后一次产物改动：放行', () => {
+    const distDir = fakeDist(Date.parse('2026-08-30T20:34:00+08:00'))
+    expect(() =>
+      assertArtifactsNotStale(plan(), {
+        distDir,
+        readProductChangeIso: () => '2026-08-30T17:32:28+08:00',
+      }),
+    ).not.toThrow()
+  })
+
+  test('产物早于最后一次产物改动：仍然拦（闸没被改松）', () => {
+    const distDir = fakeDist(Date.parse('2026-08-30T16:00:00+08:00'))
+    expect(() =>
+      assertArtifactsNotStale(plan(), {
+        distDir,
+        readProductChangeIso: () => '2026-08-30T17:32:28+08:00',
+      }),
+    ).toThrow('不含最新代码')
+  })
+
+  test('核心场景：只改文档/发版脚本之后，产物不该被判过期', () => {
+    // 产物 20:34 打的；之后 21:18 合了一个只动发版脚本与文档的提交。
+    // 旧实现拿 HEAD(21:18) 比 → 误拦；新实现拿最后一次产物改动(17:32) 比 → 放行。
+    const distDir = fakeDist(Date.parse('2026-08-30T20:34:00+08:00'))
+    expect(() =>
+      assertArtifactsNotStale(plan(), {
+        distDir,
+        readProductChangeIso: () => '2026-08-30T17:32:28+08:00',
+      }),
+    ).not.toThrow()
+  })
+
+  test('产物不存在时直接放行（没东西可复用，交给打包流程）', () => {
+    expect(() =>
+      assertArtifactsNotStale(plan(), {
+        distDir: join(tmpdir(), 'narracat-does-not-exist-' + Date.now()),
+        readProductChangeIso: () => '2999-01-01T00:00:00+08:00',
+      }),
+    ).not.toThrow()
+  })
+
+  test('排除清单确实把文档/CI/发版脚本/测试排掉了，且没排掉产物代码', () => {
+    let captured = null
+    lastProductChangeIso({
+      execFile: (_cmd, args) => {
+        captured = args
+        return '2026-08-30T17:32:28+08:00'
+      },
+    })
+
+    const spec = captured.join(' ')
+    // 确定不进产物的
+    for (const excluded of ['docs/', '.github/', '.claude/', 'workers/', '*.md', 'scripts/release.mjs', '*.test.mjs']) {
+      expect(spec).toContain(`:(exclude)${excluded}`)
+    }
+    // 决定产物内容的绝不能出现在排除清单里——漏一条就会发出不含新代码的包
+    for (const mustNotExclude of ['electron/', 'src/', 'shared/', 'agent-core/', 'resources/', 'package.json', 'electron.vite.config.ts', 'scripts/package-rc.mjs', 'scripts/prepare-']) {
+      expect(spec).not.toContain(`:(exclude)${mustNotExclude}`)
+    }
+  })
+
+  test('拿不到范围内的结果时回退 HEAD——宁可误判重打，不可放过真过期的产物', () => {
+    const calls = []
+    const iso = lastProductChangeIso({
+      execFile: (_cmd, args) => {
+        calls.push(args)
+        return calls.length === 1 ? '' : '2026-08-30T21:18:32+08:00'
+      },
+    })
+
+    expect(iso).toBe('2026-08-30T21:18:32+08:00')
+    expect(calls).toHaveLength(2)
+    expect(calls[1]).toEqual(['log', '-1', '--format=%cI']) // 第二次是不带 pathspec 的 HEAD
   })
 })


### PR DESCRIPTION
## 问题

闸的语义一直是「产物不能比它所代表的代码旧」，但实现拿的是 **HEAD 提交时间** —— 那只是那个语义的粗糙代理。发版前顺手改发版脚本、补文档、调 CI 都会推高 HEAD 却**一个字节都不进产物**，于是闸会逼人重打一份逐字节相同的包。

**2026-08-30 实撞**：PR #62 只改了 `scripts/release.mjs`、workflow、skill 与文档 —— `git diff --name-only -- electron/ src/ shared/ agent-core/ resources/` 输出为空 —— 却把一份刚打好并已真机验收的 mac 包判成「比当前提交还旧」。代价是 20-40 分钟重打，其中大部分在等 Apple 公证。

```
HEAD (04f7a00 发版脚本改动)        21:18   ← 旧实现拿这个比 → 误拦
最后一次影响产物的提交 (8d86516)   17:32   ← 应该拿这个比
mac 产物构建于                     20:34   ← 本就该放行
```

## 改法

新增 `lastProductChangeIso()`，用 git pathspec 排除确知不进产物的路径后取最后一次提交时间。

### ⚠️ 方向性判断：排除清单，不是包含清单

两种漏写的代价完全不对称：

| 漏写 | 后果 |
|---|---|
| 漏一条**排除**项 | 多打一次包（**安全**） |
| 漏一条**包含**项 | 发出一份不含新代码的包，且无人察觉（**危险**） |

所以只把**确定**不进产物的放进排除清单，拿不准的一律不加、让它触发重打。

`scripts/` 整体不排除：里面既有发版脚本（不进产物），也有 `prepare-narracat-agent-core` / `prepare-embedding-model` / `package-rc` 这些实打实决定产物内容的。只点名排除确知无关的几个。

拿不到范围内结果时**回退 HEAD** —— 宁可误判成需要重打，不可放过一份真的过期的产物。

## 测试

新增 6 条，其中两条专防「把闸改松」：

1. **产物早于产物改动仍然拦** —— 闸没被改松
2. **排除清单里绝不能出现** `electron/` `src/` `shared/` `agent-core/` `resources/` `package.json` `electron.vite.config.ts` `package-rc` `prepare-*` —— 漏一条就会发出不含新代码的包

另有核心场景（只改文档后不判过期）、回退路径、产物不存在时放行的覆盖。既有那条陈旧闸测试的**行为断言不变**，只更新了文案与用例名。

| 验证 | 结果 |
|---|---|
| `bun --no-cache run test` | ✅ **3300 pass / 0 fail across 323 files** |
| `typecheck` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXwrAUKwxx3cUkCSpmSca