### PR TITLE
fix(models): 模型目录按官方核对更新，删必 404 的 glm-5.2[1m]，下线 id 当场标出

### DIFF
--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -4,6 +4,14 @@
 
 ## Current Branch
 
+**2026-09-07（模型目录按官方核对更新 + 下线 id 当场标出，分支 fix/model-catalog-2026-09）**：PR #77 调研出的第三条：`glm-5.2[1m]` 与 `kimi-k3[1m]` 同构必 404（后缀是 Claude Code 客户端约定，各家 model 字段不认，本仓 pi 链路原样发出无剥离逻辑），目录里挂着它等于给用户一个必炸的推荐项。本次：
+- **目录**（`model-providers.ts`）：删 `glm-5.2[1m]`；deepseek 加 v4-flash；anthropic 换 opus-5 / sonnet-5 领头（4.7 / 4.6 留作 legacy）；minimax 加 M2.7；glm 加免费档 4.7-flash。**刻意不收**：claude-fable-5*（对显式关思考回 400，冷 pass / 润色 / 角色聊天三条路径都发）、glm-5.3（思考恒开不可关，未真机验证）。目录注释写明每条取舍与核对来源。
+- **第二份副本** `config.ts` 的 `LEGACY_DEFAULT_MODELS` 同步（glm → glm-5.2），测试跟改。
+- **下线表** `retiredModelReplacement`：deepseek-chat / reasoner（07-24 退役）、kimi-k2.5 / moonshot-v1* / kimi-k2-*（08-31 / 05-25）、kimi-latest、两个 `[1m]`。设置页模型行当场标「已下线 · 建议 X」（`WARNING_OUTLINE_PILL_CLASS`），不等作者写章时撞「模型不存在」。归一化仍不对照目录，旧配置零影响。
+- 守卫：目录测试钉「无 `[1m]`、不收 fable/glm-5.3、目录与下线表不矛盾」。
+- **刻意不做**：上下文窗口按模型查表——把 deepseek 从 200K 自动抬到 1M 会推迟 pi 压缩、每轮上下文成本上升，是行为改动，`[1m]` 仍是作者的显式 opt-in（只对 Anthropic 真实可用）。GLM/Kimi 想用 1M 上下文目前没有合法口子，留待做「长上下文」每条目开关。
+- **未真机验**：`glm-5.2[1m]` 的 404 是结构推断（GLM 无可用 Key），kimi 那次是实测。
+
 **2026-09-07（PR #77 评审修复四条）**：①**P1 同一问题只消费一次**——渲染端提交超时后允许再点，主进程若还在给第一次落盘，两次都收下会让 Agent 拿到答案 A、界面与历史显示答案 B（评审用真实 run-manager 复现）。修：`PendingQuestion.answering` 占坑 + 有界 `answeredQuestionIds`，第二次提交回 `{accepted:false, reason:'already-answered'}`，渲染端据此提示「已收到正在保存」并保持提交中，不复位；回执类型贯通 coordinator / ipc / preload / ipc.d.ts。②**P2 openai-completions wire 不重派**——`thinking:{type:'disabled'}` 只在 anthropic-messages wire 发得出去，pi 的 openai-completions 仅 compat 命中 deepseek/zai 才带关闭字段，自定义网关两轮请求一模一样却声称「已关闭思考」；重派条件加 `api === 'anthropic-messages'`。③**P2 描述过长撑爆链接**——描述进预算（编码后 1800 字节≈200 中文字，超出截断并注明），标题限 60 字符，`buildGitHubIssueUrl` 拼完再按 7600 兜底逐行砍日志；剪贴板版 descriptionBudget=Infinity 保全文。④**规范：去 class**——`SubmitTimeoutError` 改成普通 Error 挂 `code`，`isSubmitTimeoutError` 判。全量 3646 绿。
 
 **教训**：提交超时 + 允许重试的组合，必须在服务端配幂等（首次占坑）；「关闭思考」这类协议字段要按 wire 逐条核实是否真的发出去，不能因为 anthropic wire 生效就在另一条 wire 上也声称生效。

--- a/electron/main/config.test.ts
+++ b/electron/main/config.test.ts
@@ -25,12 +25,12 @@ const LEGACY_DEEPSEEK = {
 const legacyVerified = {
   provider: 'glm',
   baseUrl: 'https://open.bigmodel.cn/api/anthropic',
-  models: { opus: 'glm-5.2[1m]', sonnet: 'glm-5.2[1m]', haiku: 'glm-4.5-air' },
+  models: { opus: 'glm-5.2', sonnet: 'glm-5.2', haiku: 'glm-4.5-air' },
   apiKeyMetadata: { glm: { updatedAt: '2026-08-01T00:00:00.000Z' } },
   modelServiceVerification: {
     provider: 'glm',
     baseUrl: 'https://open.bigmodel.cn/api/anthropic',
-    models: { opus: 'glm-5.2[1m]', sonnet: 'glm-5.2[1m]', haiku: 'glm-4.5-air' },
+    models: { opus: 'glm-5.2', sonnet: 'glm-5.2', haiku: 'glm-4.5-air' },
     apiKeyUpdatedAt: '2026-08-01T00:00:00.000Z',
     verifiedAt: '2026-08-01T12:00:00.000Z',
   },
@@ -310,10 +310,10 @@ describe('模型池迁移', () => {
   test('旧形态迁移：三档去重进池、sonnet→主力、haiku→轻量、旧验证过渡到所有条目', () => {
     const config = normalizeAppConfig(legacyVerified, '/Users/tester')
     expect(config.modelPool.map((e) => `${e.provider}/${e.modelId}`)).toEqual([
-      'glm/glm-5.2[1m]',
+      'glm/glm-5.2',
       'glm/glm-4.5-air',
     ])
-    expect(config.primaryModelKey).toBe('glm/glm-5.2[1m]')
+    expect(config.primaryModelKey).toBe('glm/glm-5.2')
     expect(config.lightModelKey).toBe('glm/glm-4.5-air')
     expect(config.providers.glm.baseUrl).toBe('https://open.bigmodel.cn/api/anthropic')
     expect(config.modelPool.every((e) => e.verification?.verifiedAt === '2026-08-01T12:00:00.000Z')).toBe(true)
@@ -353,14 +353,14 @@ describe('markModelEntryVerified', () => {
       { ...legacyVerified, modelServiceVerification: null },
       '/Users/tester',
     )
-    const marked = markModelEntryVerified(base, 'glm/glm-5.2[1m]', '2026-08-02T08:00:00.000Z')
+    const marked = markModelEntryVerified(base, 'glm/glm-5.2', '2026-08-02T08:00:00.000Z')
     expect(isModelServiceVerified(marked)).toBe(true)
     expect(marked.modelPool.find((e) => e.modelId === 'glm-4.5-air')?.verification).toBeNull()
   })
 
   test('Key 未配置（无 apiKeyMetadata）时拒绝标记', () => {
     const base = normalizeAppConfig({ ...legacyVerified, apiKeyMetadata: {}, modelServiceVerification: null }, '/Users/tester')
-    const marked = markModelEntryVerified(base, 'glm/glm-5.2[1m]', '2026-08-02T08:00:00.000Z')
+    const marked = markModelEntryVerified(base, 'glm/glm-5.2', '2026-08-02T08:00:00.000Z')
     expect(isModelServiceVerified(marked)).toBe(false)
   })
 })
@@ -371,7 +371,7 @@ describe('markProviderVerified', () => {
       {
         apiKeyMetadata: { glm: { updatedAt: '2026-08-01T00:00:00.000Z' } },
         modelPool: [
-          { provider: 'glm', modelId: 'glm-5.2[1m]', verification: null },
+          { provider: 'glm', modelId: 'glm-5.2', verification: null },
           { provider: 'glm', modelId: 'glm-4.5-air', verification: null },
           { provider: 'deepseek', modelId: 'deepseek-v4-pro', verification: null },
         ],
@@ -401,7 +401,7 @@ describe('markProviderVerified', () => {
       {
         apiKeyMetadata: {},
         modelPool: [
-          { provider: 'glm', modelId: 'glm-5.2[1m]', verification: null },
+          { provider: 'glm', modelId: 'glm-5.2', verification: null },
           { provider: 'glm', modelId: 'glm-4.5-air', verification: null },
         ],
       },

--- a/electron/main/config.ts
+++ b/electron/main/config.ts
@@ -55,8 +55,9 @@ const LEGACY_DEFAULT_MODELS: Record<ProviderId, LegacyModelMapping> = {
     haiku: 'MiniMax-M2',
   },
   glm: {
-    opus: 'glm-5.2[1m]',
-    sonnet: 'glm-5.2[1m]',
+    // 不用 `glm-5.2[1m]`：与 `kimi-k3[1m]` 同构必 404（后缀是 Claude Code 客户端约定，智谱 model 字段不认）。
+    opus: 'glm-5.2',
+    sonnet: 'glm-5.2',
     haiku: 'glm-4.5-air',
   },
   kimi: {

--- a/src/components/settings/ModelProviderDetailPanel.test.tsx
+++ b/src/components/settings/ModelProviderDetailPanel.test.tsx
@@ -252,6 +252,20 @@ describe('ModelProviderDetailPanel（SSR 结构断言）', () => {
     expect(field).toContain('该模型上限未核实，留空按 32,000 发送')
   })
 
+  test('池里手填的下线 id 当场标「已下线 · 建议 X」，目录内正常 id 不标', () => {
+    const html = render({
+      config: baseConfig({
+        modelPool: [
+          { provider: 'deepseek', modelId: 'deepseek-v4-pro', verification: null },
+          { provider: 'deepseek', modelId: 'deepseek-chat', verification: null },
+        ],
+      }),
+    })
+    expect(html).toContain('data-model-retired="deepseek-chat"')
+    expect(html).toContain('已下线 · 建议 deepseek-v4-flash')
+    expect(html).not.toContain('data-model-retired="deepseek-v4-pro"')
+  })
+
   test('添加自定义模型：空输入禁用（SSR 默认态）', () => {
     const html = render()
     const addButton = html.match(/<button[^>]*>\s*添加\s*<\/button>/)?.[0] ?? ''

--- a/src/components/settings/ModelProviderDetailPanel.tsx
+++ b/src/components/settings/ModelProviderDetailPanel.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { SettingsRow } from '@/components/settings/SettingsLayout'
-import { GROUP_CLASS, MUTED_PILL_CLASS } from '@/design-system'
+import { GROUP_CLASS, MUTED_PILL_CLASS, WARNING_OUTLINE_PILL_CLASS } from '@/design-system'
 import { cn } from '@/lib/cn'
 import {
   documentedMaxOutputTokens,
@@ -16,7 +16,7 @@ import {
 import { isEntryVerified, modelEntryKey } from '@shared/lib/model-slots'
 import type { WireId } from '@shared/types/config'
 import type { AppConfig, ConnectionTestResult, ModelPoolEntry, ProviderId } from '@shared/types/ipc'
-import { canListModels, MODEL_CATALOG, MODEL_PROVIDERS } from './model-providers'
+import { canListModels, MODEL_CATALOG, MODEL_PROVIDERS, retiredModelReplacement } from './model-providers'
 
 /**
  * 渠道详情二级页（渠道两级 UI v2 T4）：四分组——Key 与连接 / 接口协议与地址 / 模型列表 / 添加自定义模型。
@@ -322,12 +322,19 @@ function ModelRow({
   const enabled = entry !== undefined
   const isPrimary = config.primaryModelKey === key
   const isLight = config.lightModelKey === key
+  // 手填过的旧 id 仍留在池里，只在真调用时才 404——在这里当场标出来，别让作者写章时才撞「模型不存在」。
+  const retiredReplacement = retiredModelReplacement(provider, modelId)
 
   return (
     <div data-model-toggle={modelId} data-enabled={enabled ? 'true' : 'false'} className="px-3 py-2.5">
       <div className="flex min-h-[32px] items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <span className="truncate font-mono text-xs text-foreground">{modelId}</span>
+          {retiredReplacement ? (
+            <span className={WARNING_OUTLINE_PILL_CLASS} data-model-retired={modelId} title={`该模型已下线，建议改用 ${retiredReplacement}`}>
+              已下线 · 建议 {retiredReplacement}
+            </span>
+          ) : null}
           {isPrimary ? <span className={MUTED_PILL_CLASS}>主力</span> : null}
           {isLight ? <span className={MUTED_PILL_CLASS}>轻量</span> : null}
           {enabled ? (

--- a/src/components/settings/model-providers.test.ts
+++ b/src/components/settings/model-providers.test.ts
@@ -9,6 +9,7 @@ import {
   parseModelProviderParam,
   providerStatus,
   providerStatusLabel,
+  retiredModelReplacement,
 } from './model-providers'
 
 function baseView(overrides: Partial<ModelSlotView> = {}): ModelSlotView {
@@ -56,6 +57,53 @@ describe('MODEL_CATALOG（内置推荐目录）', () => {
     expect(Object.keys(MODEL_CATALOG).sort()).toEqual([...PROVIDER_IDS].sort())
     expect(MODEL_CATALOG.custom).toEqual([])
     expect(MODEL_CATALOG.deepseek.length).toBeGreaterThan(0)
+  })
+})
+
+describe('MODEL_CATALOG（2026-09-07 官方核对后的内容约束）', () => {
+  test('目录里没有任何 `[1m]` 后缀 id——kimi-k3[1m] 真机 404，glm-5.2[1m] 同构', () => {
+    for (const ids of Object.values(MODEL_CATALOG)) {
+      expect(ids.some((id) => id.endsWith('[1m]'))).toBe(false)
+    }
+  })
+
+  test('不收必炸的型号：Fable 对显式关思考回 400；glm-5.3 思考不可关，未真机验证前不进目录', () => {
+    expect(MODEL_CATALOG.anthropic.some((id) => id.startsWith('claude-fable'))).toBe(false)
+    expect(MODEL_CATALOG.glm).not.toContain('glm-5.3')
+  })
+
+  test('核对后的领头型号在目录首位（首项是设置页默认推荐）', () => {
+    expect(MODEL_CATALOG.deepseek[0]).toBe('deepseek-v4-pro')
+    expect(MODEL_CATALOG.deepseek).toContain('deepseek-v4-flash')
+    expect(MODEL_CATALOG.anthropic[0]).toBe('claude-opus-5')
+    expect(MODEL_CATALOG.glm[0]).toBe('glm-5.2')
+    expect(MODEL_CATALOG.minimax).toContain('MiniMax-M2.7')
+  })
+
+  test('目录里的 id 都不在下线表里（目录与下线表不能自相矛盾）', () => {
+    for (const provider of PROVIDER_IDS) {
+      for (const id of MODEL_CATALOG[provider]) expect(retiredModelReplacement(provider, id)).toBeNull()
+    }
+  })
+})
+
+describe('retiredModelReplacement（下线 id → 建议替代）', () => {
+  test('精确表：deepseek-chat / deepseek-reasoner 2026-07-24 退役；[1m] 后缀必 404', () => {
+    expect(retiredModelReplacement('deepseek', 'deepseek-chat')).toBe('deepseek-v4-flash')
+    expect(retiredModelReplacement('deepseek', 'deepseek-reasoner')).toBe('deepseek-v4-pro')
+    expect(retiredModelReplacement('glm', 'glm-5.2[1m]')).toBe('glm-5.2')
+    expect(retiredModelReplacement('kimi', 'kimi-k3[1m]')).toBe('kimi-k3')
+  })
+
+  test('前缀族：moonshot-v1* 与 kimi-k2-* 全线下线，kimi-k2.6 不在其列', () => {
+    expect(retiredModelReplacement('kimi', 'moonshot-v1-128k')).toBe('kimi-k3')
+    expect(retiredModelReplacement('kimi', 'kimi-k2-0711-preview')).toBe('kimi-k3')
+    expect(retiredModelReplacement('kimi', 'kimi-k2.6')).toBeNull()
+    expect(retiredModelReplacement('kimi', 'kimi-k3')).toBeNull()
+  })
+
+  test('键是 provider 限定的：custom 渠道挂同名 id 不判下线（后端是谁我们不知道）', () => {
+    expect(retiredModelReplacement('custom', 'deepseek-chat')).toBeNull()
   })
 })
 

--- a/src/components/settings/model-providers.ts
+++ b/src/components/settings/model-providers.ts
@@ -37,19 +37,55 @@ export const MODEL_PROVIDERS: Array<{
 
 // 起步精选目录：官方模型迭代快且无可靠的列模型接口，故由 App 内置维护，
 // 下拉给推荐项、同时允许手填任意 model id（见旧 ModelIdPicker，T4 迁移时随之搬家）。
+//
+// 2026-09-07 按各家官方模型列表页核对（deepseek api-docs model_list / platform.claude.com models overview /
+// docs.bigmodel.cn model-overview / platform.kimi.com models / platform.minimaxi.com text-generation）。
+// 每条目录都是「官方仍在列且本仓链路能跑」的交集，不是官方全集：
+// - anthropic 不收 claude-fable-5*：它对显式 `thinking: {type:'disabled'}` 回 400，而冷 pass / 润色 /
+//   角色聊天三条路径都发这个字段，收进来等于给用户一个必炸的选项。
+// - glm 不收 glm-5.3：官方写明思考恒开不可关、从 5.2 升级须把 thinking.type 改 enabled 否则失败，
+//   与冷 pass 关思考的策略冲突；没有真机验证前不进目录，用户可手填。
+// - ⚠️ 不要加任何 `xxx[1m]`：`kimi-k3[1m]` 真机 404（`Not found the model kimi-k3[1m]`），`glm-5.2[1m]`
+//   同构——那个后缀是 Claude Code 客户端的上下文标记约定，各家 model 字段不认；本仓 pi 链路把 id 原样发出
+//   且无剥离逻辑。deepseek-v4 / glm-5.2 / kimi-k3 本身即 1M 上下文，无需后缀。
+// - 另有第二份副本 electron/main/config.ts 的 LEGACY_DEFAULT_MODELS（只服务旧三档配置一次性迁移），改目录须同步。
 export const MODEL_CATALOG: Record<ProviderId, string[]> = {
-  deepseek: ['deepseek-v4-pro'],
-  anthropic: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
-  minimax: ['MiniMax-M3', 'MiniMax-M2.5', 'MiniMax-M2'],
-  glm: ['glm-5.2[1m]', 'glm-5.2', 'glm-5', 'glm-4.7', 'glm-4.6', 'glm-4.5-air', 'glm-4.5-flash'],
+  // v4-flash 同上限（1M / 384K）、三分之一价格，润色链 dogfood 在用。
+  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+  // 5 代领头；4.7 / 4.6 仍可用但已是 legacy（退役不早于 2027 年），留给已在用的作者。
+  anthropic: ['claude-opus-5', 'claude-sonnet-5', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+  // M2.7 比 M2.5 新、同价；M2.x 官方标「历史模型仍支持」。
+  minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2'],
+  // glm-4.7-flash 是免费档（200K / 128K），给试用者一个零成本入口。
+  glm: ['glm-5.2', 'glm-5', 'glm-4.7', 'glm-4.7-flash', 'glm-4.6', 'glm-4.5-air', 'glm-4.5-flash'],
   // Kimi 拉不到清单（见上方 noModelListEndpoint），故这份目录 + 手填 model id 是它的全部来源，
   // 过期了要手工来改。已排除 kimi-k2.5 与 moonshot-v1 系列：官方 2026-08-31 全平台下线，
-  // 且早已停止接新注册用户。
-  // ⚠️ 不要加 `kimi-k3[1m]`：官方 Claude Code 接入页确实那样写，但真机实测该 id 直接 404
-  //（`Not found the model kimi-k3[1m] or Permission denied`）——那个后缀是 Claude Code 侧的
-  // 上下文标记约定，Moonshot 的 model 字段不认。kimi-k3 本身即 1M 上下文，无需后缀。
+  // 且早已停止接新注册用户；k2.7-code 是编程向，对小说价值低，不收。
   kimi: ['kimi-k3', 'kimi-k2.6'],
   custom: [],
+}
+
+/**
+ * 已下线 / 必 404 的 model id → 建议替代。用户手填过的旧 id 仍留在池里（归一化不对照目录），
+ * 只在真调用时才 404；这张表让设置页当场标出来，而不是等作者写章时撞一次「模型不存在」。
+ * 来源同上方核对：deepseek-chat / deepseek-reasoner 2026-07-24 退役；kimi-k2.5 与 moonshot-v1* 2026-08-31
+ * 下线，kimi-k2* 05-25、kimi-latest 01-28；`[1m]` 后缀见上。
+ */
+const RETIRED_MODEL_IDS: Readonly<Record<ProviderId, Readonly<Record<string, string>>>> = Object.freeze({
+  deepseek: Object.freeze({ 'deepseek-chat': 'deepseek-v4-flash', 'deepseek-reasoner': 'deepseek-v4-pro' }),
+  anthropic: Object.freeze({}),
+  minimax: Object.freeze({}),
+  glm: Object.freeze({ 'glm-5.2[1m]': 'glm-5.2' }),
+  kimi: Object.freeze({ 'kimi-k3[1m]': 'kimi-k3', 'kimi-k2.5': 'kimi-k2.6', 'kimi-latest': 'kimi-k3' }),
+  custom: Object.freeze({}),
+})
+
+/** 该 id 是否已下线；是则给出建议替代 id，否则 null。前缀族（moonshot-v1*、kimi-k2-*）按前缀判。 */
+export function retiredModelReplacement(provider: ProviderId, modelId: string): string | null {
+  const exact = RETIRED_MODEL_IDS[provider][modelId]
+  if (exact) return exact
+  if (provider === 'kimi' && (modelId.startsWith('moonshot-v1') || /^kimi-k2(-|$)/.test(modelId))) return 'kimi-k3'
+  return null
 }
 
 /** 该渠道能否拉模型清单（详情页据此决定渲不渲染「刷新清单」）。 */


### PR DESCRIPTION
PR #77 调研出的第三条用户反馈（BYOK 默认模型目录过期）。

## 改了什么

| 渠道 | 之前 | 之后 | 依据 |
|---|---|---|---|
| deepseek | v4-pro | v4-pro, **v4-flash** | api-docs.deepseek.com model_list（同上限、1/3 价格） |
| anthropic | opus-4-7, sonnet-4-6, haiku-4-5 | **opus-5, sonnet-5**, opus-4-7, sonnet-4-6, haiku-4-5 | platform.claude.com models overview（4.x 留作 legacy） |
| glm | **glm-5.2[1m]**, 5.2, 5, 4.7, 4.6, 4.5-air, 4.5-flash | 5.2, 5, 4.7, **4.7-flash**, 4.6, 4.5-air, 4.5-flash | docs.bigmodel.cn model-overview |
| minimax | M3, M2.5, M2 | M3, **M2.7**, M2.5, M2 | platform.minimaxi.com text-generation |
| kimi | k3, k2.6 | 不变 | platform.kimi.com models |

- **删 `glm-5.2[1m]`**：与 `kimi-k3[1m]` 同构——那个后缀是 Claude Code 客户端的上下文标记约定，各家 model 字段不认；本仓 pi 链路把 id 原样发出、全库无剥离逻辑。kimi 那次是真机 404，glm 这次是结构推断（无可用 GLM Key）。
- **刻意不收**：`claude-fable-5*`（对显式 `thinking: {type:'disabled'}` 回 400，冷 pass / 润色 / 角色聊天都发这个字段）；`glm-5.3`（官方写明思考恒开不可关，未真机验证）。
- **第二份副本** `config.ts` 的 `LEGACY_DEFAULT_MODELS` 同步。
- **下线表** `retiredModelReplacement`：deepseek-chat / reasoner、kimi-k2.5 / moonshot-v1* / kimi-k2-* / kimi-latest、两个 `[1m]`。设置页模型行当场标「已下线 · 建议 X」，不等作者写章时才撞「模型不存在」。旧配置零影响（归一化不对照目录）。
- 目录守卫测试：无 `[1m]`、不收必炸型号、目录与下线表不矛盾。

## 刻意不做

上下文窗口按模型查表：把 deepseek 从 200K 自动抬到 1M 会推迟 pi 压缩、每轮上下文成本上升，属行为改动；`[1m]` 仍是作者的显式 opt-in（只对 Anthropic 真实可用）。GLM / Kimi 想用 1M 上下文目前没有合法口子，留待「长上下文」每条目开关。

## 验证

typecheck / check:design 绿；全量 3656 测试绿。未真机验 `glm-5.2[1m]` 的 404。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ciqqe3UBVPQQAFrZffNVKQ
