### PR TITLE
chore(release): 0.4.0 已发，HIGHEST_SHIPPED 抬到 0.4.0、package.json 进 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "narracat-app",
   "productName": "NarraCat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,

--- a/scripts/client-version.mjs
+++ b/scripts/client-version.mjs
@@ -36,7 +36,7 @@ export const CLIENT_VERSION_RE = /^\d+\.\d+\.\d+$/
  * 本常量，而刚发完时两者相等。这不是断言写歪了——严格大于正是「忘了 bump 就发版」的拦截力
  * 所在，改成 `>=` 等于把闸拆了。两件一起做，仓库就始终停在「下一版待发」的状态上。
  */
-export const HIGHEST_SHIPPED_VERSION = '0.3.2'
+export const HIGHEST_SHIPPED_VERSION = '0.4.0'
 
 /** semver 三段比较：a > b。只处理 `x.y.z`，本仓不发预发布版（feed 只认 releases/latest）。 */
 export function isVersionGreater(a, b) {


### PR DESCRIPTION
发版收尾（release-app 步骤 4，两件一对）：`HIGHEST_SHIPPED_VERSION` 0.3.2 → 0.4.0；`package.json` 0.4.0 → 0.4.1。v0.4.0 已于 2026-09-07 08:50 UTC 发布，八件产物齐全，两条更新链 200。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ciqqe3UBVPQQAFrZffNVKQ