### PR TITLE
fix(notifications): 通知铃铛在 StrictMode 双挂载下永远转圈

### DIFF
--- a/docs/agents/progress.md
+++ b/docs/agents/progress.md
@@ -4,6 +4,8 @@
 
 ## Current Branch
 
+**2026-09-07（通知铃铛在 dev 里永远转圈、列表永远空，分支 fix/notification-bell-remount，攒进 0.4.1）**：根因 = `GlobalNotificationBell` 用 `initialLoadStartedRef` 保证「只首载一次」，但卸载时把 `requestSequence` +1；React StrictMode（dev）把 effect 挂载→卸载→再挂载，第二次挂载不再发请求，第一次的请求回来被当成过期丢掉、且不复位 loading。打包版无 StrictMode 故用户看不到，但任何重挂载都会撞。修 = 去掉守卫，每次挂载都首载，陈旧请求由序号兜底。新增 StrictMode 真实 DOM 回归（改前红改后绿）。
+
 **2026-09-07（模型目录按官方核对更新 + 下线 id 当场标出，分支 fix/model-catalog-2026-09）**：PR #77 调研出的第三条：`glm-5.2[1m]` 与 `kimi-k3[1m]` 同构必 404（后缀是 Claude Code 客户端约定，各家 model 字段不认，本仓 pi 链路原样发出无剥离逻辑），目录里挂着它等于给用户一个必炸的推荐项。本次：
 - **目录**（`model-providers.ts`）：删 `glm-5.2[1m]`；deepseek 加 v4-flash；anthropic 换 opus-5 / sonnet-5 领头（4.7 / 4.6 留作 legacy）；minimax 加 M2.7；glm 加免费档 4.7-flash。**刻意不收**：claude-fable-5*（对显式关思考回 400，冷 pass / 润色 / 角色聊天三条路径都发）、glm-5.3（思考恒开不可关，未真机验证）。目录注释写明每条取舍与核对来源。
 - **第二份副本** `config.ts` 的 `LEGACY_DEFAULT_MODELS` 同步（glm → glm-5.2），测试跟改。

--- a/src/components/notifications/GlobalNotificationBell.remount.test.tsx
+++ b/src/components/notifications/GlobalNotificationBell.remount.test.tsx
@@ -1,0 +1,80 @@
+// 通知铃铛在 React StrictMode（dev 双挂载）下的真实 DOM 回归：首载必须在第二次挂载后完成，
+// 不能因为「只首载一次」的 ref 守卫 + 卸载时的序号 +1 而永远转圈、列表永远空。
+//
+// happy-dom 全局注册必须先于 @testing-library/react 的加载；查询一律用 container，不用 screen。
+// 组件经 @/lib/ipc 直接调 window.electron.*，这里给 window.electron 装假实现即可，不碰 mock.module。
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+GlobalRegistrator.register()
+
+const { afterAll, afterEach, describe, expect, test } = await import('bun:test')
+const { StrictMode } = await import('react')
+const { act, cleanup, render, waitFor } = await import('@testing-library/react')
+const { MemoryRouter } = await import('react-router')
+const { GlobalNotificationBell } = await import('./GlobalNotificationBell')
+type ResultNotificationList = import('@shared/types/notifications').ResultNotificationList
+
+const list: ResultNotificationList = {
+  notifications: [
+    {
+      id: 'notification-run-1',
+      runId: 'run-1',
+      threadId: 'thread-1',
+      status: 'success',
+      title: '第 1 章正文已生成',
+      summary: 'Agent 已完成章节正文生成。',
+      projectName: '长夜星河',
+      projectPath: '/novels/stars',
+      createdAt: '2026-09-07T00:00:00.000Z',
+      updatedAt: '2026-09-07T00:00:00.000Z',
+    },
+  ],
+  unreadCount: 1,
+}
+
+let listCalls = 0
+;(window as unknown as { electron: Record<string, unknown> }).electron = {
+  listResultNotifications: async () => {
+    listCalls += 1
+    // 让首载跨过 StrictMode 的卸载→再挂载：请求在第一次挂载发出、第二次挂载后才回来
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    return list
+  },
+  onResultNotificationsChanged: () => () => {},
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+afterAll(async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  await GlobalRegistrator.unregister()
+})
+
+describe('GlobalNotificationBell（StrictMode 双挂载）', () => {
+  test('首载在第二次挂载后完成：铃铛不再转圈，未读红点出现', async () => {
+    try {
+      window.localStorage.clear()
+    } catch {
+      // 无 localStorage 也不影响本用例
+    }
+    const view = render(
+      <StrictMode>
+        <MemoryRouter>
+          <GlobalNotificationBell />
+        </MemoryRouter>
+      </StrictMode>,
+    )
+    const bell = () => view.container.querySelector('[data-global-notification-bell="true"]')
+    expect(bell()).not.toBeNull()
+    await waitFor(() => {
+      expect(bell()?.querySelector('.animate-spin')).toBeNull()
+    })
+    // 每次挂载各发一次首载（StrictMode 下 2 次）；陈旧那次被序号丢掉，不会把 loading 卡住
+    expect(listCalls).toBeGreaterThanOrEqual(1)
+    expect(bell()?.querySelector('.bg-destructive')).not.toBeNull()
+  })
+})

--- a/src/components/notifications/GlobalNotificationBell.remount.test.tsx
+++ b/src/components/notifications/GlobalNotificationBell.remount.test.tsx
@@ -9,7 +9,7 @@ GlobalRegistrator.register()
 
 const { afterAll, afterEach, describe, expect, test } = await import('bun:test')
 const { StrictMode } = await import('react')
-const { act, cleanup, render, waitFor } = await import('@testing-library/react')
+const { act, cleanup, render } = await import('@testing-library/react')
 const { MemoryRouter } = await import('react-router')
 const { GlobalNotificationBell } = await import('./GlobalNotificationBell')
 type ResultNotificationList = import('@shared/types/notifications').ResultNotificationList
@@ -34,10 +34,11 @@ const list: ResultNotificationList = {
 
 let listCalls = 0
 ;(window as unknown as { electron: Record<string, unknown> }).electron = {
+  // 立即返回：StrictMode 的卸载→再挂载在同一次 commit 里同步完成，微任务里回来的第一次请求必然
+  // 落在再挂载之后（序号已 +1 被丢掉）。不用定时器、不用 waitFor 轮询——两者在 Linux CI 的
+  // happy-dom 里曾把这条用例卡到 8 秒（PR #83 首轮）。
   listResultNotifications: async () => {
     listCalls += 1
-    // 让首载跨过 StrictMode 的卸载→再挂载：请求在第一次挂载发出、第二次挂载后才回来
-    await new Promise((resolve) => setTimeout(resolve, 20))
     return list
   },
   onResultNotificationsChanged: () => () => {},
@@ -70,11 +71,15 @@ describe('GlobalNotificationBell（StrictMode 双挂载）', () => {
     )
     const bell = () => view.container.querySelector('[data-global-notification-bell="true"]')
     expect(bell()).not.toBeNull()
-    await waitFor(() => {
-      expect(bell()?.querySelector('.animate-spin')).toBeNull()
+    // 冲刷微任务让两次首载都回来并提交渲染
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
     })
-    // 每次挂载各发一次首载（StrictMode 下 2 次）；陈旧那次被序号丢掉，不会把 loading 卡住
-    expect(listCalls).toBeGreaterThanOrEqual(1)
+    // 每次挂载各发一次首载（StrictMode 下 2 次）：改前的「只首载一次」守卫会让这里是 1，
+    // 第二次挂载拿不到数据、转圈永远不停
+    expect(listCalls).toBe(2)
+    expect(bell()?.querySelector('.animate-spin')).toBeNull()
     expect(bell()?.querySelector('.bg-destructive')).not.toBeNull()
   })
 })

--- a/src/components/notifications/GlobalNotificationBell.tsx
+++ b/src/components/notifications/GlobalNotificationBell.tsx
@@ -187,7 +187,6 @@ export function GlobalNotificationBell({
     initialProjectionRef.current ? completeLoad() : EMPTY_LOAD_STATE,
   )
   const loadStateRef = useRef(loadState)
-  const initialLoadStartedRef = useRef(false)
   const mountedRef = useRef(false)
   const requestSequenceRef = useRef(0)
   const navigate = useNavigate()
@@ -236,10 +235,11 @@ export function GlobalNotificationBell({
       }
     }
 
-    if (!initialLoadStartedRef.current) {
-      initialLoadStartedRef.current = true
-      void loadNotifications()
-    }
+    // 每次挂载都发一次首载，不用「只发一次」的 ref 守卫：卸载时 requestSequence 已经 +1，上一次挂载的
+    // 请求回来会被当成过期丢掉、且不复位 loading——React StrictMode（dev）会把 effect 挂载→卸载→再挂载，
+    // 守卫让第二次挂载不再发请求，于是铃铛永远转圈、列表永远空（2026-09-07 dev 撞到）。
+    // 陈旧请求由 requestSequence 兜底，重复首载最多多读一次本地 JSON，无害。
+    void loadNotifications()
     const unsubscribe = onResultNotificationsChanged((next) => {
       requestSequenceRef.current += 1
       updatePayload(next)


### PR DESCRIPTION
攒进 0.4.1 的细节修复之二。

**现象**：dev 里点通知铃铛，一直转圈、列表空；`result-notifications.json` 本身完好、IPC 正常。

**根因**：`GlobalNotificationBell` 用 `initialLoadStartedRef` 保证「只首载一次」，但 effect 卸载时把 `requestSequence` +1。React StrictMode（dev）把 effect 挂载→卸载→再挂载：第二次挂载不再发请求，第一次的请求回来被当成过期丢掉、且 `finally` 不复位 `loading`。打包版没有 StrictMode 所以用户看不到，但任何重挂载（路由 key 变化等）都会撞。

**修法**：去掉守卫，每次挂载都首载；陈旧请求由 `requestSequence` 兜底，重复首载最多多读一次本地 JSON。

**验证**：新增 `GlobalNotificationBell.remount.test.tsx`（happy-dom + StrictMode，改前红改后绿）；全量 3657 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ciqqe3UBVPQQAFrZffNVKQ
