### PR TITLE
chore(release): 0.4.1 已发，两个版本号一起抬

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "narracat-app",
   "productName": "NarraCat",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,

--- a/scripts/client-version.mjs
+++ b/scripts/client-version.mjs
@@ -36,7 +36,7 @@ export const CLIENT_VERSION_RE = /^\d+\.\d+\.\d+$/
  * 本常量，而刚发完时两者相等。这不是断言写歪了——严格大于正是「忘了 bump 就发版」的拦截力
  * 所在，改成 `>=` 等于把闸拆了。两件一起做，仓库就始终停在「下一版待发」的状态上。
  */
-export const HIGHEST_SHIPPED_VERSION = '0.4.0'
+export const HIGHEST_SHIPPED_VERSION = '0.4.1'
 
 /** semver 三段比较：a > b。只处理 `x.y.z`，本仓不发预发布版（feed 只认 releases/latest）。 */
 export function isVersionGreater(a, b) {


### PR DESCRIPTION
v0.4.1 已发布（tag `v0.4.1`，mac 五件 + Windows 三件齐全，两条更新链均 200，发布说明是真实用户正文）。

按 ADR-0038 的发版收尾，两个数一起抬：

| 位置 | 从 | 到 |
|---|---|---|
| `HIGHEST_SHIPPED_VERSION` | 0.4.0 | 0.4.1 |
| `package.json` 的 `version` | 0.4.1 | 0.4.2 |

必须成对：前者是「版本号别改小、别忘了抬」那道闸的唯一依据，而闸的断言是 `package.json.version` **严格大于**该常量，只抬前者会让测试当场变红。严格大于正是「忘了 bump 就发版」的拦截力所在，不改成 `>=`。

验证：全量 3683 绿 across 351 files。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES32yzHBCdFFi6jr2qQHcF